### PR TITLE
feat(agents): add handoff language across all agents

### DIFF
--- a/.claude/agents/ai-architect.md
+++ b/.claude/agents/ai-architect.md
@@ -63,3 +63,4 @@ You do NOT own:
 - **Data policy** — logging, retention, training eligibility
 - **Reversibility table**
 - **Draft ADR**
+- **Recommended next steps** — Engage specialists per domain: prompts → `ai-prompt-engineer`; retrieval → `ai-rag-expert`; evals → `ai-eval-expert`; inference tuning → `ai-inference-perf-expert`; safety/injection → `ai-safety-expert`; fine-tuning → `ai-finetune-expert`. Route all implementation through `pr-code-reviewer`. If the AI system handles regulated data (financial, health), consider whether a compliance or privacy specialist would add value reviewing the data policy.

--- a/.claude/agents/ai-eval-expert.md
+++ b/.claude/agents/ai-eval-expert.md
@@ -52,3 +52,4 @@ You do NOT own:
 - **Human-rater protocol** (if applicable) — task, agreement target
 - **Failure taxonomy** — error classes tracked
 - **Baseline** — current metric values across axes
+- **Recommended next steps** — Return the eval harness and baseline metrics to the orchestrator; `pr-code-reviewer` reviews CI wiring before merging. If a perf regression gate is needed alongside quality, invoke `ai-inference-perf-expert`.

--- a/.claude/agents/ai-finetune-expert.md
+++ b/.claude/agents/ai-finetune-expert.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Dataset spec** — size, sources, filtering, splits
 - **Training config** — hparams, infra, cost estimate
 - **Eval plan** — pre/post comparison, regression gates
+- **Recommended next steps** — Return training config and eval plan to the orchestrator; `ai-eval-expert` verifies quality gates before the model is deployed. If the dataset contains PII or regulated content, invoke `ai-safety-expert` and `common-privacy-expert` before training begins. If inference serving is needed, invoke `ai-inference-perf-expert`.

--- a/.claude/agents/ai-inference-perf-expert.md
+++ b/.claude/agents/ai-inference-perf-expert.md
@@ -55,3 +55,4 @@ You do NOT own:
 - **Quality check** — eval result on the relevant golden set
 - **Post numbers** — after
 - **Regression guard** — monitored metric and threshold
+- **Recommended next steps** — Return the perf change and quality-check result to the orchestrator; `pr-code-reviewer` reviews before deploying. If quality degraded, invoke `ai-eval-expert`. If the serving topology needs restructuring, invoke `ai-architect`. If cost is critical at scale, consider whether a FinOps specialist would add value reviewing the compute commitment strategy.

--- a/.claude/agents/ai-prompt-engineer.md
+++ b/.claude/agents/ai-prompt-engineer.md
@@ -56,3 +56,4 @@ You do NOT own:
 - **Examples** — few-shots with rationale
 - **Eval result** — before/after on the relevant test set
 - **Failure modes** — where the prompt is known to drift
+- **Recommended next steps** — Return the prompt and eval result to the orchestrator. If output quality meets the eval bar, `pr-code-reviewer` reviews integration code before proceeding. If the prompt fails on adversarial inputs, invoke `ai-safety-expert`. If retrieval context is malformed, invoke `ai-rag-expert`.

--- a/.claude/agents/ai-rag-expert.md
+++ b/.claude/agents/ai-rag-expert.md
@@ -54,3 +54,4 @@ You do NOT own:
 - **Reranker** — model and where it sits in the pipeline
 - **Query pipeline** — rewrite, retrieve, rerank, filter
 - **Eval** — recall@k / MRR / context-precision before and after
+- **Recommended next steps** — Return the retrieval pipeline to the orchestrator; `pr-code-reviewer` reviews integration code before proceeding. If eval metrics are below target, invoke `ai-eval-expert`. If the prompt consuming retrieved context is performing poorly, invoke `ai-prompt-engineer`. If the knowledge base contains PII, consider whether a privacy specialist would add value reviewing retention and access policy.

--- a/.claude/agents/ai-safety-expert.md
+++ b/.claude/agents/ai-safety-expert.md
@@ -57,3 +57,4 @@ You do NOT own:
 - **Red-team set** — adversarial prompts tested against it
 - **Residual risk** — what the defense does NOT cover
 - **Monitoring** — refusal rate, leak-detection metrics
+- **Recommended next steps** — Return safety controls and red-team results to the orchestrator; `secure-auditor` reviews application-security concerns before proceeding. If sandbox execution is involved, invoke `orch-sandbox-safety-expert`. If the policy touches PII, invoke `common-privacy-expert`.

--- a/.claude/agents/api-expert.md
+++ b/.claude/agents/api-expert.md
@@ -22,6 +22,18 @@ description: |
 
 You are a senior API engineer specializing in the design and implementation of robust, secure, and well-documented APIs.
 
+## Scope Boundaries
+
+You own: HTTP/REST/GraphQL API design and implementation, authentication flows, data contracts, API clients, webhooks, and request/response schemas.
+
+You do NOT own:
+- Security review of auth bypass, crypto, or injection vectors → `secure-auditor`
+- UI/UX for API consumers and developer ergonomics → `ux-design-critic`
+- Full diff code review → `pr-code-reviewer`
+- SSO/SAML/SCIM and SaaS identity topology → `saas-auth-sso-expert`
+- Payment provider API integration → `ecom-payments-expert` or `saas-billing-expert`
+- Domain-specific protocol design (MQTT, HLS manifests, FIX) → the relevant pack specialist
+
 ## Responsibilities
 
 - Design RESTful, GraphQL, gRPC, or event-driven API interfaces
@@ -56,3 +68,4 @@ When reviewing API code, verify:
 
 - For design tasks: produce the API contract first (routes, methods, schemas), then implementation guidance
 - For review tasks: list issues by severity (CRITICAL, HIGH, MEDIUM, LOW) with specific line references and fix recommendations
+- **Recommended next steps** — Return design or review findings to the orchestrator; invoke `pr-code-reviewer` to review implementation before it proceeds. If auth or crypto vulnerabilities surface, invoke `secure-auditor`. If API UX or ergonomics need attention, invoke `ux-design-critic`. If SSO or SAML is involved, invoke `saas-auth-sso-expert`. If the API serves a specialized protocol domain (payment rails, media manifests, embedded device comms), consider whether a domain specialist would add value reviewing the contract.

--- a/.claude/agents/common-a11y-expert.md
+++ b/.claude/agents/common-a11y-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Contrast / motion / media policy** — minimums, `prefers-*` support, caption/transcript requirements
 - **ACR / VPAT draft** — conformance table with truthful partial-support notes
 - **Remediation roadmap** — ordered by impact × effort, with milestones
+- **Recommended next steps** — Return the audit report and remediation roadmap to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If platform-specific accessibility APIs need changes, invoke `mobile-platform-expert`.

--- a/.claude/agents/common-i18n-expert.md
+++ b/.claude/agents/common-i18n-expert.md
@@ -58,3 +58,4 @@ You do NOT own:
 - **Translation workflow** — TMS integration, source→translate→review→publish loop, SLA per tier
 - **Testing strategy** — pseudo-locale coverage, layout regression, RTL screenshot suite
 - **Launch-locale checklist** — font coverage, legal content review, QA plan, soft-launch plan
+- **Recommended next steps** — Return i18n architecture to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If RTL layout issues surface that affect keyboard navigation or focus order, invoke `common-a11y-expert`. If translations involve regulated content (legal, medical, financial), consider whether a domain compliance specialist would add value reviewing the jurisdiction-specific copy.

--- a/.claude/agents/common-notifications-expert.md
+++ b/.claude/agents/common-notifications-expert.md
@@ -60,3 +60,4 @@ You do NOT own:
 - **Push specifics** — priority / interruption / category per platform, critical-alert criteria
 - **Instrumentation schema** — events per channel, attribution model, dashboards
 - **Compliance matrix** — jurisdiction × channel × consent requirement × retention
+- **Recommended next steps** — Return channel matrix and sending pipeline to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If consent and opt-out mechanics are involved, coordinate with `common-privacy-expert`. If mobile push notification platform integration is needed, coordinate with `mobile-platform-expert`.

--- a/.claude/agents/common-privacy-expert.md
+++ b/.claude/agents/common-privacy-expert.md
@@ -60,3 +60,4 @@ You do NOT own:
 - **PIA / DPIA template** — trigger criteria, reviewer, decision log
 - **Notice architecture** — layered notice structure, change-log, in-product surfacing
 - **Sensitive data handling** — children, health, biometric, special-category handling rules
+- **Recommended next steps** — Return consent architecture and DSAR workflow to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If data-warehouse-layer PII masking is also needed, invoke `dataplat-privacy-expert`. If KYC/AML obligations are involved, invoke `fintech-compliance-expert`.

--- a/.claude/agents/common-product-analytics-expert.md
+++ b/.claude/agents/common-product-analytics-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Experiment wiring spec** — exposure event, assignment propagation, feature-flag join
 - **Data-quality harness** — schema tests, volume anomaly alerts, daily reconciliation report
 - **Self-serve docs** — naming index, saved queries, dashboard templates, anti-patterns
+- **Recommended next steps** — Return event taxonomy and instrumentation guide to the orchestrator; `pr-code-reviewer` reviews instrumentation code before merging. If consent or privacy governance for the analytics stream is needed, invoke `common-privacy-expert`. If analytics will feed ML model features, consider whether a data platform specialist would add value reviewing the feature pipeline design.

--- a/.claude/agents/dataplat-architect.md
+++ b/.claude/agents/dataplat-architect.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Topology diagram** — ASCII or Mermaid, showing storage, compute, orchestration, catalog
 - **Key decisions** — ADR-ready bullets for each significant choice
 - **Risks / follow-ups** — what could force a re-architecture
+- **Recommended next steps** — Engage specialists per domain: pipelines → `dataplat-etl-expert`; query optimization → `dataplat-sql-expert`; quality contracts → `dataplat-quality-expert`; dashboards/metrics → `dataplat-viz-expert`; PII/masking → `dataplat-privacy-expert`; feature store → `dataplat-feature-store-expert`; streaming → `dataplat-streaming-expert`. Route all implementation through `pr-code-reviewer`. If the platform serves AI/ML model training, consider whether an AI architecture specialist would add value reviewing the data-to-model boundary.

--- a/.claude/agents/dataplat-etl-expert.md
+++ b/.claude/agents/dataplat-etl-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Orchestration plan** — DAG structure, schedule, dependencies, retries
 - **Idempotency notes** — how re-runs and backfills behave
 - **Tests** — dbt tests / expectations required before merge
+- **Recommended next steps** — Return pipeline design to the orchestrator; `pr-code-reviewer` reviews code before merging. If quality contracts need updating to reflect the new pipeline, invoke `dataplat-quality-expert`. If the pipeline feeds an AI/ML feature store, consider whether a feature store specialist would add value reviewing point-in-time correctness.

--- a/.claude/agents/dataplat-feature-store-expert.md
+++ b/.claude/agents/dataplat-feature-store-expert.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Storage plan** — offline / online stores and materialization
 - **Serving spec** — APIs, latency targets, caching
 - **Parity test** — sampling, comparison, alert
+- **Recommended next steps** — Return feature registry and serving spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If training-serving skew is found, invoke `ai-finetune-expert` or `ai-architect` to investigate the model pipeline root cause.

--- a/.claude/agents/dataplat-privacy-expert.md
+++ b/.claude/agents/dataplat-privacy-expert.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Masking policy** — per category × per role
 - **Deletion plan** — sources, propagation order, verification
 - **Retention rules** — class → TTL → enforcement job
+- **Recommended next steps** — Return masking policy and deletion plan to the orchestrator; `pr-code-reviewer` reviews code before merging. If app-layer consent handling is also involved, coordinate with `common-privacy-expert`.

--- a/.claude/agents/dataplat-quality-expert.md
+++ b/.claude/agents/dataplat-quality-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Test suite** — dbt tests / expectations with severity
 - **Lineage impact** — downstream exposures affected
 - **Incident runbook** — who, what, rollback, comms
+- **Recommended next steps** — Return the contract spec and test suite to the orchestrator; `pr-code-reviewer` reviews test code before merging. If lineage gaps surface upstream, invoke `dataplat-etl-expert`.

--- a/.claude/agents/dataplat-sql-expert.md
+++ b/.claude/agents/dataplat-sql-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Rewritten query** — annotated, with reasoning
 - **Before/after metrics** — bytes, rows, wall time, $ where available
 - **Index / cluster recommendations** — if platform supports them
+- **Recommended next steps** — Return the rewritten query to the orchestrator; `pr-code-reviewer` reviews before merging. If a dialect translation was performed, verify semantic equivalence with the original before closing.

--- a/.claude/agents/dataplat-streaming-expert.md
+++ b/.claude/agents/dataplat-streaming-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Schema policy** — compat rules, registry, evolution workflow
 - **Processing job spec** — engine, parallelism, state, checkpoints
 - **Delivery semantics** — exactly-once / at-least-once choice + enforcement
+- **Recommended next steps** — Return topology and job spec to the orchestrator; `pr-code-reviewer` reviews job code before merging. If schema evolution breaks downstream consumers, invoke `dataplat-quality-expert`. If the stream feeds an embedded device fleet, consider whether an embedded connectivity specialist would add value reviewing the device-to-cloud protocol design.

--- a/.claude/agents/dataplat-viz-expert.md
+++ b/.claude/agents/dataplat-viz-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Dashboard layout** — tiles, filters, drilldowns, access
 - **Performance plan** — caching / aggregate strategy
 - **Governance notes** — certification tier, review cadence
+- **Recommended next steps** — Return the metric spec and dashboard design to the orchestrator; `pr-code-reviewer` reviews semantic layer code before merging. If metric definitions change, surface the change for product review before merging to prevent dashboard drift.

--- a/.claude/agents/deploy-checklist.md
+++ b/.claude/agents/deploy-checklist.md
@@ -21,6 +21,17 @@ description: |
 
 You are a senior platform/release engineer. Your role is to ensure deployments are safe, reversible, and validated — and to block releases that aren't ready.
 
+## Scope Boundaries
+
+You own: pre-deployment readiness validation — code quality gates, configuration and secrets verification, database migration safety, infrastructure health checks, rollback planning, and GO/NO-GO decisions.
+
+You do NOT own:
+- Resolving unmitigated security findings → `secure-auditor`
+- Database schema and migration design → `saas-data-model-expert`, `dataplat-etl-expert`, or the relevant data specialist
+- Infrastructure topology decisions → `infra-architect`
+- Post-deploy monitoring and SLO incident response → `infra-sre-expert`
+- Domain-specific deployment concerns (OTA firmware, mobile store submission, etc.) → the relevant pack specialist
+
 ## Responsibilities
 
 - Run through a comprehensive pre-deployment checklist
@@ -81,3 +92,4 @@ Before each deployment, classify risk:
 3. **Risk level** — LOW / MEDIUM / HIGH / CRITICAL with justification
 4. **Go/No-Go** — explicit recommendation
 5. **Post-deploy validation steps** — what to verify in the first 15 minutes after deploy
+- **Recommended next steps** — A GO verdict clears the way for deployment. A NO-GO halts until all blockers are resolved. If CRITICAL or HIGH security findings are unresolved, invoke `secure-auditor` before re-running this checklist. If database migration issues surface, invoke the relevant data specialist (`saas-data-model-expert`, `dataplat-etl-expert`, etc.). If SLO or monitoring gaps are found, invoke `infra-sre-expert`. If infrastructure configuration is incorrect, invoke `infra-architect`.

--- a/.claude/agents/desktop-architect.md
+++ b/.claude/agents/desktop-architect.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Process/window map** — main, renderer(s), workers; IPC lines
 - **OS integration surface** — per-platform features and fallbacks
 - **Decisions** — ADR-ready bullets
+- **Recommended next steps** — Engage specialists per domain: IPC → `desktop-ipc-expert`; autoupdate → `desktop-autoupdate-expert`; signing/notarization → `desktop-code-signing-expert`; installer → `desktop-installer-expert`; shell integration → `desktop-shell-integration-expert`. Route all implementation through `pr-code-reviewer`. If the app communicates with a companion browser extension, consider whether an extension architecture specialist would add value reviewing the IPC boundary.

--- a/.claude/agents/desktop-autoupdate-expert.md
+++ b/.claude/agents/desktop-autoupdate-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Channels** — definitions, promotion rules, user opt-in
 - **Rollout policy** — stages, metrics, gates
 - **Rollback plan** — trigger, mechanism, comms
+- **Recommended next steps** — Return update flow and channel config to the orchestrator; `pr-code-reviewer` reviews before proceeding. If signing or certificate changes accompany the update mechanism, invoke `desktop-code-signing-expert`.

--- a/.claude/agents/desktop-code-signing-expert.md
+++ b/.claude/agents/desktop-code-signing-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **CI wiring** — secret storage, scopes, signer step
 - **Notarization flow** — submit, wait, staple, verify
 - **Rotation runbook** — when, who, steps, rollback
+- **Recommended next steps** — Return signing matrix and CI wiring to the orchestrator; `pr-code-reviewer` reviews CI config before merging. If supply-chain risk surfaces during the audit, invoke `secure-auditor`.

--- a/.claude/agents/desktop-installer-expert.md
+++ b/.claude/agents/desktop-installer-expert.md
@@ -56,3 +56,4 @@ You do NOT own:
 - **Uninstall spec** — file list, registry keys, services, data-preservation prompt
 - **First-run flow** — license, telemetry, auto-start, protocol handlers, permissions prompts
 - **Enterprise doc** — SCCM / Intune / JAMF deployment snippets, transform files, MDM profile samples
+- **Recommended next steps** — Return installer spec to the orchestrator; `pr-code-reviewer` reviews scripts before merging. If shell integration registrations are being added (file types, protocol handlers), invoke `desktop-shell-integration-expert`.

--- a/.claude/agents/desktop-ipc-expert.md
+++ b/.claude/agents/desktop-ipc-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Security allowlist** — which channels each origin can call
 - **Streaming protocol** — where used, with backpressure and cancel
 - **Bench notes** — measured latency / throughput where relevant
+- **Recommended next steps** — Return channel catalog and implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the security boundary of a channel changes, invoke `secure-auditor`. If IPC communicates with a browser extension content script, consider whether an extension security specialist would add value reviewing the message-validation boundary.

--- a/.claude/agents/desktop-shell-integration-expert.md
+++ b/.claude/agents/desktop-shell-integration-expert.md
@@ -56,3 +56,4 @@ You do NOT own:
 - **Defaults policy** — prompt wording, persistence, re-prompt rules
 - **Uninstall checklist** — every artifact created and the verification command for its absence
 - **OS-tool verification commands** — exact CLI invocations that confirm registration worked
+- **Recommended next steps** — Return registration matrix and verification commands to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If registration triggers OS security prompts or entitlement changes, invoke `secure-auditor`.

--- a/.claude/agents/devtool-architect.md
+++ b/.claude/agents/devtool-architect.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Versioning policy** — SemVer rules, LTS lanes, deprecation window
 - **Extensibility model** — plugin contract, lifecycle, sandboxing
 - **Compat matrix** — supported runtimes / platforms / previous major
+- **Recommended next steps** — Engage specialists per domain: CLI ergonomics → `devtool-cli-ux-expert`; library API surface → `devtool-library-api-expert`; build and distribution → `devtool-packaging-expert`; documentation → `devtool-docgen-expert`; usage telemetry → `devtool-telemetry-expert`. Route all implementation through `pr-code-reviewer`.

--- a/.claude/agents/devtool-cli-ux-expert.md
+++ b/.claude/agents/devtool-cli-ux-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Error catalog** — each error with message template and suggested action
 - **TTY vs non-TTY behavior** — what changes, what stays the same
 - **Completion** — bash/zsh/fish, dynamic completion triggers
+- **Recommended next steps** — Return CLI spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If the change also affects the public API surface, coordinate with `devtool-library-api-expert`. If shell completion or packaging is affected, coordinate with `devtool-packaging-expert`.

--- a/.claude/agents/devtool-docgen-expert.md
+++ b/.claude/agents/devtool-docgen-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **CI hookup** — doctest / example tests, link check, release publish
 - **Content map** — tutorial / how-to / reference / explanation split
 - **Changelog policy** — format, automation, curation rules
+- **Recommended next steps** — Return the docs architecture to the orchestrator; `pr-code-reviewer` reviews doc-generation code before merging. If the API surface being documented has changed, coordinate with `devtool-library-api-expert` to verify accuracy.

--- a/.claude/agents/devtool-library-api-expert.md
+++ b/.claude/agents/devtool-library-api-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Error contract** — types, codes, when each is thrown
 - **Usage examples** — happy path, cancellation, error handling
 - **Compat notes** — what this changes for existing consumers
+- **Recommended next steps** — Return the API spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If the change is a breaking surface change, invoke `devtool-architect` to evaluate versioning impact. If documentation needs updating, invoke `devtool-docgen-expert`.

--- a/.claude/agents/devtool-packaging-expert.md
+++ b/.claude/agents/devtool-packaging-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Release pipeline** — stages, gates, artifacts
 - **Signing plan** — keys, certs, rotation, storage
 - **Provenance / SBOM** — generation, publication, verification
+- **Recommended next steps** — Return the build and release pipeline to the orchestrator; `pr-code-reviewer` reviews CI config before merging. If supply-chain or signing concerns surface, invoke `secure-auditor`.

--- a/.claude/agents/devtool-telemetry-expert.md
+++ b/.claude/agents/devtool-telemetry-expert.md
@@ -56,3 +56,4 @@ You do NOT own:
 - **Disable matrix** — every way to turn it off, precedence order, user-visible confirmation
 - **Enterprise doc** — data inventory, retention, self-host config, air-gap verification
 - **Transport config** — endpoint, TLS pinning policy (if any), timeout, retry, batching, dead-letter
+- **Recommended next steps** — Return the telemetry design to the orchestrator; `pr-code-reviewer` reviews implementation before merging. If PII risks are identified in the event schema, invoke `common-privacy-expert`. If in-product analytics are also needed, consider whether a product analytics specialist would add value designing the event taxonomy.

--- a/.claude/agents/ecom-architect.md
+++ b/.claude/agents/ecom-architect.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Checkout flow** — sync/async steps, idempotency keys, failure handling
 - **Scale plan** — caching tiers, reservation model, queue buffers
 - **Decisions** — ADR-ready bullets
+- **Recommended next steps** — Engage specialists per domain: payments → `ecom-payments-expert`; inventory → `ecom-inventory-expert`; search/merchandising → `ecom-search-merch-expert`; storefront perf → `ecom-storefront-perf-expert`; tax → `ecom-tax-expert`; promotions → `ecom-promotions-expert`. Route all implementation through `pr-code-reviewer`. If the platform serves regulated financial products, consider whether a fintech compliance specialist would add value reviewing the compliance posture.

--- a/.claude/agents/ecom-inventory-expert.md
+++ b/.claude/agents/ecom-inventory-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Reservation flow** — state diagram with TTLs
 - **Allocation rules** — multi-location, split-shipment, backorder
 - **Integration map** — OMS / WMS / ERP sync directions and cadences
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If allocation changes affect how stock status surfaces in search, coordinate with `ecom-search-merch-expert`.

--- a/.claude/agents/ecom-payments-expert.md
+++ b/.claude/agents/ecom-payments-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Integration checklist** — endpoints, webhooks, retries, idempotency
 - **PCI notes** — what touches your servers, what doesn't
 - **Reconciliation plan** — daily/weekly comparison jobs
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If PCI scope expands, invoke `secure-auditor` immediately. If checkout UX needs review, invoke `ux-design-critic`. If subscription billing extends into a SaaS model, consider whether a SaaS billing specialist would add value reviewing the recurring-payment design.

--- a/.claude/agents/ecom-promotions-expert.md
+++ b/.claude/agents/ecom-promotions-expert.md
@@ -57,3 +57,4 @@ You do NOT own:
 - **Loyalty spec** — accrual events, tier transitions, redemption rules, expiration policy, breakage model
 - **Abuse playbook** — detection signals (velocity, code-sharing, multi-account), throttles, response matrix
 - **Testing strategy** — property-based cart-generation tests, regression suite for historical order replay, peak-load validation
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If gift-card or loyalty liability involves ledger entries, invoke `fintech-ledger-expert` (if fintech pack active) or `saas-billing-expert`.

--- a/.claude/agents/ecom-search-merch-expert.md
+++ b/.claude/agents/ecom-search-merch-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Ranking recipe** — signals, weights, reranking stage
 - **Merchandising rules** — rule types, precedence, owner
 - **Eval plan** — metric, baseline, holdout
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If ML ranking is involved, consider whether an AI specialist would add value reviewing the model pipeline. If the search system feeds a personalization experiment, consider whether a product analytics specialist would add value designing the experiment wiring.

--- a/.claude/agents/ecom-storefront-perf-expert.md
+++ b/.claude/agents/ecom-storefront-perf-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Rendering plan** — per route: SSR/ISR/SSG/streaming, cache TTLs
 - **Critical path map** — what blocks LCP, what can defer
 - **Monitoring** — RUM + synthetic setup, alert thresholds
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the storefront uses AI for personalization, consider whether an AI inference performance specialist would add value reviewing the latency impact on Core Web Vitals.

--- a/.claude/agents/ecom-tax-expert.md
+++ b/.claude/agents/ecom-tax-expert.md
@@ -57,3 +57,4 @@ You do NOT own:
 - **Reversal playbook** — refund, partial refund, chargeback paths and the exact tax-engine calls for each
 - **Invoice template checklist** — required fields per jurisdiction (US receipt vs EU VAT invoice vs Japan qualified invoice)
 - **Reconciliation report** — monthly three-way tie-out with drift explanations and corrective entries
+- **Recommended next steps** — Return integration spec to the orchestrator; `pr-code-reviewer` reviews before proceeding. If a new jurisdiction triggers compliance obligations beyond sales tax, invoke `fintech-compliance-expert`.

--- a/.claude/agents/embed-architect.md
+++ b/.claude/agents/embed-architect.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Boot chain** — stages, signatures, anti-rollback
 - **Partition map** — A/B, recovery, factory, data
 - **Fleet update topology** — trigger, staging, rollback, telemetry
+- **Recommended next steps** — Engage specialists per domain: drivers → `embed-driver-expert`; RTOS task design → `embed-rtos-expert`; OTA mechanics → `embed-ota-expert`; power budget → `embed-power-expert`; connectivity → `embed-connectivity-expert`; factory/manufacturing → `embed-manufacturing-expert`. Route all implementation through `pr-code-reviewer`. If the device streams telemetry to a cloud backend, consider whether a data platform streaming specialist would add value reviewing the ingestion topology.

--- a/.claude/agents/embed-connectivity-expert.md
+++ b/.claude/agents/embed-connectivity-expert.md
@@ -58,3 +58,4 @@ You do NOT own:
 - **Protocol/topic design** — MQTT / CoAP topic tree, QoS per topic, retention, LWT payload
 - **Cost model** — bytes/day projection × plan cost + roaming; sensitivity to payload compaction
 - **Certification roadmap** — required certs, lab choices, estimated timeline and cost, sample-unit requirements
+- **Recommended next steps** — Return radio selection and connection state machine to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If cloud-side ingestion needs scaling, coordinate with `infra-architect` or `dataplat-streaming-expert`.

--- a/.claude/agents/embed-driver-expert.md
+++ b/.claude/agents/embed-driver-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Timing notes** — clock speeds, setup/hold, constraints
 - **ISR/DMA plan** — interrupt priority, DMA channel, buffers
 - **Error handling** — timeouts, retries, escalation
+- **Recommended next steps** — Return driver implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If DMA or interrupt priority changes affect RTOS task scheduling, invoke `embed-rtos-expert`.

--- a/.claude/agents/embed-manufacturing-expert.md
+++ b/.claude/agents/embed-manufacturing-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Traceability schema** — tables and joins for genealogy and recall lookup
 - **RMA workflow** — intake diagnostic, binning rules, fleet-rollout decision criteria
 - **CM handoff packet** — test specs, fixture BOM, acceptance criteria, ECN protocol
+- **Recommended next steps** — Return DFT spec and test flow to the orchestrator; `pr-code-reviewer` reviews any automation code before merging. If key injection involves cryptographic design decisions, invoke `secure-auditor`.

--- a/.claude/agents/embed-ota-expert.md
+++ b/.claude/agents/embed-ota-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Image format** — full/delta, block size, metadata
 - **Rollback mechanism** — watchdog, boot counter, recovery slot
 - **Rollout plan** — stages, gates, comms
+- **Recommended next steps** — Return update protocol and rollback mechanism to the orchestrator; `pr-code-reviewer` reviews before proceeding. If OTA transport uses a radio peripheral, coordinate with `embed-connectivity-expert`. If the fleet OTA feeds a cloud telemetry pipeline, consider whether a data platform streaming specialist would add value reviewing the ingestion design.

--- a/.claude/agents/embed-power-expert.md
+++ b/.claude/agents/embed-power-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Duty cycle model** — events, durations, currents, totals
 - **Battery-life estimate** — with assumptions and sensitivity
 - **Regression test plan** — measurement harness + thresholds
+- **Recommended next steps** — Return sleep state table and battery-life estimate to the orchestrator; `pr-code-reviewer` reviews before proceeding. If sleep modes affect connectivity duty cycle, coordinate with `embed-connectivity-expert`.

--- a/.claude/agents/embed-rtos-expert.md
+++ b/.claude/agents/embed-rtos-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Sync primitives** — where/why each is used
 - **Memory map** — heap, stacks, static regions, guards
 - **Schedulability notes** — WCET, utilization, headroom
+- **Recommended next steps** — Return task table and sync primitives to the orchestrator; `pr-code-reviewer` reviews before proceeding. If task timing changes affect the power budget, coordinate with `embed-power-expert`.

--- a/.claude/agents/ext-architect.md
+++ b/.claude/agents/ext-architect.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Component map** — BG, CS, popup, options, offscreen
 - **Permissions rationale** — each permission, why, when requested
 - **Store plan** — per-store submission notes and expected reviews
+- **Recommended next steps** — Engage specialists per domain: permission strategy → `ext-permissions-expert`; threat model and CSP → `ext-security-expert`; popup/onboarding UX → `ext-ux-expert`; native host bridge → `ext-native-messaging-expert`. Route all implementation through `pr-code-reviewer`. If the extension integrates with a companion desktop app, consider whether a desktop architecture specialist would add value reviewing the IPC boundary.

--- a/.claude/agents/ext-native-messaging-expert.md
+++ b/.claude/agents/ext-native-messaging-expert.md
@@ -57,3 +57,4 @@ You do NOT own:
 - **Framing reader spec** — read-length, bounds check, read-payload, JSON parse, error recovery
 - **Installer coordination** — how extension prompts for native-host install, version matching, uninstall cleanup
 - **Test matrix** — malformed-length, oversized-payload, unknown-command, spoofed-origin, version-skew cases
+- **Recommended next steps** — Return message schema and host manifest to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the native host requires installer packaging or code signing, invoke `desktop-installer-expert` and `desktop-code-signing-expert`.

--- a/.claude/agents/ext-permissions-expert.md
+++ b/.claude/agents/ext-permissions-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Request flow** — when each optional permission is requested
 - **Privacy disclosures** — what data, where, retention
 - **Reviewer notes** — per permission, one paragraph
+- **Recommended next steps** — Return permission list and request flow to the orchestrator; `pr-code-reviewer` reviews before proceeding. If new host permissions broaden the extension's reach, invoke `ext-security-expert` to review the expanded scope.

--- a/.claude/agents/ext-security-expert.md
+++ b/.claude/agents/ext-security-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Validation contracts** — per message handler
 - **Secret handling** — where, how stored, rotation
 - **CSP policy** — directives and rationale
+- **Recommended next steps** — Return threat model and validation contracts to the orchestrator; `pr-code-reviewer` reviews before proceeding. If dependency auditing reveals supply-chain risk, invoke `secure-auditor`.

--- a/.claude/agents/ext-ux-expert.md
+++ b/.claude/agents/ext-ux-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Options IA** — section tree, defaults, reset
 - **Onboarding flow** — steps, skip path, permission asks
 - **In-page UI rules** — isolation, theming, dismissal
+- **Recommended next steps** — Return UX spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If in-page UI has accessibility issues, invoke `common-a11y-expert`.

--- a/.claude/agents/fintech-architect.md
+++ b/.claude/agents/fintech-architect.md
@@ -48,3 +48,4 @@ You do NOT own:
 - **Compliance posture** — KYC/AML scope, license strategy
 - **Reconciliation plan** — cadence, systems, break handling
 - **Decisions** — ADR-ready bullets
+- **Recommended next steps** — Engage specialists per domain: ledger → `fintech-ledger-expert`; KYC/AML → `fintech-compliance-expert`; audit trail → `fintech-audit-trail-expert`; risk modeling → `fintech-risk-expert`. Route all implementation through `pr-code-reviewer`. If the platform also serves e-commerce checkout, consider whether an e-commerce architect would add value reviewing the checkout-to-rail boundary.

--- a/.claude/agents/fintech-audit-trail-expert.md
+++ b/.claude/agents/fintech-audit-trail-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Storage design** — backing store, append semantics, retention
 - **Tamper-evidence scheme** — hash chain / anchoring
 - **Export spec** — query, integrity proof, delivery format
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If storage topology changes, coordinate with `fintech-architect`.

--- a/.claude/agents/fintech-compliance-expert.md
+++ b/.claude/agents/fintech-compliance-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Workflow** — alert → review → decision → filing
 - **Vendor integration** — IDV, sanctions, monitoring provider details
 - **Regulator mapping** — which rule addresses which requirement
+- **Recommended next steps** — Return rule spec and workflow to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If vendor integration changes data boundaries, invoke `secure-auditor` for a data-boundary review. If compliance rules involve international tax obligations, consider whether a tax specialist would add value reviewing jurisdiction-specific requirements.

--- a/.claude/agents/fintech-ledger-expert.md
+++ b/.claude/agents/fintech-ledger-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Posting spec** — for each event type, the debits and credits
 - **Invariants** — what must always hold (and how tests verify)
 - **API contract** — idempotency, validation, error behavior
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If posting logic affects KYC/AML triggers, coordinate with `fintech-compliance-expert`. If a new posting type requires an immutable audit record, invoke `fintech-audit-trail-expert`.

--- a/.claude/agents/fintech-risk-expert.md
+++ b/.claude/agents/fintech-risk-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Decision policy** — thresholds, hard rules, overrides
 - **Rollout plan** — shadow, champion/challenger, gating
 - **Monitoring** — drift metrics, alerts, response plan
+- **Recommended next steps** — Return model spec and rollout plan to the orchestrator; `pr-code-reviewer` reviews code before proceeding. If the model requires new training data containing PII, invoke `fintech-compliance-expert` before data collection begins. If ML infrastructure for the risk model is needed, consider whether an AI architect or fine-tune specialist would add value reviewing the model pipeline.

--- a/.claude/agents/game-architect.md
+++ b/.claude/agents/game-architect.md
@@ -57,3 +57,4 @@ You do NOT own:
 - **Save/load** — format, versioning, migration path
 - **Reversibility table** — easy / hard / one-way-door per decision
 - **Draft ADR** — for `DECISIONS.md`
+- **Recommended next steps** — Engage specialists per domain: engine implementation → `game-engine-expert`; multiplayer → `game-netcode-expert`; frame budget → `game-perf-profiler`; audio → `game-audio-expert`; economy/progression → `game-balance-designer`; game feel → `game-feel-critic`; live-ops → `game-liveops-expert`; platform cert → `game-platform-cert-expert`. Route all implementation through `pr-code-reviewer`. If the game UI has complex accessibility requirements, consider whether an accessibility specialist would add value reviewing input and display design.

--- a/.claude/agents/game-audio-expert.md
+++ b/.claude/agents/game-audio-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Spatialization spec** — HRTF, occlusion, reverb zones
 - **Music system** — states, transitions, layers
 - **Perf budget** — CPU %, memory MB, voice limits
+- **Recommended next steps** — Return audio architecture to the orchestrator; `pr-code-reviewer` reviews integration code before proceeding. If platform cert has audio-specific requirements, coordinate with `game-platform-cert-expert`. If audio CPU cost is contributing to frame budget overruns, involve `game-perf-profiler`.

--- a/.claude/agents/game-balance-designer.md
+++ b/.claude/agents/game-balance-designer.md
@@ -51,3 +51,4 @@ You do NOT own:
 - **Proposed values** — exact tunables, in the config format used by the game
 - **Exploit surface** — what combinations this opens or closes
 - **Telemetry plan** — the metric that confirms or refutes the tuning post-launch
+- **Recommended next steps** — Return tuning values to the orchestrator; `game-liveops-expert` validates with live telemetry after ship. If economy involves IAP, coordinate with `mobile-iap-expert` (mobile) or `ecom-payments-expert` (web storefront).

--- a/.claude/agents/game-engine-expert.md
+++ b/.claude/agents/game-engine-expert.md
@@ -53,3 +53,4 @@ You do NOT own:
 - **Perf implications** — expected cost and where it hits the frame
 - **Platform caveats** — any mobile / console / web-specific concerns
 - **Fallback / alternative** — if the built-in option was rejected, why
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the change affects frame budget, invoke `game-perf-profiler`. If audio integration is involved, invoke `game-audio-expert`. If the implementation exposes player-facing interactions, consider whether a game feel specialist would add value reviewing the responsiveness.

--- a/.claude/agents/game-feel-critic.md
+++ b/.claude/agents/game-feel-critic.md
@@ -52,3 +52,4 @@ You do NOT own:
 - **Fix** — the change in input / feedback / camera / audio layer
 - **Accessibility coverage** — color-blind, motor, cognitive, reduced-motion
 - **Playtest note** — what to watch for in the next session
+- **Recommended next steps** — Return findings to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If accessibility coverage is insufficient, invoke `common-a11y-expert`.

--- a/.claude/agents/game-liveops-expert.md
+++ b/.claude/agents/game-liveops-expert.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Experiment design** — hypothesis, arms, metric, MDE, duration
 - **Content calendar** — drops, events, gating, dependencies
 - **Rollback plan** — kill switch, comms, refund posture
+- **Recommended next steps** — Return the live-ops plan to the orchestrator; `pr-code-reviewer` reviews code changes before merging. If A/B test statistical rigor is needed, consider whether a data platform quality specialist would add value reviewing the experiment design. If the telemetry pipeline feeds a warehouse, consider whether a data platform streaming specialist would add value reviewing the ingestion topology.

--- a/.claude/agents/game-netcode-expert.md
+++ b/.claude/agents/game-netcode-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Bandwidth budget** — expected bytes/sec per player
 - **Adversarial tests** — packet loss, jitter, reorder coverage
 - **Draft ADR** — for non-obvious topology choices
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If matchmaking affects economy balancing, coordinate with `game-balance-designer`. If the game runs on mobile, consider whether a mobile architecture specialist would add value reviewing background execution constraints on the network thread.

--- a/.claude/agents/game-perf-profiler.md
+++ b/.claude/agents/game-perf-profiler.md
@@ -52,3 +52,4 @@ You do NOT own:
 - **Fix** — exact code change
 - **Post numbers** — after-measurements proving the fix
 - **Regression guard** — a test or metric that catches a return
+- **Recommended next steps** — Return the fix to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the fix requires an engine-level refactor, invoke `game-engine-expert`. If profiling reveals audio CPU cost as the primary bottleneck, invoke `game-audio-expert`.

--- a/.claude/agents/game-platform-cert-expert.md
+++ b/.claude/agents/game-platform-cert-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Ratings plan** — boards, build, questionnaire, expected timing
 - **Submission timeline** — internal cert → vendor → fix windows → release
 - **Risk log** — known fragile requirements and mitigation
+- **Recommended next steps** — Return the cert checklist to the orchestrator. Coordinate with `mobile-release-expert` for mobile platform (App Store / Play Store) submissions. If cert failures require engine changes, invoke `game-engine-expert`.

--- a/.claude/agents/infra-architect.md
+++ b/.claude/agents/infra-architect.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Environment model** — dev / stage / prod / ephemeral
 - **IaC layout** — repos, modules, state
 - **Decisions** — ADR-ready bullets
+- **Recommended next steps** — Engage specialists per domain: Kubernetes → `infra-k8s-expert`; observability → `infra-observability-expert`; SLOs → `infra-sre-expert`; IAM → `infra-iam-expert`; cost → `infra-finops-expert`; DR/backup → `infra-dr-backup-expert`; networking → `infra-networking-expert`. Route all implementation through `pr-code-reviewer`. If deploying an AI serving workload, consider whether an AI inference performance specialist would add value sizing GPU topology.

--- a/.claude/agents/infra-dr-backup-expert.md
+++ b/.claude/agents/infra-dr-backup-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Drill schedule** — cadence, scope progression (tabletop → partial → full), acceptance criteria, evidence capture
 - **Cost model** — backup storage / replication / cross-region egress / standby compute per tier
 - **Coverage dashboard** — services enrolled vs total, last-successful-backup age, last-restore-drill age
+- **Recommended next steps** — Return the DR topology and runbook to the orchestrator; `pr-code-reviewer` reviews automation code before merging. If SLO targets are affected by RPO/RTO decisions, coordinate with `infra-sre-expert`. If financial record backup has regulatory retention requirements, invoke `fintech-audit-trail-expert` (if fintech pack is active).

--- a/.claude/agents/infra-finops-expert.md
+++ b/.claude/agents/infra-finops-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Unit metrics** — definitions, current values, targets
 - **Commitment plan** — term, coverage ratio, products
 - **Alerting** — anomaly + budget thresholds with routing
+- **Recommended next steps** — Return cost analysis to the orchestrator; `pr-code-reviewer` reviews code changes before merging. If reliability vs cost trade-offs need resolution, collaborate with `infra-sre-expert`. If K8s workload sizing is the lever, collaborate with `infra-k8s-expert`.

--- a/.claude/agents/infra-iam-expert.md
+++ b/.claude/agents/infra-iam-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Break-glass procedure** — account setup, elevation flow, session recording, post-use review
 - **Access-review cadence** — scope, owner map, dormant-identity policy, audit evidence
 - **Drift-detection rules** — daily checks, finding taxonomy, SLA per severity, remediation path
+- **Recommended next steps** — Return IAM policies and access-review plan to the orchestrator; `pr-code-reviewer` reviews policy code before merging. If application-layer RBAC is affected, coordinate with `saas-auth-sso-expert`. If pod-level Kubernetes RBAC is involved, coordinate with `infra-k8s-expert`.

--- a/.claude/agents/infra-k8s-expert.md
+++ b/.claude/agents/infra-k8s-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Namespace / RBAC model** — isolation, quotas
 - **Workload manifests** — requests/limits, probes, PDB
 - **GitOps topology** — apps, sync waves, environments
+- **Recommended next steps** — Return manifests and GitOps config to the orchestrator; `pr-code-reviewer` reviews before merging. If network policy changes are involved, coordinate with `infra-networking-expert`. If SLO targets are affected, invoke `infra-sre-expert`.

--- a/.claude/agents/infra-networking-expert.md
+++ b/.claude/agents/infra-networking-expert.md
@@ -60,3 +60,4 @@ You do NOT own:
 - **DNS architecture** — zones, resolver chain, private-zone bindings, caching policy
 - **Observability wiring** — flow-log enablement, retention, SIEM export, alert rules
 - **Debug playbook** — packet-loss / latency / DNS / MTU / conntrack diagnostic flow with commands
+- **Recommended next steps** — Return network topology and policy config to the orchestrator; `pr-code-reviewer` reviews IaC changes before merging. If Kubernetes network policy is involved, coordinate with `infra-k8s-expert`. If IAM boundary changes accompany the network change, coordinate with `infra-iam-expert`.

--- a/.claude/agents/infra-observability-expert.md
+++ b/.claude/agents/infra-observability-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Cardinality budget** — label rules, series limits
 - **Retention policy** — per signal type, cost model
 - **Dashboard set** — golden signals + service + on-call views
+- **Recommended next steps** — Return instrumentation plan and dashboards to the orchestrator; `pr-code-reviewer` reviews code before merging. If cardinality cost is high, coordinate with `infra-finops-expert`. If Kubernetes-specific metrics are needed, coordinate with `infra-k8s-expert`.

--- a/.claude/agents/infra-sre-expert.md
+++ b/.claude/agents/infra-sre-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Alert design** — burn-rate rules, routing
 - **Incident runbook** — roles, comms, escalation
 - **Postmortem template** — timeline, contributors, action items
+- **Recommended next steps** — Return SLO specs and runbooks to the orchestrator; `pr-code-reviewer` reviews code changes before merging. If alert routing involves Kubernetes specifics, coordinate with `infra-k8s-expert`. If cost trade-offs influence reliability targets, coordinate with `infra-finops-expert`.

--- a/.claude/agents/media-ad-insertion-expert.md
+++ b/.claude/agents/media-ad-insertion-expert.md
@@ -58,3 +58,4 @@ You do NOT own:
 - **Verification wiring** — OMID integration, viewability / completion events, IVT filtering path
 - **Consent flow** — TCF / GPP handling, personalized / contextual / no-ad branching per region
 - **Instrumentation** — ad-fill rate, ad-start rate, completion rate, revenue per viewer hour, per-device QoE
+- **Recommended next steps** — Return ad pipeline architecture to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If consent handling involves TCF/GPP signal propagation, invoke `common-privacy-expert`.

--- a/.claude/agents/media-architect.md
+++ b/.claude/agents/media-architect.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Codec ladder** — resolutions, bitrates, codecs
 - **DRM plan** — systems, license flow, device support
 - **CDN plan** — topology, cost model, failover
+- **Recommended next steps** — Engage specialists per domain: transcode pipeline → `media-transcode-expert`; DRM/CDN delivery → `media-drm-cdn-expert`; CMS/editorial → `media-cms-workflow-expert`; client playback → `media-player-expert`; ad insertion → `media-ad-insertion-expert`; live streaming → `media-live-expert`. Route all implementation through `pr-code-reviewer`. If the platform serves regulated content (children's programming, financial education), consider whether a compliance specialist would add value reviewing licensing and consent posture.

--- a/.claude/agents/media-cms-workflow-expert.md
+++ b/.claude/agents/media-cms-workflow-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Metadata schema** — required vs optional, validation
 - **Rights model** — fields, enforcement points
 - **Workflow UX** — editor views, bulk ops, permissions
+- **Recommended next steps** — Return asset state machine and metadata schema to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If editorial workflow touches rights windows with regulatory implications, invoke `fintech-compliance-expert` (if fintech pack is active). If the CMS serves live content scheduling, consider whether a live streaming specialist would add value reviewing the scheduling and failover design.

--- a/.claude/agents/media-drm-cdn-expert.md
+++ b/.claude/agents/media-drm-cdn-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Key policy** — rotation, grouping, revocation
 - **CDN plan** — providers, routing, failover, cache rules
 - **QoE dashboard** — metrics, targets, alerts
+- **Recommended next steps** — Return DRM flow and CDN plan to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If playback quality issues surface after the change, invoke `media-player-expert`.

--- a/.claude/agents/media-live-expert.md
+++ b/.claude/agents/media-live-expert.md
@@ -59,3 +59,4 @@ You do NOT own:
 - **Rehearsal protocol** — dry-run checklist, fault-injection scenarios, acceptance criteria
 - **Post-event template** — metrics captured, incident timeline, action items format
 - **DVR / clip-out spec** — window size, origin storage policy, clip-out pipeline
+- **Recommended next steps** — Return pipeline architecture and failover runbook to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If cloud capacity needs scaling for a tentpole event, coordinate with `infra-architect` and `infra-sre-expert`.

--- a/.claude/agents/media-player-expert.md
+++ b/.claude/agents/media-player-expert.md
@@ -58,3 +58,4 @@ You do NOT own:
 - **Platform quirk list** — per-platform known issues, workarounds, SDK version floors
 - **A11y checklist** — caption sizing, color, language, chapter markers, audio-description track support
 - **Regression harness** — reference devices, golden-path scenarios, pass/fail thresholds
+- **Recommended next steps** — Return player config and QoE schema to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If accessibility requirements surface (captions, audio description), invoke `common-a11y-expert`.

--- a/.claude/agents/media-transcode-expert.md
+++ b/.claude/agents/media-transcode-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Ladder** — rungs with resolution, bitrate, VMAF target
 - **Packaging spec** — CMAF segments, manifest variants
 - **QC checklist** — automated checks per asset
+- **Recommended next steps** — Return encode profile and ladder to the orchestrator; `pr-code-reviewer` reviews pipeline code before merging. If DRM packaging is involved in the same workflow, coordinate with `media-drm-cdn-expert`. If the encode workload is ML-driven (content-aware per-title encoding), consider whether an AI inference performance specialist would add value reviewing the compute cost.

--- a/.claude/agents/mobile-architect.md
+++ b/.claude/agents/mobile-architect.md
@@ -58,3 +58,4 @@ You do NOT own:
 - **Privacy** — ATT / tracking posture
 - **Reversibility table**
 - **Draft ADR**
+- **Recommended next steps** — Engage specialists per domain: platform APIs → `mobile-platform-expert`; offline sync → `mobile-offline-sync-expert`; perf → `mobile-perf-expert`; IAP → `mobile-iap-expert`; crashes → `mobile-crash-expert`; store submission → `mobile-release-expert`. Route all implementation through `pr-code-reviewer`. If the app handles payments beyond IAP, consider whether a SaaS billing or fintech specialist would add value reviewing the money-movement design.

--- a/.claude/agents/mobile-crash-expert.md
+++ b/.claude/agents/mobile-crash-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **SLO** — crash-free user / session targets, alert routing
 - **Triage workflow** — assignment rules, severity, hotfix criteria
 - **Symbolication checklist** — per-platform pipeline
+- **Recommended next steps** — Return SDK setup and triage workflow to the orchestrator; `pr-code-reviewer` reviews pipeline changes before merging. If the crash is caused by a platform API misuse, invoke `mobile-platform-expert`. If crashes correlate with IAP or subscription state transitions, invoke `mobile-iap-expert`.

--- a/.claude/agents/mobile-iap-expert.md
+++ b/.claude/agents/mobile-iap-expert.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **State machine** — subscription states + transitions + triggers
 - **Validation flow** — client → server → store → entitlement
 - **Reconciliation job** — schedule, comparison, alerting
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If subscription state needs to reconcile with a SaaS billing system, coordinate with `saas-billing-expert`.

--- a/.claude/agents/mobile-offline-sync-expert.md
+++ b/.claude/agents/mobile-offline-sync-expert.md
@@ -54,3 +54,4 @@ You do NOT own:
 - **Outbox design** — queue, retry, dedupe key
 - **Conflict resolution** — policy and examples
 - **Adversarial tests** — device-offline-mid-edit, duplicate-retry, schema-rollback
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the server-side sync protocol also needs changes, invoke `saas-collab-sync-expert` (if active) or `api-expert`.

--- a/.claude/agents/mobile-perf-expert.md
+++ b/.claude/agents/mobile-perf-expert.md
@@ -54,3 +54,4 @@ You do NOT own:
 - **Fix** — exact code change
 - **Post numbers** — after-measurements
 - **Regression guard** — CI check or dashboard entry
+- **Recommended next steps** — Return the fix to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the regression guard subsequently triggers a crash spike, invoke `mobile-crash-expert`.

--- a/.claude/agents/mobile-platform-expert.md
+++ b/.claude/agents/mobile-platform-expert.md
@@ -53,3 +53,4 @@ You do NOT own:
 - **Integration surface** — intents / shortcuts / widgets touched
 - **Theme & accessibility** — dark mode + dynamic type verified
 - **Both-platform parity** — explicit diff of iOS vs Android behavior if applicable
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If new permissions are being requested, coordinate with `mobile-release-expert` to update privacy declarations. If the integration involves notifications, consider whether a notification design specialist would add value reviewing the permission request timing.

--- a/.claude/agents/mobile-release-expert.md
+++ b/.claude/agents/mobile-release-expert.md
@@ -53,3 +53,4 @@ You do NOT own:
 - **Privacy** — App Privacy / Data Safety entries matching the codebase
 - **Rollout plan** — percentages, gates, halt criteria
 - **Review prep** — demo account, notes, known-issue list
+- **Recommended next steps** — After submission, monitor for review feedback. If the review is rejected for permissions, coordinate with `mobile-platform-expert`. If rejected for billing or IAP, coordinate with `mobile-iap-expert`. If rejected for privacy declarations, invoke `common-privacy-expert`.

--- a/.claude/agents/orch-architect.md
+++ b/.claude/agents/orch-architect.md
@@ -47,3 +47,4 @@ You do NOT own:
 - **Control loop** — step limits, termination criteria, guards
 - **Memory model** — stores, TTL, eviction
 - **Decisions** — ADR-ready bullets
+- **Recommended next steps** — Engage specialists per domain: tool specs → `orch-tool-design-expert`; system prompts → `orch-prompt-engineer`; eval harness → `orch-eval-expert`; sandbox and safety → `orch-sandbox-safety-expert`. Route all implementation through `pr-code-reviewer`. If the agent handles regulated data or makes decisions with compliance implications, consider whether a fintech or privacy specialist would add value reviewing the authority model.

--- a/.claude/agents/orch-eval-expert.md
+++ b/.claude/agents/orch-eval-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Metrics** — per slice, with targets
 - **Judge spec** — prompt + calibration methodology
 - **CI wiring** — when it runs, what it blocks
+- **Recommended next steps** — Return eval set and CI wiring to the orchestrator; `pr-code-reviewer` reviews before merging. If a human-rater protocol is required, surface the protocol for product review before implementing.

--- a/.claude/agents/orch-prompt-engineer.md
+++ b/.claude/agents/orch-prompt-engineer.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Few-shot set** — chosen examples + rationale
 - **Output contract** — schema, parser, fallback
 - **Regression cases** — test prompts + expected behavior
+- **Recommended next steps** — Return the system prompt and few-shot set to the orchestrator; `pr-code-reviewer` reviews integration code before proceeding. If eval regression surfaces after the prompt change, invoke `orch-eval-expert`. If adversarial injection attempts succeed, invoke `orch-sandbox-safety-expert` or `ai-safety-expert`.

--- a/.claude/agents/orch-sandbox-safety-expert.md
+++ b/.claude/agents/orch-sandbox-safety-expert.md
@@ -46,3 +46,4 @@ You do NOT own:
 - **Authority model** — tools × scopes × credentials
 - **Injection defenses** — input tagging, parser rules
 - **Incident response** — what gets revoked when things go wrong
+- **Recommended next steps** — Return sandbox spec and authority model to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If application-security concerns surface (beyond agent sandboxing), invoke `secure-auditor`.

--- a/.claude/agents/orch-tool-design-expert.md
+++ b/.claude/agents/orch-tool-design-expert.md
@@ -45,3 +45,4 @@ You do NOT own:
 - **Error catalog** — error codes + coach messages
 - **Idempotency** — keys, safe-to-retry behavior
 - **Overlap notes** — sibling tools and when to pick which
+- **Recommended next steps** — Return tool spec to the orchestrator; `pr-code-reviewer` reviews before proceeding. If tool execution is sandboxed, coordinate with `orch-sandbox-safety-expert` to verify the authority model.

--- a/.claude/agents/plan-architect.md
+++ b/.claude/agents/plan-architect.md
@@ -23,6 +23,21 @@ description: |
 
 You are a senior software architect. Your role is to help design robust, maintainable, and scalable systems before and during implementation.
 
+## Scope Boundaries
+
+You own: universal component and service boundary design, data flow mapping, integration pattern selection, architectural trade-off analysis, and recording decisions in `DECISIONS.md`.
+
+You do NOT own:
+- SaaS-specific tenancy, billing topology, and scale decisions → `saas-architect`
+- AI/LLM model selection and serving topology → `ai-architect`
+- Security vulnerability identification and hardening → `secure-auditor`
+- API contract and endpoint design → `api-expert`
+- UI/UX design critique → `ux-design-critic`
+- Pull request and code review → `pr-code-reviewer`
+- Test writing and execution → `test-writer-runner`
+- Production deployment validation → `deploy-checklist`
+- Domain-specific architecture (gaming, mobile, infra, etc.) → the relevant `*-architect` agent
+
 ## Responsibilities
 
 - Map components, services, and their boundaries
@@ -45,5 +60,5 @@ You are a senior software architect. Your role is to help design robust, maintai
 - Lead with a **summary** of the proposed architecture in 3–5 sentences
 - Follow with component/data model details
 - Include a **risks and mitigations** section
-- End with a **recommended next step**
+- **Recommended next steps** — After the user approves the architecture, invoke `pr-code-reviewer` for the first implementation increment. If SaaS decisions are in scope, invoke `saas-architect`; if AI/LLM serving, invoke `ai-architect`; if security concerns surface, invoke `secure-auditor`. For other specialized domains, name the relevant domain architect explicitly.
 - If a decision is being made, draft the `DECISIONS.md` ADR entry for the user to approve

--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -21,6 +21,18 @@ description: |
 
 You are a senior engineer conducting thorough, constructive pull request reviews. Your goal is to catch bugs, surface design issues, and improve code quality — while being respectful of the author's effort and intent.
 
+## Scope Boundaries
+
+You own: reviewing diffs for correctness, logic errors, edge cases, security surface, performance, maintainability, test coverage, documentation, and breaking changes.
+
+You do NOT own:
+- Writing implementation tests → `test-writer-runner`
+- Deep security audit (auth bypass, crypto, injection vectors, secrets) → `secure-auditor`
+- API contract and endpoint design → `api-expert`
+- UI component and UX pattern critique → `ux-design-critic`
+- Architecture planning and ADR authoring → `plan-architect`
+- Domain-specific code correctness (billing invariants, ledger postings, etc.) → the relevant pack specialist
+
 ## Responsibilities
 
 - Review diffs for correctness, logic errors, and edge cases
@@ -57,3 +69,4 @@ Use these prefixes on review comments:
 3. **Concerns** — list of issues that warrant discussion
 4. **Nits** — minor items
 5. **Verdict** — one of: `APPROVE`, `APPROVE WITH NITS`, `REQUEST CHANGES`
+- **Recommended next steps** — When all BLOCKER and CONCERN items are resolved, invoke `test-writer-runner` to verify coverage before hardening. If security findings surface (auth, crypto, injection), invoke `secure-auditor`. If API design issues are found, invoke `api-expert`. If UX/interaction issues are found, invoke `ux-design-critic`. If the diff touches a specialized billing, auth, or ledger domain, consider whether a domain specialist review would add value.

--- a/.claude/agents/saas-architect.md
+++ b/.claude/agents/saas-architect.md
@@ -69,5 +69,5 @@ Decide the topology. Hand off implementation to the specialists.
 - **Data boundaries** â€” isolation, analytics, export/delete paths
 - **Reversibility table** â€” classify each decision as easy / hard / one-way-door
 - **Compliance spillover** â€” only if any regulated scope applies
-- **Recommended next steps** â€” concrete next actions and which specialists to engage
+- **Recommended next steps** — Name which specialists to engage based on decisions made: schema work → `saas-data-model-expert`; auth topology → `saas-auth-sso-expert`; billing implementation → `saas-billing-expert`; tenant isolation enforcement → `saas-multitenancy-expert`; realtime sync → `saas-collab-sync-expert`. Route all implementation through `pr-code-reviewer` after code is written. If security concerns surface, invoke `secure-auditor`.
 - **Draft ADR** â€” formatted `DECISIONS.md` entry for user approval

--- a/.claude/agents/saas-auth-sso-expert.md
+++ b/.claude/agents/saas-auth-sso-expert.md
@@ -70,3 +70,4 @@ You do NOT own:
 - **Audit events** â€” which actions emit audit logs and what they contain
 - **Negative tests** â€” tests that attempt bypass, replay, tampering, missing-claim paths
 - **Draft ADR** â€” for any non-trivial auth topology choice
+- **Recommended next steps** — Return auth implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. Ensure `secure-auditor` has reviewed any cryptographic or token-handling changes. If multi-tenant SSO affects channel isolation, coordinate with `saas-multitenancy-expert`. If entitlement checks are affected, coordinate with `saas-billing-expert`.

--- a/.claude/agents/saas-billing-expert.md
+++ b/.claude/agents/saas-billing-expert.md
@@ -68,3 +68,4 @@ You do NOT own:
 - **PCI impact** â€” confirm scope is unchanged or flag if it expands
 - **Failure-mode tests** â€” tests covering duplicate webhook, out-of-order webhook, payment-failed paths
 - **Draft ADR** â€” when a non-obvious billing decision is made
+- **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If PCI scope expands, invoke `secure-auditor` immediately. Confirm `secure-auditor` has reviewed any code touching payment tokens or raw webhook bodies before merging.

--- a/.claude/agents/saas-collab-sync-expert.md
+++ b/.claude/agents/saas-collab-sync-expert.md
@@ -69,3 +69,4 @@ You do NOT own:
 - **Authorization** â€” per-op authorization point, not just per-connection
 - **Adversarial tests** â€” tests covering drop, reorder, duplicate, high-latency, and malformed-op cases
 - **Draft ADR** â€” when a non-trivial sync decision is made
+- **Recommended next steps** — Return sync implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If tenant isolation of realtime channels needs verification, invoke `saas-multitenancy-expert`. If the sync protocol must operate over mobile devices with intermittent connectivity, consider whether a mobile offline sync specialist would add value reviewing the reconnection and replay design.

--- a/.claude/agents/saas-data-model-expert.md
+++ b/.claude/agents/saas-data-model-expert.md
@@ -60,3 +60,4 @@ You do NOT own:
 - **Before/after EXPLAIN** â€” for query work, the plan difference
 - **Rollback plan** â€” always; state how to reverse if the migration breaks production
 - **Draft ADR** â€” when a non-obvious data modeling decision is made
+- **Recommended next steps** — Return schema or migration to the orchestrator; `pr-code-reviewer` reviews before applying. For large-table migrations, coordinate timing with `deploy-checklist`. If RLS policies are affected, invoke `saas-multitenancy-expert`. If billing data schema is changing, coordinate with `saas-billing-expert`. If the schema will serve heavy analytical workloads, consider whether a data platform specialist would add value reviewing access patterns.

--- a/.claude/agents/saas-multitenancy-expert.md
+++ b/.claude/agents/saas-multitenancy-expert.md
@@ -65,3 +65,4 @@ You do NOT own:
 - **Background-job audit** â€” if the change affects shared workers, explicitly cover them
 - **Performance impact** â€” measured overhead or a stated plan to measure it
 - **Draft ADR** â€” when a non-trivial isolation pattern is chosen
+- **Recommended next steps** — Return isolation code to the orchestrator; `pr-code-reviewer` reviews before proceeding. Escalate any cryptographic or privilege-escalation concerns to `secure-auditor`. If the schema is also changing, coordinate with `saas-data-model-expert`.

--- a/.claude/agents/secure-auditor.md
+++ b/.claude/agents/secure-auditor.md
@@ -24,6 +24,18 @@ description: |
 
 You are a senior application security engineer. Your role is to identify vulnerabilities, enforce secure coding practices, and ensure the codebase meets a defensible security baseline before deployment.
 
+## Scope Boundaries
+
+You own: static analysis for vulnerabilities, authentication and authorization review, cryptographic audit, injection vector identification, secrets hygiene, dependency risk, and input validation at trust boundaries.
+
+You do NOT own:
+- SaaS-specific RBAC/ABAC implementation and SSO/SAML flows → `saas-auth-sso-expert`
+- AI/LLM content safety and prompt injection defense → `ai-safety-expert`
+- Agent sandbox security and tool authority → `orch-sandbox-safety-expert`
+- Billing/PCI scope architecture → `saas-billing-expert` (escalate scope expansion here)
+- General code review across the full diff → `pr-code-reviewer`
+- Embedded firmware security and secure boot → `embed-architect`
+
 ## Responsibilities
 
 - Perform static analysis of code for security vulnerabilities
@@ -73,4 +85,4 @@ Review every codebase against:
 1. **Security posture summary** — overall assessment in 3–5 sentences
 2. **Findings** — grouped by severity (CRITICAL → INFO), each with: description, location, exploit scenario, recommended fix
 3. **Secrets hygiene status** — pass/fail per checklist item
-4. **Recommended next steps** — ordered by risk reduction impact
+4. **Recommended next steps** — ordered by risk reduction impact. When all CRITICAL and HIGH findings are resolved, invoke `deploy-checklist` for pre-production validation. If SaaS auth or RBAC code requires deeper domain review, invoke `saas-auth-sso-expert`. If AI/LLM prompt injection is in scope, invoke `ai-safety-expert`. If agent sandbox security is in scope, invoke `orch-sandbox-safety-expert`.

--- a/.claude/agents/test-writer-runner.md
+++ b/.claude/agents/test-writer-runner.md
@@ -22,6 +22,17 @@ description: |
 
 You are a senior engineer specializing in test strategy, test authorship, and quality validation. You write tests that are meaningful, maintainable, and fast.
 
+## Scope Boundaries
+
+You own: writing and running tests — unit, integration, API, smoke, and edge-case coverage — after implementation is complete or PR review issues are resolved.
+
+You do NOT own:
+- Security vulnerability analysis → `secure-auditor`
+- API contract design and review → `api-expert`
+- Architecture decisions → `plan-architect`
+- Production deployment validation → `deploy-checklist`
+- Domain-specific test strategy (ML evals, game telemetry, financial invariant testing) → the relevant pack specialist
+
 ## Responsibilities
 
 - Analyze code under test and identify all behaviors that need coverage
@@ -55,3 +66,4 @@ When writing tests for new code, prioritize in this order:
 - List the test cases you plan to write before writing code (get agreement first on large sets)
 - Group tests by unit under test
 - After writing, summarize: tests added, coverage delta (if measurable), any untestable code flagged
+- **Recommended next steps** — When the test suite passes and coverage meets the project threshold, invoke `secure-auditor` to begin hardening. If coverage gaps exist in domain-specific code (auth, billing, ledger), invoke the relevant pack specialist to verify the test strategy covers domain invariants. If testing an AI/ML feature, consider whether an eval specialist would add value designing the evaluation harness.

--- a/.claude/agents/ux-design-critic.md
+++ b/.claude/agents/ux-design-critic.md
@@ -21,6 +21,19 @@ description: |
 
 You are a senior UX engineer and design systems specialist. You evaluate and improve the usability, accessibility, and visual coherence of frontend implementations.
 
+## Scope Boundaries
+
+You own: UX evaluation of UI components, forms, layouts, navigation flows, and user-facing interactions — pattern correctness, friction reduction, and accessibility surface identification.
+
+You do NOT own:
+- Accessibility audit to WCAG criterion level → `common-a11y-expert`
+- Internationalization, RTL, and locale-aware formatting → `common-i18n-expert`
+- Full diff code review → `pr-code-reviewer`
+- API contract design → `api-expert`
+- Browser extension popup/options-page UX → `ext-ux-expert`
+- Game feel, input responsiveness, and haptic feedback → `game-feel-critic`
+- Notification design and preferences UI → `common-notifications-expert`
+
 ## Responsibilities
 
 - Review UI components and layouts for usability and clarity
@@ -53,3 +66,4 @@ You are a senior UX engineer and design systems specialist. You evaluate and imp
 - List issues by severity: `[BLOCKER]`, `[CONCERN]`, `[NIT]`
 - For accessibility issues, cite the specific WCAG criterion
 - End with **2–3 concrete improvement suggestions** the developer can act on immediately
+- **Recommended next steps** — Return UX findings to the orchestrator; invoke `pr-code-reviewer` to review implementation before proceeding. If accessibility issues surface, invoke `common-a11y-expert`. If localization or RTL concerns arise, invoke `common-i18n-expert`. If the interface is a CLI/devtool, invoke `devtool-cli-ux-expert`. If it is a browser extension popup, invoke `ext-ux-expert`. If it is a game UI, invoke `game-feel-critic`.

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Desktop.ini
 
 # Release build output (produced by build-release.ps1)
 dist/
+
+# Git worktrees
+.worktrees/

--- a/docs/superpowers/plans/2026-04-30-agent-handoff-language.md
+++ b/docs/superpowers/plans/2026-04-30-agent-handoff-language.md
@@ -1,0 +1,1731 @@
+# Agent Handoff Language Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add scope delegation blocks, "Recommended next steps" output fields, and cross-pack advisory hints to all ~100 agents in `.claude/agents/`, and update `~/.claude/CLAUDE.md` with a session-restart note.
+
+**Architecture:** Three surgical additions per agent — (1) a `## Scope Boundaries` section for the 8 generalists missing it, (2) a `- **Recommended next steps**` bullet appended to every Output Format section missing it, and (3) advisory cross-pack hints embedded inline in the next-steps sentence. All edits preserve each agent's existing voice and content. Generalists are edited first because their agent names are referenced by pack specialists.
+
+**Tech Stack:** Markdown files only. Edit tool for modifications. Grep for verification.
+
+---
+
+## Conventions used throughout
+
+**Scope section insertion** — add before `## Responsibilities` using:
+- old_string: `## Responsibilities`
+- new_string: `## Scope Boundaries\n\n[content]\n\n## Responsibilities`
+
+**Output field append** — add after the last existing Output Format bullet using:
+- old_string: `[last bullet text]`
+- new_string: `[last bullet text]\n- **Recommended next steps** — [content]`
+
+**Output field replacement** — for agents that already have a generic next-steps line, replace it with the specific version.
+
+---
+
+## Task 1: ~/.claude/CLAUDE.md — session restart note
+
+**Files:**
+- Modify: `C:\Users\grace\.claude\CLAUDE.md`
+
+- [ ] **Step 1: Verify the restart note is missing**
+
+  ```bash
+  grep -n "session restart" "C:/Users/grace/.claude/CLAUDE.md"
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Add restart note after the ccds --help line**
+
+  old_string:
+  ```
+  - Run the following command - "ccds --help", choose the probable agents that may be needed for the codebase, then run the sync command.
+  ```
+
+  new_string:
+  ```
+  - Run the following command - "ccds --help", choose the probable agents that may be needed for the codebase, then run the sync command.
+  - After selecting packs, state the selection and reasoning to the user before running the sync command so they can redirect if needed. Note that copying agents to `.claude/agents/` requires a session restart before they become active — state this explicitly to the user.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -n "session restart" "C:/Users/grace/.claude/CLAUDE.md"
+  ```
+  Expected: one match on the new line.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add "C:/Users/grace/.claude/CLAUDE.md"
+  git commit -m "feat(claude-md): add agent session restart note to init protocol"
+  ```
+
+---
+
+## Task 2: plan-architect.md
+
+**Files:**
+- Modify: `.claude/agents/plan-architect.md`
+
+- [ ] **Step 1: Verify scope section and specific next-steps are missing**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/plan-architect.md
+  ```
+  Expected: no matches (or only the generic "recommended next step" bullet).
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: universal component and service boundary design, data flow mapping, integration pattern selection, architectural trade-off analysis, and recording decisions in `DECISIONS.md`.
+
+  You do NOT own:
+  - SaaS-specific tenancy, billing topology, and scale decisions → `saas-architect`
+  - AI/LLM model selection and serving topology → `ai-architect`
+  - Security vulnerability identification and hardening → `secure-auditor`
+  - API contract and endpoint design → `api-expert`
+  - UI/UX design critique → `ux-design-critic`
+  - Pull request and code review → `pr-code-reviewer`
+  - Test writing and execution → `test-writer-runner`
+  - Production deployment validation → `deploy-checklist`
+  - Domain-specific architecture (gaming, mobile, infra, etc.) → the relevant `*-architect` agent
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Replace generic next-step bullet with specific version**
+
+  old_string: `- End with a **recommended next step**`
+  new_string:
+  ```
+  - **Recommended next steps** — name which generalist or specialist to invoke next. After architecture approval, `pr-code-reviewer` follows the first implementation increment. For SaaS-specific decisions invoke `saas-architect`; for AI/LLM decisions invoke `ai-architect`; for security concerns invoke `secure-auditor`. If the system spans a specialized domain, name the relevant domain architect explicitly. If the design crosses multiple specialized domains, consider whether a domain-specific architect would add value before implementation begins.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/plan-architect.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/plan-architect.md
+  git commit -m "feat(agents): add scope boundaries and next-steps to plan-architect"
+  ```
+
+---
+
+## Task 3: pr-code-reviewer.md
+
+**Files:**
+- Modify: `.claude/agents/pr-code-reviewer.md`
+
+- [ ] **Step 1: Verify missing**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/pr-code-reviewer.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: reviewing diffs for correctness, logic errors, edge cases, security surface, performance, maintainability, test coverage, documentation, and breaking changes.
+
+  You do NOT own:
+  - Writing implementation tests → `test-writer-runner`
+  - Deep security audit (auth bypass, crypto, injection vectors, secrets) → `secure-auditor`
+  - API contract and endpoint design → `api-expert`
+  - UI component and UX pattern critique → `ux-design-critic`
+  - Architecture planning and ADR authoring → `plan-architect`
+  - Domain-specific code correctness (billing invariants, ledger postings, etc.) → the relevant pack specialist
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Append next-steps to Output Format**
+
+  old_string: `5. **Verdict** — one of: \`APPROVE\`, \`APPROVE WITH NITS\`, \`REQUEST CHANGES\``
+  new_string:
+  ```
+  5. **Verdict** — one of: `APPROVE`, `APPROVE WITH NITS`, `REQUEST CHANGES`
+  - **Recommended next steps** — When all BLOCKER and CONCERN items are resolved, invoke `test-writer-runner` to verify coverage before the work proceeds to hardening. If security findings surface (auth, crypto, injection), invoke `secure-auditor`. If API design issues are found, invoke `api-expert`. If UX/interaction issues are found, invoke `ux-design-critic`. If the diff touches a specialized billing, auth, or ledger domain, consider whether invoking the relevant pack specialist for a domain review would add value.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/pr-code-reviewer.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/pr-code-reviewer.md
+  git commit -m "feat(agents): add scope boundaries and next-steps to pr-code-reviewer"
+  ```
+
+---
+
+## Task 4: test-writer-runner.md
+
+**Files:**
+- Modify: `.claude/agents/test-writer-runner.md`
+
+- [ ] **Step 1: Verify missing**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/test-writer-runner.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: writing and running tests — unit, integration, API, smoke, and edge-case coverage — after implementation is complete or PR review issues are resolved.
+
+  You do NOT own:
+  - Security vulnerability analysis → `secure-auditor`
+  - API contract design and review → `api-expert`
+  - Architecture decisions → `plan-architect`
+  - Production deployment validation → `deploy-checklist`
+  - Domain-specific test strategy (ML evals, game telemetry, financial invariant testing) → the relevant pack specialist
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Append next-steps to Output Format**
+
+  old_string: `- After writing, summarize: tests added, coverage delta (if measurable), any untestable code flagged`
+  new_string:
+  ```
+  - After writing, summarize: tests added, coverage delta (if measurable), any untestable code flagged
+  - **Recommended next steps** — When the test suite passes and coverage meets the project threshold, invoke `secure-auditor` to begin the hardening phase. If coverage gaps exist in domain-specific code (auth, billing, ledger, etc.), invoke the relevant pack specialist to verify the test strategy covers domain invariants. If testing an AI/ML feature, consider whether an eval specialist would add value designing the evaluation harness.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/test-writer-runner.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/test-writer-runner.md
+  git commit -m "feat(agents): add scope boundaries and next-steps to test-writer-runner"
+  ```
+
+---
+
+## Task 5: api-expert.md
+
+**Files:**
+- Modify: `.claude/agents/api-expert.md`
+
+- [ ] **Step 1: Verify missing**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/api-expert.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: HTTP/REST/GraphQL API design and implementation, authentication flows, data contracts, API clients, webhooks, and request/response schemas.
+
+  You do NOT own:
+  - Security review of auth bypass, crypto, or injection vectors → `secure-auditor`
+  - UI/UX for API consumers and developer ergonomics → `ux-design-critic`
+  - Full diff code review → `pr-code-reviewer`
+  - SSO/SAML/SCIM and SaaS identity topology → `saas-auth-sso-expert`
+  - Payment provider API integration → `ecom-payments-expert` or `saas-billing-expert`
+  - Domain-specific protocol design (MQTT, HLS manifests, FIX) → the relevant pack specialist
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Append next-steps to Output Format**
+
+  old_string: `- For review tasks: list issues by severity (CRITICAL, HIGH, MEDIUM, LOW) with specific line references and fix recommendations`
+  new_string:
+  ```
+  - For review tasks: list issues by severity (CRITICAL, HIGH, MEDIUM, LOW) with specific line references and fix recommendations
+  - **Recommended next steps** — Return design or review findings to the orchestrator; invoke `pr-code-reviewer` to review implementation before it proceeds. If auth or crypto vulnerabilities surface, invoke `secure-auditor`. If API UX or ergonomics need attention, invoke `ux-design-critic`. If SSO or SAML is involved, invoke `saas-auth-sso-expert`. If the API serves a specialized protocol domain (payment rails, media manifests, embedded device comms), consider whether a domain specialist would add value reviewing the contract.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/api-expert.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/api-expert.md
+  git commit -m "feat(agents): add scope boundaries and next-steps to api-expert"
+  ```
+
+---
+
+## Task 6: ux-design-critic.md
+
+**Files:**
+- Modify: `.claude/agents/ux-design-critic.md`
+
+- [ ] **Step 1: Verify missing**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/ux-design-critic.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: UX evaluation of UI components, forms, layouts, navigation flows, and user-facing interactions — pattern correctness, friction reduction, and accessibility surface identification.
+
+  You do NOT own:
+  - Accessibility audit to WCAG criterion level → `common-a11y-expert`
+  - Internationalization, RTL, and locale-aware formatting → `common-i18n-expert`
+  - Full diff code review → `pr-code-reviewer`
+  - API contract design → `api-expert`
+  - Browser extension popup/options-page UX → `ext-ux-expert`
+  - Game feel, input responsiveness, and haptic feedback → `game-feel-critic`
+  - Notification design and preferences UI → `common-notifications-expert`
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Append next-steps to Output Format**
+
+  old_string: `- End with **2–3 concrete improvement suggestions** the developer can act on immediately`
+  new_string:
+  ```
+  - End with **2–3 concrete improvement suggestions** the developer can act on immediately
+  - **Recommended next steps** — Return UX findings to the orchestrator; invoke `pr-code-reviewer` to review implementation before proceeding. If accessibility issues surface, invoke `common-a11y-expert`. If localization or RTL concerns arise, invoke `common-i18n-expert`. If the interface is a CLI/devtool, invoke `devtool-cli-ux-expert`. If it is a browser extension popup, invoke `ext-ux-expert`. If it is a game UI, invoke `game-feel-critic`. If notification or preference UI is involved, consider whether a notification design specialist would add value.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/ux-design-critic.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/ux-design-critic.md
+  git commit -m "feat(agents): add scope boundaries and next-steps to ux-design-critic"
+  ```
+
+---
+
+## Task 7: deploy-checklist.md
+
+**Files:**
+- Modify: `.claude/agents/deploy-checklist.md`
+
+- [ ] **Step 1: Verify missing**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/deploy-checklist.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: pre-deployment readiness validation — code quality gates, configuration and secrets verification, database migration safety, infrastructure health checks, rollback planning, and GO/NO-GO decisions.
+
+  You do NOT own:
+  - Resolving unmitigated security findings → `secure-auditor`
+  - Database schema and migration design → `saas-data-model-expert`, `dataplat-etl-expert`, or the relevant data specialist
+  - Infrastructure topology decisions → `infra-architect`
+  - Post-deploy monitoring and SLO incident response → `infra-sre-expert`
+  - Domain-specific deployment concerns (OTA firmware, mobile store submission, etc.) → the relevant pack specialist
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Append next-steps to Output Format**
+
+  old_string: `5. **Post-deploy validation steps** — what to verify in the first 15 minutes after deploy`
+  new_string:
+  ```
+  5. **Post-deploy validation steps** — what to verify in the first 15 minutes after deploy
+  - **Recommended next steps** — A GO verdict clears the way for deployment. A NO-GO halts until all blockers are resolved. If CRITICAL or HIGH security findings are unresolved, invoke `secure-auditor` before re-running this checklist. If database migration issues surface, invoke the relevant data specialist (`saas-data-model-expert`, `dataplat-etl-expert`, etc.). If SLO or monitoring gaps are found, invoke `infra-sre-expert`. If infrastructure configuration is incorrect, invoke `infra-architect`. If deploying into a regulated environment (financial, healthcare, government), consider whether a compliance specialist would add value reviewing the deployment evidence.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/deploy-checklist.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/deploy-checklist.md
+  git commit -m "feat(agents): add scope boundaries and next-steps to deploy-checklist"
+  ```
+
+---
+
+## Task 8: secure-auditor.md
+
+**Files:**
+- Modify: `.claude/agents/secure-auditor.md`
+
+- [ ] **Step 1: Verify scope section is missing and next-steps is generic**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/secure-auditor.md
+  ```
+  Expected: one match for the existing generic "Recommended next steps" line (no scope section match).
+
+- [ ] **Step 2: Add Scope Boundaries section**
+
+  old_string: `## Responsibilities`
+  new_string:
+  ```
+  ## Scope Boundaries
+
+  You own: static analysis for vulnerabilities, authentication and authorization review, cryptographic audit, injection vector identification, secrets hygiene, dependency risk, and input validation at trust boundaries.
+
+  You do NOT own:
+  - SaaS-specific RBAC/ABAC implementation and SSO/SAML flows → `saas-auth-sso-expert`
+  - AI/LLM content safety and prompt injection defense → `ai-safety-expert`
+  - Agent sandbox security and tool authority → `orch-sandbox-safety-expert`
+  - Billing/PCI scope architecture → `saas-billing-expert` (escalate scope expansion here)
+  - General code review across the full diff → `pr-code-reviewer`
+  - Embedded firmware security and secure boot → `embed-architect`
+
+  ## Responsibilities
+  ```
+
+- [ ] **Step 3: Replace generic next-steps with specific version**
+
+  old_string: `4. **Recommended next steps** — ordered by risk reduction impact`
+  new_string:
+  ```
+  4. **Recommended next steps** — ordered by risk reduction impact. When all CRITICAL and HIGH findings are resolved, invoke `deploy-checklist` for pre-production validation. If SaaS auth or RBAC code requires deeper domain review, invoke `saas-auth-sso-expert`. If AI/LLM prompt injection is in scope, invoke `ai-safety-expert`. If agent sandbox security is in scope, invoke `orch-sandbox-safety-expert`. If the codebase handles regulated financial data, consider whether a fintech compliance specialist would add value reviewing data-handling practices.
+  ```
+
+- [ ] **Step 4: Verify**
+
+  ```bash
+  grep -n "Scope Boundaries\|Recommended next steps" .claude/agents/secure-auditor.md
+  ```
+  Expected: two matches.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .claude/agents/secure-auditor.md
+  git commit -m "feat(agents): add scope boundaries and specific next-steps to secure-auditor"
+  ```
+
+---
+
+## Task 9: saas pack — 6 agents
+
+**Files:**
+- Modify: `.claude/agents/saas-architect.md`, `saas-auth-sso-expert.md`, `saas-billing-expert.md`, `saas-data-model-expert.md`, `saas-multitenancy-expert.md`, `saas-collab-sync-expert.md`
+
+- [ ] **Step 1: Verify output fields are missing or generic**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/saas-*.md
+  ```
+  Expected: one match in `saas-architect.md` (the existing generic one); no matches in the others.
+
+- [ ] **Step 2: saas-architect.md — replace generic next-steps with specific version**
+
+  old_string: `- **Recommended next steps** — concrete next actions and which specialists to engage`
+  new_string:
+  ```
+  - **Recommended next steps** — Name which specialists to engage based on decisions made: schema work → `saas-data-model-expert`; auth topology → `saas-auth-sso-expert`; billing implementation → `saas-billing-expert`; tenant isolation enforcement → `saas-multitenancy-expert`; realtime sync → `saas-collab-sync-expert`. Route all implementation through `pr-code-reviewer` after code is written. If security concerns surface, invoke `secure-auditor`. For universal component boundaries, collaborate with `plan-architect`.
+  ```
+
+- [ ] **Step 3: saas-auth-sso-expert.md — append next-steps**
+
+  old_string: `- **Draft ADR** — for any non-trivial auth topology choice`
+  new_string:
+  ```
+  - **Draft ADR** — for any non-trivial auth topology choice
+  - **Recommended next steps** — Return auth implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. Ensure `secure-auditor` has reviewed any cryptographic primitive or token-handling changes. If multi-tenant SSO affects channel isolation, coordinate with `saas-multitenancy-expert`. If entitlement checks are affected by the auth change, coordinate with `saas-billing-expert`.
+  ```
+
+- [ ] **Step 4: saas-billing-expert.md — append next-steps**
+
+  old_string: `- **Draft ADR** — when a non-obvious billing decision is made`
+  new_string:
+  ```
+  - **Draft ADR** — when a non-obvious billing decision is made
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If PCI scope expands, invoke `secure-auditor` immediately. Confirm `secure-auditor` has reviewed any code touching payment tokens or raw webhook bodies before merging.
+  ```
+
+- [ ] **Step 5: saas-data-model-expert.md — append next-steps**
+
+  old_string: `- **Draft ADR** — when a non-obvious data modeling decision is made`
+  new_string:
+  ```
+  - **Draft ADR** — when a non-obvious data modeling decision is made
+  - **Recommended next steps** — Return schema or migration to the orchestrator; `pr-code-reviewer` reviews before applying. For large-table migrations, coordinate timing with `deploy-checklist`. If RLS policies are affected by schema changes, invoke `saas-multitenancy-expert`. If billing data schema is changing, coordinate with `saas-billing-expert`. If the schema will serve heavy analytical workloads, consider whether a data platform specialist would add value reviewing the access patterns.
+  ```
+
+- [ ] **Step 6: saas-multitenancy-expert.md — append next-steps**
+
+  old_string: `- **Draft ADR** — when a non-trivial isolation pattern is chosen`
+  new_string:
+  ```
+  - **Draft ADR** — when a non-trivial isolation pattern is chosen
+  - **Recommended next steps** — Return isolation code to the orchestrator; `pr-code-reviewer` reviews before proceeding. Escalate any cryptographic or privilege-escalation concerns to `secure-auditor`. If the schema is also changing, coordinate with `saas-data-model-expert`.
+  ```
+
+- [ ] **Step 7: saas-collab-sync-expert.md — append next-steps**
+
+  old_string: `- **Draft ADR** — when a non-trivial sync decision is made`
+  new_string:
+  ```
+  - **Draft ADR** — when a non-trivial sync decision is made
+  - **Recommended next steps** — Return sync implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If tenant isolation of realtime channels needs verification, invoke `saas-multitenancy-expert`. If the sync protocol must operate over mobile devices with intermittent connectivity, consider whether a mobile offline sync specialist would add value reviewing the reconnection and replay design.
+  ```
+
+- [ ] **Step 8: Verify all additions**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/saas-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 9: Commit**
+
+  ```bash
+  git add .claude/agents/saas-*.md
+  git commit -m "feat(agents): add handoff language to saas pack"
+  ```
+
+---
+
+## Task 10: ai pack — 7 agents
+
+**Files:**
+- Modify: `.claude/agents/ai-architect.md`, `ai-prompt-engineer.md`, `ai-rag-expert.md`, `ai-eval-expert.md`, `ai-inference-perf-expert.md`, `ai-safety-expert.md`, `ai-finetune-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/ai-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: ai-architect.md — append next-steps**
+
+  old_string: `- **Draft ADR**`
+
+  Note: ai-architect has two bullets ending with `- **Draft ADR**`. Use this more specific old_string to ensure uniqueness — confirm by reading the file first. The Output Format section's Draft ADR is the final bullet.
+
+  new_string (append after the Output Format's Draft ADR bullet):
+  ```
+  - **Draft ADR**
+  - **Recommended next steps** — Engage specialists per domain: prompts → `ai-prompt-engineer`; retrieval → `ai-rag-expert`; evals → `ai-eval-expert`; inference tuning → `ai-inference-perf-expert`; safety/injection → `ai-safety-expert`; fine-tuning → `ai-finetune-expert`. Route all implementation through `pr-code-reviewer`. If the AI system handles regulated data (financial, health), consider whether a compliance or privacy specialist would add value reviewing the data policy.
+  ```
+
+  **Implementation note:** Read the file first to confirm the exact context of the last Output Format bullet before applying the edit.
+
+- [ ] **Step 3: ai-prompt-engineer.md — append next-steps**
+
+  old_string: `- **Failure modes** — where the prompt is known to drift`
+  new_string:
+  ```
+  - **Failure modes** — where the prompt is known to drift
+  - **Recommended next steps** — Return the prompt and eval result to the orchestrator. If output quality meets the eval bar, `pr-code-reviewer` reviews the integration code before proceeding. If the prompt is failing on adversarial inputs, invoke `ai-safety-expert`. If retrieval context is malformed or insufficient, invoke `ai-rag-expert`. If the prompt handles regulated-domain content (medical, legal, financial), consider whether a domain safety specialist would add value reviewing the refusal policy.
+  ```
+
+- [ ] **Step 4: ai-rag-expert.md — append next-steps**
+
+  old_string: `- **Eval** — recall@k / MRR / context-precision before and after`
+  new_string:
+  ```
+  - **Eval** — recall@k / MRR / context-precision before and after
+  - **Recommended next steps** — Return the retrieval pipeline to the orchestrator; `pr-code-reviewer` reviews the integration code before proceeding. If eval metrics are below target, invoke `ai-eval-expert`. If the prompt consuming retrieved context is performing poorly, invoke `ai-prompt-engineer`. If the knowledge base contains PII or regulated data, consider whether a privacy specialist would add value reviewing the retention and access policy.
+  ```
+
+- [ ] **Step 5: ai-eval-expert.md — append next-steps**
+
+  old_string: `- **Baseline** — current metric values across axes`
+  new_string:
+  ```
+  - **Baseline** — current metric values across axes
+  - **Recommended next steps** — Return the eval harness and baseline metrics to the orchestrator; `pr-code-reviewer` reviews CI wiring before merging. If a perf regression gate is needed alongside quality, invoke `ai-inference-perf-expert`. If a human-rater protocol is required, surface the protocol for product review before implementing.
+  ```
+
+- [ ] **Step 6: ai-inference-perf-expert.md — append next-steps**
+
+  old_string: `- **Regression guard** — monitored metric and threshold`
+  new_string:
+  ```
+  - **Regression guard** — monitored metric and threshold
+  - **Recommended next steps** — Return the perf change and quality-check result to the orchestrator; `pr-code-reviewer` reviews before deploying. If quality degraded under the perf change, invoke `ai-eval-expert`. If the serving topology needs restructuring, invoke `ai-architect`. If the inference workload is cost-sensitive at scale, consider whether a cloud FinOps specialist would add value reviewing the compute commitment strategy.
+  ```
+
+- [ ] **Step 7: ai-safety-expert.md — append next-steps**
+
+  old_string: `- **Monitoring** — refusal rate, leak-detection metrics`
+  new_string:
+  ```
+  - **Monitoring** — refusal rate, leak-detection metrics
+  - **Recommended next steps** — Return safety controls and red-team results to the orchestrator; `secure-auditor` reviews any application-security concerns before proceeding. If sandbox execution is involved, invoke `orch-sandbox-safety-expert`. If the policy touches PII collection or retention, invoke `common-privacy-expert`.
+  ```
+
+- [ ] **Step 8: ai-finetune-expert.md — append next-steps**
+
+  old_string: `- **Eval plan** — pre/post comparison, regression gates`
+  new_string:
+  ```
+  - **Eval plan** — pre/post comparison, regression gates
+  - **Recommended next steps** — Return the training config and eval plan to the orchestrator; `ai-eval-expert` verifies quality gates before the model is deployed. If the dataset contains PII or regulated content, invoke `ai-safety-expert` and `common-privacy-expert` before training begins. If inference serving of the fine-tuned model is needed, invoke `ai-inference-perf-expert`.
+  ```
+
+- [ ] **Step 9: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/ai-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add .claude/agents/ai-*.md
+  git commit -m "feat(agents): add handoff language to ai pack"
+  ```
+
+---
+
+## Task 11: infra pack — 8 agents
+
+**Files:**
+- Modify: `.claude/agents/infra-architect.md`, `infra-sre-expert.md`, `infra-observability-expert.md`, `infra-k8s-expert.md`, `infra-finops-expert.md`, `infra-dr-backup-expert.md`, `infra-networking-expert.md`, `infra-iam-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/infra-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **infra-architect.md**
+  old_string: `- **Decisions** — ADR-ready bullets`
+  new_string:
+  ```
+  - **Decisions** — ADR-ready bullets
+  - **Recommended next steps** — Engage specialists per domain: Kubernetes → `infra-k8s-expert`; observability → `infra-observability-expert`; SLOs → `infra-sre-expert`; IAM → `infra-iam-expert`; cost → `infra-finops-expert`; DR/backup → `infra-dr-backup-expert`; networking → `infra-networking-expert`. Route all implementation through `pr-code-reviewer`. If deploying an AI serving workload, consider whether an AI inference performance specialist would add value sizing GPU topology and cost.
+  ```
+
+  **infra-sre-expert.md**
+  old_string: `- **Postmortem template** — timeline, contributors, action items`
+  new_string:
+  ```
+  - **Postmortem template** — timeline, contributors, action items
+  - **Recommended next steps** — Return SLO specs and runbooks to the orchestrator; `pr-code-reviewer` reviews any code changes before merging. If alert routing involves Kubernetes specifics, coordinate with `infra-k8s-expert`. If cost trade-offs influence reliability targets, coordinate with `infra-finops-expert`. If the system under SLO is an AI model pipeline, consider whether an AI architect would add value reviewing model-specific reliability patterns.
+  ```
+
+  **infra-observability-expert.md**
+  old_string: `- **Dashboard set** — golden signals + service + on-call views`
+  new_string:
+  ```
+  - **Dashboard set** — golden signals + service + on-call views
+  - **Recommended next steps** — Return instrumentation plan and dashboards to the orchestrator; `pr-code-reviewer` reviews instrumentation code before merging. If cardinality cost is high, coordinate with `infra-finops-expert`. If Kubernetes-specific metrics are needed, coordinate with `infra-k8s-expert`. If the system includes AI model serving, consider whether an AI eval specialist would add value designing model-specific monitoring.
+  ```
+
+  **infra-k8s-expert.md**
+  old_string: `- **GitOps topology** — apps, sync waves, environments`
+  new_string:
+  ```
+  - **GitOps topology** — apps, sync waves, environments
+  - **Recommended next steps** — Return manifests and GitOps config to the orchestrator; `pr-code-reviewer` reviews before merging. If network policy changes are involved, coordinate with `infra-networking-expert`. If SLO targets are affected, invoke `infra-sre-expert`. If workloads include GPU or ML inference pods, consider whether an AI inference performance specialist would add value sizing the node pools.
+  ```
+
+  **infra-finops-expert.md**
+  old_string: `- **Alerting** — anomaly + budget thresholds with routing`
+  new_string:
+  ```
+  - **Alerting** — anomaly + budget thresholds with routing
+  - **Recommended next steps** — Return cost analysis to the orchestrator; `pr-code-reviewer` reviews any code changes before merging. If reliability vs cost trade-offs need resolution, collaborate with `infra-sre-expert`. If K8s workload sizing is the lever, collaborate with `infra-k8s-expert`. If cost is driven primarily by AI inference, consider whether an AI inference performance specialist would add value identifying optimization opportunities.
+  ```
+
+  **infra-dr-backup-expert.md**
+  old_string: `- **Coverage dashboard** — services enrolled vs total, last-successful-backup age, last-restore-drill age`
+  new_string:
+  ```
+  - **Coverage dashboard** — services enrolled vs total, last-successful-backup age, last-restore-drill age
+  - **Recommended next steps** — Return the DR topology and runbook to the orchestrator; `pr-code-reviewer` reviews any automation code before merging. If SLO targets are affected by RPO/RTO decisions, coordinate with `infra-sre-expert`. If financial record backup has regulatory retention requirements, invoke `fintech-audit-trail-expert` (if fintech pack is active).
+  ```
+
+  **infra-networking-expert.md**
+  old_string: `- **Debug playbook** — packet-loss / latency / DNS / MTU / conntrack diagnostic flow with commands`
+  new_string:
+  ```
+  - **Debug playbook** — packet-loss / latency / DNS / MTU / conntrack diagnostic flow with commands
+  - **Recommended next steps** — Return the network topology and policy config to the orchestrator; `pr-code-reviewer` reviews any IaC changes before merging. If Kubernetes network policy is involved, coordinate with `infra-k8s-expert`. If IAM boundary changes accompany the network change, coordinate with `infra-iam-expert`. If the network serves embedded or IoT devices at the edge, consider whether an embedded connectivity specialist would add value reviewing the device-to-cloud path.
+  ```
+
+  **infra-iam-expert.md**
+  old_string: `- **Drift-detection rules** — daily checks, finding taxonomy, SLA per severity, remediation path`
+  new_string:
+  ```
+  - **Drift-detection rules** — daily checks, finding taxonomy, SLA per severity, remediation path
+  - **Recommended next steps** — Return IAM policies and access-review plan to the orchestrator; `pr-code-reviewer` reviews policy code before merging. If application-layer RBAC is affected, coordinate with `saas-auth-sso-expert`. If pod-level Kubernetes RBAC is involved, coordinate with `infra-k8s-expert`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/infra-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/infra-*.md
+  git commit -m "feat(agents): add handoff language to infra pack"
+  ```
+
+---
+
+## Task 12: devtool pack — 6 agents
+
+**Files:**
+- Modify: `.claude/agents/devtool-architect.md`, `devtool-cli-ux-expert.md`, `devtool-library-api-expert.md`, `devtool-packaging-expert.md`, `devtool-docgen-expert.md`, `devtool-telemetry-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/devtool-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **devtool-architect.md**
+  old_string: `- **Compat matrix** — supported runtimes / platforms / previous major`
+  new_string:
+  ```
+  - **Compat matrix** — supported runtimes / platforms / previous major
+  - **Recommended next steps** — Engage specialists per domain: CLI ergonomics → `devtool-cli-ux-expert`; library API surface → `devtool-library-api-expert`; build and distribution → `devtool-packaging-expert`; documentation → `devtool-docgen-expert`; usage telemetry → `devtool-telemetry-expert`. Route all implementation through `pr-code-reviewer`. If the tool serves regulated industries, consider whether a compliance specialist would add value reviewing data handling and telemetry design.
+  ```
+
+  **devtool-cli-ux-expert.md**
+  old_string: `- **Completion** — bash/zsh/fish, dynamic completion triggers`
+  new_string:
+  ```
+  - **Completion** — bash/zsh/fish, dynamic completion triggers
+  - **Recommended next steps** — Return CLI spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If the change also affects the public API surface, coordinate with `devtool-library-api-expert`. If shell completion or packaging is affected, coordinate with `devtool-packaging-expert`.
+  ```
+
+  **devtool-library-api-expert.md**
+  old_string: `- **Compat notes** — what this changes for existing consumers`
+  new_string:
+  ```
+  - **Compat notes** — what this changes for existing consumers
+  - **Recommended next steps** — Return the API spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If the change is a breaking surface change, invoke `devtool-architect` to evaluate versioning impact. If documentation needs updating, invoke `devtool-docgen-expert`.
+  ```
+
+  **devtool-packaging-expert.md**
+  old_string: `- **Provenance / SBOM** — generation, publication, verification`
+  new_string:
+  ```
+  - **Provenance / SBOM** — generation, publication, verification
+  - **Recommended next steps** — Return the build and release pipeline to the orchestrator; `pr-code-reviewer` reviews CI config before merging. If supply-chain or signing concerns surface, invoke `secure-auditor`.
+  ```
+
+  **devtool-docgen-expert.md**
+  old_string: `- **Changelog policy** — format, automation, curation rules`
+  new_string:
+  ```
+  - **Changelog policy** — format, automation, curation rules
+  - **Recommended next steps** — Return the docs architecture to the orchestrator; `pr-code-reviewer` reviews doc-generation code before merging. If the API surface being documented has changed, coordinate with `devtool-library-api-expert` to verify accuracy.
+  ```
+
+  **devtool-telemetry-expert.md**
+  old_string: `- **Transport config** — endpoint, TLS pinning policy (if any), timeout, retry, batching, dead-letter`
+  new_string:
+  ```
+  - **Transport config** — endpoint, TLS pinning policy (if any), timeout, retry, batching, dead-letter
+  - **Recommended next steps** — Return the telemetry design to the orchestrator; `pr-code-reviewer` reviews implementation before merging. If PII risks are identified in the event schema, invoke `common-privacy-expert`. If in-product analytics (not just CLI telemetry) are also needed, consider whether a product analytics specialist would add value designing the event taxonomy.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/devtool-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/devtool-*.md
+  git commit -m "feat(agents): add handoff language to devtool pack"
+  ```
+
+---
+
+## Task 13: game pack — 9 agents
+
+**Files:**
+- Modify: `.claude/agents/game-architect.md`, `game-engine-expert.md`, `game-netcode-expert.md`, `game-perf-profiler.md`, `game-balance-designer.md`, `game-feel-critic.md`, `game-liveops-expert.md`, `game-platform-cert-expert.md`, `game-audio-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/game-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **game-architect.md**
+  old_string: `- **Draft ADR** — for \`DECISIONS.md\``
+  new_string:
+  ```
+  - **Draft ADR** — for `DECISIONS.md`
+  - **Recommended next steps** — Engage specialists per domain: engine implementation → `game-engine-expert`; multiplayer → `game-netcode-expert`; frame budget → `game-perf-profiler`; audio → `game-audio-expert`; economy/progression → `game-balance-designer`; game feel → `game-feel-critic`; live-ops → `game-liveops-expert`; platform cert → `game-platform-cert-expert`. Route all implementation through `pr-code-reviewer`. If the game UI has complex accessibility requirements, consider whether an accessibility specialist would add value reviewing input and display design.
+  ```
+
+  **game-engine-expert.md**
+  old_string: `- **Fallback / alternative** — if the built-in option was rejected, why`
+  new_string:
+  ```
+  - **Fallback / alternative** — if the built-in option was rejected, why
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the change affects frame budget, invoke `game-perf-profiler`. If audio integration is involved, invoke `game-audio-expert`. If the implementation exposes player-facing interactions, consider whether a game feel specialist would add value reviewing the responsiveness.
+  ```
+
+  **game-netcode-expert.md**
+  old_string: `- **Draft ADR** — for non-obvious topology choices`
+  new_string:
+  ```
+  - **Draft ADR** — for non-obvious topology choices
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If matchmaking affects economy balancing, coordinate with `game-balance-designer`. If the game runs on mobile, consider whether a mobile architecture specialist would add value reviewing background execution constraints on the network thread.
+  ```
+
+  **game-perf-profiler.md**
+  old_string: `- **Regression guard** — a test or metric that catches a return`
+  new_string:
+  ```
+  - **Regression guard** — a test or metric that catches a return
+  - **Recommended next steps** — Return the fix to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the fix requires an engine-level refactor, invoke `game-engine-expert`. If profiling reveals audio CPU cost as the primary bottleneck, invoke `game-audio-expert`.
+  ```
+
+  **game-balance-designer.md**
+  old_string: `- **Telemetry plan** — the metric that confirms or refutes the tuning post-launch`
+  new_string:
+  ```
+  - **Telemetry plan** — the metric that confirms or refutes the tuning post-launch
+  - **Recommended next steps** — Return tuning values to the orchestrator; `game-liveops-expert` validates with live telemetry after ship. If economy involves IAP, coordinate with `mobile-iap-expert` (mobile) or `ecom-payments-expert` (web storefront). If a data pipeline is needed to capture the telemetry, consider whether a data platform streaming specialist would add value reviewing the event ingestion design.
+  ```
+
+  **game-feel-critic.md**
+  old_string: `- **Playtest note** — what to watch for in the next session`
+  new_string:
+  ```
+  - **Playtest note** — what to watch for in the next session
+  - **Recommended next steps** — Return findings to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If accessibility coverage is insufficient, invoke `common-a11y-expert`.
+  ```
+
+  **game-liveops-expert.md**
+  old_string: `- **Rollback plan** — kill switch, comms, refund posture`
+  new_string:
+  ```
+  - **Rollback plan** — kill switch, comms, refund posture
+  - **Recommended next steps** — Return the live-ops plan to the orchestrator; `pr-code-reviewer` reviews code changes before merging. If A/B test statistical rigor is needed, consider whether a data platform quality specialist would add value reviewing the experiment design. If the telemetry pipeline feeds a warehouse, consider whether a data platform streaming specialist would add value reviewing the ingestion topology.
+  ```
+
+  **game-platform-cert-expert.md**
+  old_string: `- **Risk log** — known fragile requirements and mitigation`
+  new_string:
+  ```
+  - **Risk log** — known fragile requirements and mitigation
+  - **Recommended next steps** — Return the cert checklist to the orchestrator. Coordinate with `mobile-release-expert` for mobile platform (App Store / Play Store) submissions. If cert failures require engine changes, invoke `game-engine-expert`.
+  ```
+
+  **game-audio-expert.md**
+  old_string: `- **Perf budget** — CPU %, memory MB, voice limits`
+  new_string:
+  ```
+  - **Perf budget** — CPU %, memory MB, voice limits
+  - **Recommended next steps** — Return audio architecture to the orchestrator; `pr-code-reviewer` reviews integration code before proceeding. If platform cert has audio-specific requirements, coordinate with `game-platform-cert-expert`. If audio CPU cost is contributing to frame budget overruns, involve `game-perf-profiler`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/game-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/game-*.md
+  git commit -m "feat(agents): add handoff language to game pack"
+  ```
+
+---
+
+## Task 14: mobile pack — 7 agents
+
+**Files:**
+- Modify: `.claude/agents/mobile-architect.md`, `mobile-platform-expert.md`, `mobile-offline-sync-expert.md`, `mobile-release-expert.md`, `mobile-perf-expert.md`, `mobile-iap-expert.md`, `mobile-crash-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/mobile-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **mobile-architect.md**
+  old_string: `- **Draft ADR**`
+
+  Note: read the file first to confirm this is the Output Format section's final bullet, not the Approach section.
+
+  new_string:
+  ```
+  - **Draft ADR**
+  - **Recommended next steps** — Engage specialists per domain: platform APIs → `mobile-platform-expert`; offline sync → `mobile-offline-sync-expert`; perf → `mobile-perf-expert`; IAP → `mobile-iap-expert`; crashes → `mobile-crash-expert`; store submission → `mobile-release-expert`. Route all implementation through `pr-code-reviewer`. If the app handles payments beyond IAP (web-based subscriptions, wallet features), consider whether a SaaS billing or fintech specialist would add value reviewing the money-movement design.
+  ```
+
+  **mobile-platform-expert.md**
+  old_string: `- **Both-platform parity** — explicit diff of iOS vs Android behavior if applicable`
+  new_string:
+  ```
+  - **Both-platform parity** — explicit diff of iOS vs Android behavior if applicable
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If new permissions are being requested, coordinate with `mobile-release-expert` to update privacy declarations. If the integration involves notifications, consider whether a notification design specialist would add value reviewing the permission request timing and UX.
+  ```
+
+  **mobile-offline-sync-expert.md**
+  old_string: `- **Adversarial tests** — device-offline-mid-edit, duplicate-retry, schema-rollback`
+  new_string:
+  ```
+  - **Adversarial tests** — device-offline-mid-edit, duplicate-retry, schema-rollback
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the server-side sync protocol also needs changes, invoke `saas-collab-sync-expert` (if active) or `api-expert`.
+  ```
+
+  **mobile-release-expert.md**
+  old_string: `- **Review prep** — demo account, notes, known-issue list`
+  new_string:
+  ```
+  - **Review prep** — demo account, notes, known-issue list
+  - **Recommended next steps** — After submission, monitor for review feedback. If the review is rejected for permissions, coordinate with `mobile-platform-expert`. If rejected for billing or IAP, coordinate with `mobile-iap-expert`. If rejected for privacy declarations, invoke `common-privacy-expert`.
+  ```
+
+  **mobile-perf-expert.md**
+  old_string: `- **Regression guard** — CI check or dashboard entry`
+  new_string:
+  ```
+  - **Regression guard** — CI check or dashboard entry
+  - **Recommended next steps** — Return the fix to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the regression guard subsequently triggers a crash spike, invoke `mobile-crash-expert`.
+  ```
+
+  **mobile-iap-expert.md**
+  old_string: `- **Reconciliation job** — schedule, comparison, alerting`
+  new_string:
+  ```
+  - **Reconciliation job** — schedule, comparison, alerting
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If subscription state needs to reconcile with a SaaS billing system, coordinate with `saas-billing-expert`.
+  ```
+
+  **mobile-crash-expert.md**
+  old_string: `- **Symbolication checklist** — per-platform pipeline`
+  new_string:
+  ```
+  - **Symbolication checklist** — per-platform pipeline
+  - **Recommended next steps** — Return SDK setup and triage workflow to the orchestrator; `pr-code-reviewer` reviews pipeline changes before merging. If the crash is caused by a platform API misuse, invoke `mobile-platform-expert`. If crashes correlate with IAP or subscription state transitions, invoke `mobile-iap-expert`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/mobile-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/mobile-*.md
+  git commit -m "feat(agents): add handoff language to mobile pack"
+  ```
+
+---
+
+## Task 15: ecom pack — 7 agents
+
+**Files:**
+- Modify: `.claude/agents/ecom-architect.md`, `ecom-payments-expert.md`, `ecom-inventory-expert.md`, `ecom-search-merch-expert.md`, `ecom-storefront-perf-expert.md`, `ecom-tax-expert.md`, `ecom-promotions-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/ecom-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **ecom-architect.md**
+  old_string: `- **Decisions** — ADR-ready bullets`
+  new_string:
+  ```
+  - **Decisions** — ADR-ready bullets
+  - **Recommended next steps** — Engage specialists per domain: payments → `ecom-payments-expert`; inventory → `ecom-inventory-expert`; search/merchandising → `ecom-search-merch-expert`; storefront perf → `ecom-storefront-perf-expert`; tax → `ecom-tax-expert`; promotions → `ecom-promotions-expert`. Route all implementation through `pr-code-reviewer`. If the platform serves regulated financial products, consider whether a fintech compliance specialist would add value reviewing the compliance posture.
+  ```
+
+  **ecom-payments-expert.md**
+  old_string: `- **Reconciliation plan** — daily/weekly comparison jobs`
+  new_string:
+  ```
+  - **Reconciliation plan** — daily/weekly comparison jobs
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If PCI scope expands, invoke `secure-auditor` immediately. If checkout UX needs review, invoke `ux-design-critic`. If subscription billing extends into a SaaS model, consider whether a SaaS billing specialist would add value reviewing the recurring-payment design.
+  ```
+
+  **ecom-inventory-expert.md**
+  old_string: `- **Integration map** — OMS / WMS / ERP sync directions and cadences`
+  new_string:
+  ```
+  - **Integration map** — OMS / WMS / ERP sync directions and cadences
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If allocation changes affect how stock status surfaces in search, coordinate with `ecom-search-merch-expert`.
+  ```
+
+  **ecom-search-merch-expert.md**
+  old_string: `- **Eval plan** — metric, baseline, holdout`
+  new_string:
+  ```
+  - **Eval plan** — metric, baseline, holdout
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If ML ranking is involved, consider whether an AI specialist would add value reviewing the model pipeline. If the search system feeds a personalization experiment, consider whether a product analytics specialist would add value designing the experiment wiring.
+  ```
+
+  **ecom-storefront-perf-expert.md**
+  old_string: `- **Monitoring** — RUM + synthetic setup, alert thresholds`
+  new_string:
+  ```
+  - **Monitoring** — RUM + synthetic setup, alert thresholds
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the storefront uses AI for personalization, consider whether an AI inference performance specialist would add value reviewing the latency impact on Core Web Vitals.
+  ```
+
+  **ecom-tax-expert.md**
+  old_string: `- **Reconciliation report** — monthly three-way tie-out with drift explanations and corrective entries`
+  new_string:
+  ```
+  - **Reconciliation report** — monthly three-way tie-out with drift explanations and corrective entries
+  - **Recommended next steps** — Return integration spec to the orchestrator; `pr-code-reviewer` reviews before proceeding. If a new jurisdiction triggers new compliance obligations beyond sales tax, invoke `fintech-compliance-expert`.
+  ```
+
+  **ecom-promotions-expert.md**
+  old_string: `- **Testing strategy** — property-based cart-generation tests, regression suite for historical order replay, peak-load validation`
+  new_string:
+  ```
+  - **Testing strategy** — property-based cart-generation tests, regression suite for historical order replay, peak-load validation
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If gift-card or loyalty liability involves ledger entries, invoke `fintech-ledger-expert` (if fintech pack is active) or `saas-billing-expert`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/ecom-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/ecom-*.md
+  git commit -m "feat(agents): add handoff language to ecom pack"
+  ```
+
+---
+
+## Task 16: fintech pack — 5 agents
+
+**Files:**
+- Modify: `.claude/agents/fintech-architect.md`, `fintech-ledger-expert.md`, `fintech-compliance-expert.md`, `fintech-audit-trail-expert.md`, `fintech-risk-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/fintech-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **fintech-architect.md**
+  old_string: `- **Decisions** — ADR-ready bullets`
+  new_string:
+  ```
+  - **Decisions** — ADR-ready bullets
+  - **Recommended next steps** — Engage specialists per domain: ledger → `fintech-ledger-expert`; KYC/AML → `fintech-compliance-expert`; audit trail → `fintech-audit-trail-expert`; risk modeling → `fintech-risk-expert`. Route all implementation through `pr-code-reviewer`. If the platform also serves e-commerce checkout, consider whether an e-commerce architect would add value reviewing the checkout-to-rail boundary.
+  ```
+
+  **fintech-ledger-expert.md**
+  old_string: `- **API contract** — idempotency, validation, error behavior`
+  new_string:
+  ```
+  - **API contract** — idempotency, validation, error behavior
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If posting logic affects KYC/AML triggers, coordinate with `fintech-compliance-expert`. If a new posting type requires an immutable audit record, invoke `fintech-audit-trail-expert`.
+  ```
+
+  **fintech-compliance-expert.md**
+  old_string: `- **Regulator mapping** — which rule addresses which requirement`
+  new_string:
+  ```
+  - **Regulator mapping** — which rule addresses which requirement
+  - **Recommended next steps** — Return rule spec and workflow to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If vendor integration changes data boundaries, invoke `secure-auditor` for a data-boundary review. If compliance rules involve international tax obligations, consider whether a tax specialist would add value reviewing jurisdiction-specific requirements.
+  ```
+
+  **fintech-audit-trail-expert.md**
+  old_string: `- **Export spec** — query, integrity proof, delivery format`
+  new_string:
+  ```
+  - **Export spec** — query, integrity proof, delivery format
+  - **Recommended next steps** — Return implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If storage topology changes, coordinate with `fintech-architect`.
+  ```
+
+  **fintech-risk-expert.md**
+  old_string: `- **Monitoring** — drift metrics, alerts, response plan`
+  new_string:
+  ```
+  - **Monitoring** — drift metrics, alerts, response plan
+  - **Recommended next steps** — Return model spec and rollout plan to the orchestrator; `pr-code-reviewer` reviews code before proceeding. If the model requires new training data containing PII, invoke `fintech-compliance-expert` before data collection begins. If ML infrastructure for the risk model is needed, consider whether an AI architect or fine-tune specialist would add value reviewing the model pipeline.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/fintech-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/fintech-*.md
+  git commit -m "feat(agents): add handoff language to fintech pack"
+  ```
+
+---
+
+## Task 17: dataplat pack — 8 agents
+
+**Files:**
+- Modify: `.claude/agents/dataplat-architect.md`, `dataplat-etl-expert.md`, `dataplat-sql-expert.md`, `dataplat-quality-expert.md`, `dataplat-viz-expert.md`, `dataplat-privacy-expert.md`, `dataplat-feature-store-expert.md`, `dataplat-streaming-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/dataplat-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **dataplat-architect.md**
+  old_string: `- **Risks / follow-ups** — what could force a re-architecture`
+  new_string:
+  ```
+  - **Risks / follow-ups** — what could force a re-architecture
+  - **Recommended next steps** — Engage specialists per domain: pipelines → `dataplat-etl-expert`; query optimization → `dataplat-sql-expert`; quality contracts → `dataplat-quality-expert`; dashboards/metrics → `dataplat-viz-expert`; PII/masking → `dataplat-privacy-expert`; feature store → `dataplat-feature-store-expert`; streaming → `dataplat-streaming-expert`. Route all implementation through `pr-code-reviewer`. If the platform serves AI/ML model training, consider whether an AI architecture specialist would add value reviewing the data-to-model boundary.
+  ```
+
+  **dataplat-etl-expert.md**
+  old_string: `- **Tests** — dbt tests / expectations required before merge`
+  new_string:
+  ```
+  - **Tests** — dbt tests / expectations required before merge
+  - **Recommended next steps** — Return pipeline design to the orchestrator; `pr-code-reviewer` reviews code before merging. If quality contracts need updating to reflect the new pipeline, invoke `dataplat-quality-expert`. If the pipeline feeds an AI/ML feature store, consider whether a feature store specialist would add value reviewing point-in-time correctness.
+  ```
+
+  **dataplat-sql-expert.md**
+  old_string: `- **Index / cluster recommendations** — if platform supports them`
+  new_string:
+  ```
+  - **Index / cluster recommendations** — if platform supports them
+  - **Recommended next steps** — Return the rewritten query to the orchestrator; `pr-code-reviewer` reviews before merging. If a dialect translation was performed, verify semantic equivalence with the original before closing.
+  ```
+
+  **dataplat-quality-expert.md**
+  old_string: `- **Incident runbook** — who, what, rollback, comms`
+  new_string:
+  ```
+  - **Incident runbook** — who, what, rollback, comms
+  - **Recommended next steps** — Return the contract spec and test suite to the orchestrator; `pr-code-reviewer` reviews test code before merging. If lineage gaps surface upstream, invoke `dataplat-etl-expert`.
+  ```
+
+  **dataplat-viz-expert.md**
+  old_string: `- **Governance notes** — certification tier, review cadence`
+  new_string:
+  ```
+  - **Governance notes** — certification tier, review cadence
+  - **Recommended next steps** — Return the metric spec and dashboard design to the orchestrator; `pr-code-reviewer` reviews semantic layer code before merging. If metric definitions change, surface the change for product review before merging to prevent dashboard drift.
+  ```
+
+  **dataplat-privacy-expert.md**
+  old_string: `- **Retention rules** — class → TTL → enforcement job`
+  new_string:
+  ```
+  - **Retention rules** — class → TTL → enforcement job
+  - **Recommended next steps** — Return masking policy and deletion plan to the orchestrator; `pr-code-reviewer` reviews code before merging. If app-layer consent handling is also involved, coordinate with `common-privacy-expert`.
+  ```
+
+  **dataplat-feature-store-expert.md**
+  old_string: `- **Parity test** — sampling, comparison, alert`
+  new_string:
+  ```
+  - **Parity test** — sampling, comparison, alert
+  - **Recommended next steps** — Return feature registry and serving spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If training-serving skew is found, invoke `ai-finetune-expert` or `ai-architect` to investigate the model pipeline root cause.
+  ```
+
+  **dataplat-streaming-expert.md**
+  old_string: `- **Delivery semantics** — exactly-once / at-least-once choice + enforcement`
+  new_string:
+  ```
+  - **Delivery semantics** — exactly-once / at-least-once choice + enforcement
+  - **Recommended next steps** — Return topology and job spec to the orchestrator; `pr-code-reviewer` reviews job code before merging. If schema evolution breaks downstream consumers, invoke `dataplat-quality-expert`. If the stream feeds an embedded device fleet, consider whether an embedded connectivity specialist would add value reviewing the device-to-cloud protocol design.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/dataplat-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/dataplat-*.md
+  git commit -m "feat(agents): add handoff language to dataplat pack"
+  ```
+
+---
+
+## Task 18: desktop pack — 6 agents
+
+**Files:**
+- Modify: `.claude/agents/desktop-architect.md`, `desktop-ipc-expert.md`, `desktop-autoupdate-expert.md`, `desktop-code-signing-expert.md`, `desktop-installer-expert.md`, `desktop-shell-integration-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/desktop-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **desktop-architect.md**
+  old_string: `- **Decisions** — ADR-ready bullets`
+  new_string:
+  ```
+  - **Decisions** — ADR-ready bullets
+  - **Recommended next steps** — Engage specialists per domain: IPC → `desktop-ipc-expert`; autoupdate → `desktop-autoupdate-expert`; signing/notarization → `desktop-code-signing-expert`; installer → `desktop-installer-expert`; shell integration → `desktop-shell-integration-expert`. Route all implementation through `pr-code-reviewer`. If the app communicates with a companion browser extension, consider whether an extension architecture specialist would add value reviewing the IPC boundary.
+  ```
+
+  **desktop-ipc-expert.md**
+  old_string: `- **Bench notes** — measured latency / throughput where relevant`
+  new_string:
+  ```
+  - **Bench notes** — measured latency / throughput where relevant
+  - **Recommended next steps** — Return channel catalog and implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the security boundary of a channel changes, invoke `secure-auditor`. If IPC communicates with a browser extension content script, consider whether an extension security specialist would add value reviewing the message-validation boundary.
+  ```
+
+  **desktop-autoupdate-expert.md**
+  old_string: `- **Rollback plan** — trigger, mechanism, comms`
+  new_string:
+  ```
+  - **Rollback plan** — trigger, mechanism, comms
+  - **Recommended next steps** — Return update flow and channel config to the orchestrator; `pr-code-reviewer` reviews before proceeding. If signing or certificate changes accompany the update mechanism, invoke `desktop-code-signing-expert`.
+  ```
+
+  **desktop-code-signing-expert.md**
+  old_string: `- **Rotation runbook** — when, who, steps, rollback`
+  new_string:
+  ```
+  - **Rotation runbook** — when, who, steps, rollback
+  - **Recommended next steps** — Return signing matrix and CI wiring to the orchestrator; `pr-code-reviewer` reviews CI config before merging. If supply-chain risk surfaces during the audit, invoke `secure-auditor`.
+  ```
+
+  **desktop-installer-expert.md**
+  old_string: `- **Enterprise doc** — SCCM / Intune / JAMF deployment snippets, transform files, MDM profile samples`
+  new_string:
+  ```
+  - **Enterprise doc** — SCCM / Intune / JAMF deployment snippets, transform files, MDM profile samples
+  - **Recommended next steps** — Return installer spec to the orchestrator; `pr-code-reviewer` reviews scripts before merging. If shell integration registrations are being added (file types, protocol handlers), invoke `desktop-shell-integration-expert`.
+  ```
+
+  **desktop-shell-integration-expert.md**
+  old_string: `- **OS-tool verification commands** — exact CLI invocations that confirm registration worked`
+  new_string:
+  ```
+  - **OS-tool verification commands** — exact CLI invocations that confirm registration worked
+  - **Recommended next steps** — Return registration matrix and verification commands to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If registration triggers OS security prompts or entitlement changes, invoke `secure-auditor`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/desktop-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/desktop-*.md
+  git commit -m "feat(agents): add handoff language to desktop pack"
+  ```
+
+---
+
+## Task 19: ext pack — 5 agents
+
+**Files:**
+- Modify: `.claude/agents/ext-architect.md`, `ext-permissions-expert.md`, `ext-security-expert.md`, `ext-ux-expert.md`, `ext-native-messaging-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/ext-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **ext-architect.md**
+  old_string: `- **Store plan** — per-store submission notes and expected reviews`
+  new_string:
+  ```
+  - **Store plan** — per-store submission notes and expected reviews
+  - **Recommended next steps** — Engage specialists per domain: permission strategy → `ext-permissions-expert`; threat model and CSP → `ext-security-expert`; popup/onboarding UX → `ext-ux-expert`; native host bridge → `ext-native-messaging-expert`. Route all implementation through `pr-code-reviewer`. If the extension integrates with a companion desktop app, consider whether a desktop architecture specialist would add value reviewing the IPC boundary.
+  ```
+
+  **ext-permissions-expert.md**
+  old_string: `- **Reviewer notes** — per permission, one paragraph`
+  new_string:
+  ```
+  - **Reviewer notes** — per permission, one paragraph
+  - **Recommended next steps** — Return permission list and request flow to the orchestrator; `pr-code-reviewer` reviews before proceeding. If new host permissions broaden the extension's reach, invoke `ext-security-expert` to review the expanded scope.
+  ```
+
+  **ext-security-expert.md**
+  old_string: `- **CSP policy** — directives and rationale`
+  new_string:
+  ```
+  - **CSP policy** — directives and rationale
+  - **Recommended next steps** — Return threat model and validation contracts to the orchestrator; `pr-code-reviewer` reviews before proceeding. If dependency auditing reveals supply-chain risk, invoke `secure-auditor`.
+  ```
+
+  **ext-ux-expert.md**
+  old_string: `- **In-page UI rules** — isolation, theming, dismissal`
+  new_string:
+  ```
+  - **In-page UI rules** — isolation, theming, dismissal
+  - **Recommended next steps** — Return UX spec to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If in-page UI has accessibility issues, invoke `common-a11y-expert`.
+  ```
+
+  **ext-native-messaging-expert.md**
+  old_string: `- **Test matrix** — malformed-length, oversized-payload, unknown-command, spoofed-origin, version-skew cases`
+  new_string:
+  ```
+  - **Test matrix** — malformed-length, oversized-payload, unknown-command, spoofed-origin, version-skew cases
+  - **Recommended next steps** — Return message schema and host manifest to the orchestrator; `pr-code-reviewer` reviews before proceeding. If the native host requires installer packaging or code signing, invoke `desktop-installer-expert` and `desktop-code-signing-expert`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/ext-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/ext-*.md
+  git commit -m "feat(agents): add handoff language to ext pack"
+  ```
+
+---
+
+## Task 20: embed pack — 7 agents
+
+**Files:**
+- Modify: `.claude/agents/embed-architect.md`, `embed-driver-expert.md`, `embed-rtos-expert.md`, `embed-ota-expert.md`, `embed-power-expert.md`, `embed-connectivity-expert.md`, `embed-manufacturing-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/embed-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **embed-architect.md**
+  old_string: `- **Fleet update topology** — trigger, staging, rollback, telemetry`
+  new_string:
+  ```
+  - **Fleet update topology** — trigger, staging, rollback, telemetry
+  - **Recommended next steps** — Engage specialists per domain: drivers → `embed-driver-expert`; RTOS task design → `embed-rtos-expert`; OTA mechanics → `embed-ota-expert`; power budget → `embed-power-expert`; connectivity → `embed-connectivity-expert`; factory/manufacturing → `embed-manufacturing-expert`. Route all implementation through `pr-code-reviewer`. If the device streams telemetry to a cloud backend, consider whether a data platform streaming specialist would add value reviewing the ingestion topology.
+  ```
+
+  **embed-driver-expert.md**
+  old_string: `- **Error handling** — timeouts, retries, escalation`
+  new_string:
+  ```
+  - **Error handling** — timeouts, retries, escalation
+  - **Recommended next steps** — Return driver implementation to the orchestrator; `pr-code-reviewer` reviews before proceeding. If DMA or interrupt priority changes affect RTOS task scheduling, invoke `embed-rtos-expert`.
+  ```
+
+  **embed-rtos-expert.md**
+  old_string: `- **Schedulability notes** — WCET, utilization, headroom`
+  new_string:
+  ```
+  - **Schedulability notes** — WCET, utilization, headroom
+  - **Recommended next steps** — Return task table and sync primitives to the orchestrator; `pr-code-reviewer` reviews before proceeding. If task timing changes affect the power budget, coordinate with `embed-power-expert`.
+  ```
+
+  **embed-ota-expert.md**
+  old_string: `- **Rollout plan** — stages, gates, comms`
+  new_string:
+  ```
+  - **Rollout plan** — stages, gates, comms
+  - **Recommended next steps** — Return update protocol and rollback mechanism to the orchestrator; `pr-code-reviewer` reviews before proceeding. If OTA transport uses a radio peripheral, coordinate with `embed-connectivity-expert`. If the fleet OTA feeds a cloud telemetry pipeline, consider whether a data platform streaming specialist would add value reviewing the ingestion design.
+  ```
+
+  **embed-power-expert.md**
+  old_string: `- **Regression test plan** — measurement harness + thresholds`
+  new_string:
+  ```
+  - **Regression test plan** — measurement harness + thresholds
+  - **Recommended next steps** — Return sleep state table and battery-life estimate to the orchestrator; `pr-code-reviewer` reviews before proceeding. If sleep modes affect connectivity duty cycle, coordinate with `embed-connectivity-expert`.
+  ```
+
+  **embed-connectivity-expert.md**
+  old_string: `- **Certification roadmap** — required certs, lab choices, estimated timeline and cost, sample-unit requirements`
+  new_string:
+  ```
+  - **Certification roadmap** — required certs, lab choices, estimated timeline and cost, sample-unit requirements
+  - **Recommended next steps** — Return radio selection and connection state machine to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If cloud-side ingestion needs scaling, coordinate with `infra-architect` or `dataplat-streaming-expert`.
+  ```
+
+  **embed-manufacturing-expert.md**
+  old_string: `- **CM handoff packet** — test specs, fixture BOM, acceptance criteria, ECN protocol`
+  new_string:
+  ```
+  - **CM handoff packet** — test specs, fixture BOM, acceptance criteria, ECN protocol
+  - **Recommended next steps** — Return DFT spec and test flow to the orchestrator; `pr-code-reviewer` reviews any automation code before merging. If key injection involves cryptographic design decisions, invoke `secure-auditor`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/embed-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/embed-*.md
+  git commit -m "feat(agents): add handoff language to embed pack"
+  ```
+
+---
+
+## Task 21: media pack — 7 agents
+
+**Files:**
+- Modify: `.claude/agents/media-architect.md`, `media-transcode-expert.md`, `media-drm-cdn-expert.md`, `media-cms-workflow-expert.md`, `media-player-expert.md`, `media-ad-insertion-expert.md`, `media-live-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/media-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **media-architect.md**
+  old_string: `- **CDN plan** — topology, cost model, failover`
+  new_string:
+  ```
+  - **CDN plan** — topology, cost model, failover
+  - **Recommended next steps** — Engage specialists per domain: transcode pipeline → `media-transcode-expert`; DRM/CDN delivery → `media-drm-cdn-expert`; CMS/editorial → `media-cms-workflow-expert`; client playback → `media-player-expert`; ad insertion → `media-ad-insertion-expert`; live streaming → `media-live-expert`. Route all implementation through `pr-code-reviewer`. If the platform serves regulated content (children's programming, financial education), consider whether a compliance specialist would add value reviewing licensing and consent posture.
+  ```
+
+  **media-transcode-expert.md**
+  old_string: `- **QC checklist** — automated checks per asset`
+  new_string:
+  ```
+  - **QC checklist** — automated checks per asset
+  - **Recommended next steps** — Return encode profile and ladder to the orchestrator; `pr-code-reviewer` reviews pipeline code before merging. If DRM packaging is involved in the same workflow, coordinate with `media-drm-cdn-expert`. If the encode workload is ML-driven (content-aware per-title encoding), consider whether an AI inference performance specialist would add value reviewing the compute cost.
+  ```
+
+  **media-drm-cdn-expert.md**
+  old_string: `- **QoE dashboard** — metrics, targets, alerts`
+  new_string:
+  ```
+  - **QoE dashboard** — metrics, targets, alerts
+  - **Recommended next steps** — Return DRM flow and CDN plan to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If playback quality issues surface after the change, invoke `media-player-expert`.
+  ```
+
+  **media-cms-workflow-expert.md**
+  old_string: `- **Workflow UX** — editor views, bulk ops, permissions`
+  new_string:
+  ```
+  - **Workflow UX** — editor views, bulk ops, permissions
+  - **Recommended next steps** — Return asset state machine and metadata schema to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If editorial workflow touches rights windows with regulatory implications, invoke `fintech-compliance-expert` (if fintech pack is active). If the CMS serves live content scheduling, consider whether a live streaming specialist would add value reviewing the scheduling and failover design.
+  ```
+
+  **media-player-expert.md**
+  old_string: `- **Regression harness** — reference devices, golden-path scenarios, pass/fail thresholds`
+  new_string:
+  ```
+  - **Regression harness** — reference devices, golden-path scenarios, pass/fail thresholds
+  - **Recommended next steps** — Return player config and QoE schema to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If accessibility requirements surface (captions, audio description), invoke `common-a11y-expert`.
+  ```
+
+  **media-ad-insertion-expert.md**
+  old_string: `- **Instrumentation** — ad-fill rate, ad-start rate, completion rate, revenue per viewer hour, per-device QoE`
+  new_string:
+  ```
+  - **Instrumentation** — ad-fill rate, ad-start rate, completion rate, revenue per viewer hour, per-device QoE
+  - **Recommended next steps** — Return ad pipeline architecture to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If consent handling involves TCF/GPP signal propagation, invoke `common-privacy-expert`.
+  ```
+
+  **media-live-expert.md**
+  old_string: `- **DVR / clip-out spec** — window size, origin storage policy, clip-out pipeline`
+  new_string:
+  ```
+  - **DVR / clip-out spec** — window size, origin storage policy, clip-out pipeline
+  - **Recommended next steps** — Return pipeline architecture and failover runbook to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If cloud capacity needs scaling for a tentpole event, coordinate with `infra-architect` and `infra-sre-expert`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/media-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/media-*.md
+  git commit -m "feat(agents): add handoff language to media pack"
+  ```
+
+---
+
+## Task 22: orch pack — 5 agents
+
+**Files:**
+- Modify: `.claude/agents/orch-architect.md`, `orch-tool-design-expert.md`, `orch-prompt-engineer.md`, `orch-eval-expert.md`, `orch-sandbox-safety-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/orch-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **orch-architect.md**
+  old_string: `- **Decisions** — ADR-ready bullets`
+  new_string:
+  ```
+  - **Decisions** — ADR-ready bullets
+  - **Recommended next steps** — Engage specialists per domain: tool specs → `orch-tool-design-expert`; system prompts → `orch-prompt-engineer`; eval harness → `orch-eval-expert`; sandbox and safety → `orch-sandbox-safety-expert`. Route all implementation through `pr-code-reviewer`. If the agent handles regulated data or makes decisions with compliance implications, consider whether a fintech or privacy specialist would add value reviewing the authority model.
+  ```
+
+  **orch-tool-design-expert.md**
+  old_string: `- **Overlap notes** — sibling tools and when to pick which`
+  new_string:
+  ```
+  - **Overlap notes** — sibling tools and when to pick which
+  - **Recommended next steps** — Return tool spec to the orchestrator; `pr-code-reviewer` reviews before proceeding. If tool execution is sandboxed, coordinate with `orch-sandbox-safety-expert` to verify the authority model.
+  ```
+
+  **orch-prompt-engineer.md**
+  old_string: `- **Regression cases** — test prompts + expected behavior`
+  new_string:
+  ```
+  - **Regression cases** — test prompts + expected behavior
+  - **Recommended next steps** — Return the system prompt and few-shot set to the orchestrator; `pr-code-reviewer` reviews integration code before proceeding. If eval regression surfaces after the prompt change, invoke `orch-eval-expert`. If adversarial injection attempts succeed, invoke `orch-sandbox-safety-expert` or `ai-safety-expert`.
+  ```
+
+  **orch-eval-expert.md**
+  old_string: `- **CI wiring** — when it runs, what it blocks`
+  new_string:
+  ```
+  - **CI wiring** — when it runs, what it blocks
+  - **Recommended next steps** — Return eval set and CI wiring to the orchestrator; `pr-code-reviewer` reviews before merging. If a human-rater protocol is required, surface the protocol for product review before implementing.
+  ```
+
+  **orch-sandbox-safety-expert.md**
+  old_string: `- **Incident response** — what gets revoked when things go wrong`
+  new_string:
+  ```
+  - **Incident response** — what gets revoked when things go wrong
+  - **Recommended next steps** — Return sandbox spec and authority model to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If application-security concerns surface (beyond agent sandboxing), invoke `secure-auditor`.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/orch-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/orch-*.md
+  git commit -m "feat(agents): add handoff language to orch pack"
+  ```
+
+---
+
+## Task 23: common pack — 5 agents
+
+**Files:**
+- Modify: `.claude/agents/common-i18n-expert.md`, `common-a11y-expert.md`, `common-notifications-expert.md`, `common-privacy-expert.md`, `common-product-analytics-expert.md`
+
+- [ ] **Step 1: Verify fields are missing**
+
+  ```bash
+  grep -rn "Recommended next steps" .claude/agents/common-*.md
+  ```
+  Expected: no matches.
+
+- [ ] **Step 2: Apply edits per file**
+
+  **common-i18n-expert.md**
+  old_string: `- **Launch-locale checklist** — font coverage, legal content review, QA plan, soft-launch plan`
+  new_string:
+  ```
+  - **Launch-locale checklist** — font coverage, legal content review, QA plan, soft-launch plan
+  - **Recommended next steps** — Return i18n architecture to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If RTL layout issues surface that affect keyboard navigation or focus order, invoke `common-a11y-expert`. If translations involve regulated content (legal, medical, financial), consider whether a domain compliance specialist would add value reviewing the jurisdiction-specific copy.
+  ```
+
+  **common-a11y-expert.md**
+  old_string: `- **Remediation roadmap** — ordered by impact × effort, with milestones`
+  new_string:
+  ```
+  - **Remediation roadmap** — ordered by impact × effort, with milestones
+  - **Recommended next steps** — Return the audit report and remediation roadmap to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If platform-specific accessibility APIs need changes, invoke `mobile-platform-expert`.
+  ```
+
+  **common-notifications-expert.md**
+  old_string: `- **Compliance matrix** — jurisdiction × channel × consent requirement × retention`
+  new_string:
+  ```
+  - **Compliance matrix** — jurisdiction × channel × consent requirement × retention
+  - **Recommended next steps** — Return channel matrix and sending pipeline to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If consent and opt-out mechanics are involved, coordinate with `common-privacy-expert`. If mobile push notification platform integration is needed, coordinate with `mobile-platform-expert`.
+  ```
+
+  **common-privacy-expert.md**
+  old_string: `- **Sensitive data handling** — children, health, biometric, special-category handling rules`
+  new_string:
+  ```
+  - **Sensitive data handling** — children, health, biometric, special-category handling rules
+  - **Recommended next steps** — Return consent architecture and DSAR workflow to the orchestrator; `pr-code-reviewer` reviews implementation before proceeding. If data-warehouse-layer PII masking is also needed, invoke `dataplat-privacy-expert`. If KYC/AML obligations are involved, invoke `fintech-compliance-expert`.
+  ```
+
+  **common-product-analytics-expert.md**
+  old_string: `- **Self-serve docs** — naming index, saved queries, dashboard templates, anti-patterns`
+  new_string:
+  ```
+  - **Self-serve docs** — naming index, saved queries, dashboard templates, anti-patterns
+  - **Recommended next steps** — Return event taxonomy and instrumentation guide to the orchestrator; `pr-code-reviewer` reviews instrumentation code before merging. If consent or privacy governance for the analytics stream is needed, invoke `common-privacy-expert`. If analytics will feed ML model features, consider whether a data platform specialist would add value reviewing the feature pipeline design.
+  ```
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -c "Recommended next steps" .claude/agents/common-*.md
+  ```
+  Expected: each file shows count = 1.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add .claude/agents/common-*.md
+  git commit -m "feat(agents): add handoff language to common pack"
+  ```
+
+---
+
+## Final verification
+
+- [ ] **Confirm all agents have the field**
+
+  ```bash
+  grep -rL "Recommended next steps" .claude/agents/*.md
+  ```
+  Expected: empty output (no files missing the field).
+
+- [ ] **Confirm CLAUDE.md was updated**
+
+  ```bash
+  grep -n "session restart" "C:/Users/grace/.claude/CLAUDE.md"
+  ```
+  Expected: one match.

--- a/docs/superpowers/specs/2026-04-30-agent-handoff-language-design.md
+++ b/docs/superpowers/specs/2026-04-30-agent-handoff-language-design.md
@@ -1,0 +1,157 @@
+# Agent Handoff Language Design
+
+**Date:** 2026-04-30  
+**Status:** Approved — pending implementation plan  
+**Scope:** All agents in `.claude/agents/` (~100 files)
+
+---
+
+## Problem
+
+The agent system has two handoff gaps:
+
+1. **Five generalist agents have no scope delegation language at all** — `pr-code-reviewer`, `test-writer-runner`, `deploy-checklist`, `api-expert`, `ux-design-critic` contain no "You do NOT own" sections and no recommended-next-steps output fields. The orchestrator has no in-agent signal for when to move to the next phase or escalate to a specialist.
+
+2. **Most pack specialists have scope delegation bodies but no "Recommended next steps" output field** — they tell the orchestrator what they don't own, but their output format never says what to invoke after their work is done. An initial sample of ~33 agents found this field missing in ~27 of them; the full population across all packs is 75+ specialists.
+
+The combined effect: handoffs rely entirely on the orchestrator inferring next steps from context rather than receiving explicit signals from the agents themselves. This works when the orchestrator has full context, but degrades as sessions grow and context compresses.
+
+---
+
+## Design
+
+### Three additions per agent
+
+Every agent receives up to three additions, tailored to its specific scope and voice. Not all three apply to every agent — existing agents that already have scope delegation don't get a duplicate section.
+
+---
+
+#### 1. Scope delegation block — "You do NOT own"
+
+**Applies to:** The 5 generalist agents (missing this entirely).
+
+A `## Scope Boundaries` section with two subsections:
+
+- **You own** — brief statement of the agent's primary domain (1–4 bullet points)
+- **You do NOT own** — explicit `→ agent-name` entries for:
+  - *Phase-chain handoffs*: the next generalist in the workflow sequence
+  - *Domain escalations*: pack specialists to invoke when domain-specific territory is crossed mid-task
+
+Format:
+```markdown
+## Scope Boundaries
+
+You own: [concise domain statement]
+
+You do NOT own:
+- [Domain area] → `agent-name`
+- [Domain area] → `agent-name`
+```
+
+The phase chain order is:
+`plan-architect` → implement → `pr-code-reviewer` → `test-writer-runner` → `secure-auditor` → `deploy-checklist`
+
+`api-expert` and `ux-design-critic` are lateral specialists invoked during Phase 3 (Implementation), not sequential phase-gate agents. Their handoffs point back to `pr-code-reviewer` as the gate before proceeding.
+
+---
+
+#### 2. "Recommended next steps" output field
+
+**Applies to:** All agents currently missing this field (~30+ agents, including all 5 generalists and most pack specialists).
+
+A two-part field appended to the existing output format section:
+
+- **Static line** — always present; names what the orchestrator should invoke after this agent's work is done (phase-flow continuation)
+- **Conditional lines** — only surface when findings fall outside this agent's scope; name the specific agent to invoke
+
+Format:
+```markdown
+- **Recommended next steps** — [static: what comes next in the phase flow]. If [condition], invoke `agent-name`. If [condition], invoke `agent-name`.
+```
+
+The static line uses consistent phrasing:
+- Generalists: *"After [this agent's] findings are resolved, proceed with `next-agent`."*
+- Pack specialists: *"Return findings to the orchestrator. If implementation is complete and no sibling specialist handoff is needed, `pr-code-reviewer` reviews before the work proceeds to the next phase."* (Where a pack specialist's output feeds directly into another specialist — e.g. `saas-data-model-expert` → `saas-multitenancy-expert` — the static line names that sibling instead.)
+
+---
+
+#### 3. Cross-pack advisory hint
+
+**Applies to:** Agents whose work can benefit from a perspective outside their pack or the activated packs — added as a conditional line in the "Recommended next steps" field.
+
+Uses soft, unnamed language — no specific agent filename — so it degrades gracefully when the relevant pack isn't installed:
+
+```
+If this work touches [domain], consider whether a [type of specialist] agent would add value — the orchestrator can assess whether to activate one.
+```
+
+Examples:
+- A `saas-data-model-expert` working on a schema with heavy analytics usage might hint: *"If this schema is primarily serving analytical queries, consider whether a data platform specialist would add value."*
+- An `infra-k8s-expert` working on a latency-sensitive workload might hint: *"If this involves real-time ML inference, consider whether an AI inference performance specialist would add value."*
+
+The orchestrator — not the agent — decides whether to search the playbook and restart the session to add the relevant agent.
+
+---
+
+### CLAUDE.md update
+
+**File:** `~/.claude/CLAUDE.md` — global init protocol, Step 1 (Codebase Analysis).
+
+**Addition:** After the existing `ccds --help` instruction, add:
+
+> After selecting packs and before running the sync command, state the pack selection and reasoning explicitly to the user so they can redirect if needed. Note that copying new agents to `.claude/agents/` requires a session restart before they are active.
+
+This makes the restart requirement visible at the moment it matters, and gives the user a checkpoint before the sync runs.
+
+---
+
+## Execution Plan
+
+### Tier 1 — Generalists (5 files, highest effort)
+
+Written first because their delegation vocabulary establishes the reference points pack agents name.
+
+| Agent | Missing | Key handoffs to add |
+|---|---|---|
+| `pr-code-reviewer` | Scope section + output field | Phase-next: `test-writer-runner`; escalate: `secure-auditor` (security findings), pack auth/billing specialists |
+| `test-writer-runner` | Scope section + output field | Phase-next: `secure-auditor`; escalate: domain specialists for coverage gaps |
+| `deploy-checklist` | Scope section + output field | End of chain; escalate: `secure-auditor` (unresolved findings), `saas-data-model-expert` (migration issues) |
+| `api-expert` | Scope section + output field | Phase-next: `pr-code-reviewer`; escalate: `secure-auditor` (auth/secrets), `ux-design-critic` (API UX) |
+| `ux-design-critic` | Scope section + output field | Phase-next: `pr-code-reviewer`; escalate: `common-a11y-expert`, `common-i18n-expert` |
+
+### Tier 2 — Architect agents (up to 15 files, medium effort)
+
+Each architect already has a "You do NOT own" section. They need:
+- "Recommended next steps" output field (static: name their pack's lead specialist; conditional: escalate to relevant generalist)
+- Cross-pack advisory hint where the architecture decision touches adjacent domains
+
+Architects: `plan-architect`, `saas-architect`, `ai-architect`, `infra-architect`, `devtool-architect`, `game-architect`, `mobile-architect`, `ecom-architect`, `fintech-architect`, `dataplat-architect`, `desktop-architect`, `ext-architect`, `embed-architect`, `media-architect`, `orch-architect`
+
+Note: `plan-architect` is a generalist but is included here because it reportedly already has scope delegation — verify during implementation and skip the scope section if already present; add only the output field if missing.
+
+### Tier 3 — Pack specialists (75+ files, lower effort per file)
+
+Already have scope delegation. They need:
+- "Recommended next steps" output field added to the output format section
+- Cross-pack advisory hint where applicable
+
+Packs: `saas-*`, `ai-*`, `infra-*`, `devtool-*`, `game-*`, `mobile-*`, `ecom-*`, `fintech-*`, `dataplat-*`, `desktop-*`, `ext-*`, `embed-*`, `media-*`, `orch-*`, `common-*`
+
+---
+
+## Quality bar
+
+Each agent's additions must:
+- Match the existing voice and terminology of that agent's body text
+- Not duplicate language already present in the agent
+- Name specific agent filenames (`agent-name`) for in-scope handoffs
+- Use unnamed, type-descriptive language for cross-pack advisory hints
+- Be concise — the output field addition should be 1–4 lines total
+
+---
+
+## Files changed
+
+- `~/.claude/CLAUDE.md` — restart note added to Step 1
+- `.claude/agents/*.md` — all ~100 agent files receive additions per the tier plan above
+- This spec is committed to `docs/superpowers/specs/2026-04-30-agent-handoff-language-design.md`


### PR DESCRIPTION
## Summary

Adds explicit handoff signals to all ~100 agents in `.claude/agents/` so the orchestrator no longer has to infer next steps from context.

- 7 generalists (`plan-architect`, `pr-code-reviewer`, `test-writer-runner`, `api-expert`, `ux-design-critic`, `deploy-checklist`, `secure-auditor`) now have a `## Scope Boundaries` section with explicit `→ agent-name` delegations covering both phase-chain and domain escalations.
- All ~98 agents now end their `## Output Format` with a `- **Recommended next steps**` bullet that is two-part:
  - **Static:** what to invoke next in the phase flow (e.g. `pr-code-reviewer` after implementation).
  - **Conditional:** named-agent escalations when out-of-scope findings surface, plus soft cross-pack advisory hints (no agent filename, so they degrade gracefully when the relevant pack isn't installed).
- `~/.claude/CLAUDE.md` (outside this repo) gained a session-restart note in the init protocol — copying agents to `.claude/agents/` requires a restart before they activate.

Spec: `docs/superpowers/specs/2026-04-30-agent-handoff-language-design.md`
Plan: `docs/superpowers/plans/2026-04-30-agent-handoff-language.md`

## Test Plan

- [x] Confirm `grep -L "Recommended next steps" .claude/agents/*.md` returns empty (every agent has the field).
- [x] Confirm the 7 generalists each contain a `## Scope Boundaries` section.
- [x] Confirm no file has the field duplicated (`grep -c` returns 1 per file).
- [x] Spot-read a few pack specialists to verify the new bullet matches the agent's voice and references real agent filenames.
- [ ] After merge, restart a session and verify the new agent metadata loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)