### PR TITLE
fix(install): make CLAUDE.md JIT injection idempotent (#2)

### DIFF
--- a/Install-Playbook.ps1
+++ b/Install-Playbook.ps1
@@ -368,24 +368,43 @@ function Set-ClaudePlaybookBlock {
         New-Item -ItemType Directory -Path $claudeHome -Force | Out-Null
     }
 
-    $blockContent = Get-Content -LiteralPath $JitBlockPath -Raw
-    $existing     = if (Test-Path $claudeMd) { Get-Content $claudeMd -Raw } else { '' }
+    $blockContent = (Get-Content -LiteralPath $JitBlockPath -Raw).TrimEnd("`r","`n")
+    $existing     = if (Test-Path $claudeMd) { Get-Content -LiteralPath $claudeMd -Raw } else { '' }
+
+    # Backup before any mutation. Timestamped so reinstalls keep history.
+    if (Test-Path $claudeMd) {
+        $stamp  = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $backup = "$claudeMd.ccds-backup-$stamp"
+        Copy-Item -LiteralPath $claudeMd -Destination $backup -Force
+        Write-Info "Backed up existing CLAUDE.md to $(Split-Path -Leaf $backup)"
+    }
 
     $markerStart = '# >>> ccds >>>'
     $markerEnd   = '# <<< ccds <<<'
 
-    if ($existing -match [regex]::Escape($markerStart)) {
-        # Replace existing block (preserves everything outside the markers)
-        $pattern = "(?s)$([regex]::Escape($markerStart)).*?$([regex]::Escape($markerEnd))`r?`n?"
-        $updated = [regex]::Replace($existing, $pattern, "$blockContent`n")
-        [System.IO.File]::WriteAllText($claudeMd, $updated, [System.Text.UTF8Encoding]::new($false))
-        Write-OkMsg "Updated playbook JIT block in $claudeMd"
-    } else {
-        # Append block; ensure there is a blank line separator if file has content
-        $sep = if ($existing -and -not $existing.EndsWith("`n")) { "`n`n" } elseif ($existing) { "`n" } else { '' }
-        [System.IO.File]::WriteAllText($claudeMd, $existing + $sep + $blockContent + "`n", [System.Text.UTF8Encoding]::new($false))
-        Write-OkMsg "Appended playbook JIT block to $claudeMd"
+    # Strip ALL existing ccds blocks (handles duplicates from prior buggy
+    # installs and tolerates trailing whitespace on the marker lines).
+    $stripPattern = "(?s)\r?\n?[ \t]*$([regex]::Escape($markerStart))[ \t\r]*\r?\n.*?[ \t]*$([regex]::Escape($markerEnd))[ \t\r]*\r?\n?"
+    $cleaned = [regex]::Replace($existing, $stripPattern, '')
+    $cleaned = $cleaned.TrimEnd("`r","`n")
+
+    # Canary: legacy installs (pre-marker era, or hand-edited) may have left
+    # JIT content in CLAUDE.md without markers. We can't safely auto-strip it,
+    # but we can warn so the user can clean up by hand or restore the backup.
+    if ($cleaned -match '##\s+Playbook JIT Agent Loading') {
+        Write-WarnMsg "Detected legacy 'Playbook JIT Agent Loading' content outside markers."
+        if ($backup) {
+            Write-WarnMsg "Inspect $claudeMd and (if duplicated) restore from $(Split-Path -Leaf $backup)."
+        }
     }
+
+    if ($cleaned.Length -gt 0) {
+        $updated = $cleaned + "`n`n" + $blockContent + "`n"
+    } else {
+        $updated = $blockContent + "`n"
+    }
+    [System.IO.File]::WriteAllText($claudeMd, $updated, [System.Text.UTF8Encoding]::new($false))
+    Write-OkMsg "Refreshed playbook JIT block in $claudeMd"
 }
 
 # Remove the playbook JIT block from ~/.claude/CLAUDE.md (used by uninstall)

--- a/scripts/ccds-user-setup.sh
+++ b/scripts/ccds-user-setup.sh
@@ -99,35 +99,57 @@ set_claude_playbook_block() {
         return
     fi
 
-    local block_content
-    block_content="$(cat "$jit_src")"
-
     mkdir -p "$claude_home"
     [[ -f "$claude_md" ]] || touch "$claude_md"
+
+    # Backup before any mutation. Timestamped so reinstalls keep history.
+    local backup="$claude_md.ccds-backup-$(date +%Y%m%d-%H%M%S)"
+    cp -p "$claude_md" "$backup"
+    log_info "Backed up existing CLAUDE.md to $(basename "$backup")"
 
     local tmp
     tmp="$(mktemp)"
 
-    if grep -qF "$MARKER_BEGIN" "$claude_md"; then
-        # Replace existing block in place
-        awk -v b="$MARKER_BEGIN" -v e="$MARKER_END" -v block="$block_content" '
-            BEGIN { in_block=0; printed=0 }
-            $0 == b { in_block=1; if (!printed) { print block; printed=1 } next }
-            $0 == e { in_block=0; next }
-            in_block { next }
-            { print }
-        ' "$claude_md" > "$tmp"
-        mv "$tmp" "$claude_md"
-        log_ok "Updated JIT block in $claude_md"
-    else
-        # Append block
+    # Strip ALL existing ccds blocks (handles duplicates, CRLF, trailing whitespace
+    # on marker lines). Anything outside the markers is preserved verbatim.
+    awk -v b="$MARKER_BEGIN" -v e="$MARKER_END" '
+        BEGIN { in_block=0 }
         {
-            cat "$claude_md"
-            printf '\n%s\n' "$block_content"
-        } > "$tmp"
-        mv "$tmp" "$claude_md"
-        log_ok "Injected JIT block into $claude_md"
+            check = $0
+            sub(/[[:space:]\r]+$/, "", check)
+            if (check == b) { in_block=1; next }
+            if (check == e) { in_block=0; next }
+            if (!in_block) print
+        }
+    ' "$claude_md" > "$tmp"
+
+    # Trim trailing blank lines from the surviving user content, then append
+    # a single fresh ccds block separated by one blank line.
+    local cleaned
+    cleaned="$(mktemp)"
+    awk 'NF { for (i=1;i<=hold;i++) print ""; hold=0; print; next }
+         { hold++ }' "$tmp" > "$cleaned"
+
+    if [[ -s "$cleaned" ]]; then
+        printf '\n' >> "$cleaned"
     fi
+    cat "$jit_src" >> "$cleaned"
+    # Ensure file ends with a single newline.
+    if [[ "$(tail -c1 "$cleaned" | od -An -c | tr -d ' ')" != '\n' ]]; then
+        printf '\n' >> "$cleaned"
+    fi
+
+    # Canary: legacy installs (pre-marker era, or hand-edited) may have left
+    # JIT content in CLAUDE.md without markers. We can't safely auto-strip it,
+    # but we can warn so the user can clean up by hand or restore the backup.
+    if grep -qF "## Playbook JIT Agent Loading" "$tmp"; then
+        log_warn "Detected legacy 'Playbook JIT Agent Loading' content outside markers."
+        log_warn "Inspect $claude_md and (if duplicated) restore from $(basename "$backup")."
+    fi
+
+    mv "$cleaned" "$claude_md"
+    rm -f "$tmp"
+    log_ok "Refreshed JIT block in $claude_md"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes #2 — re-running the installer no longer appends or duplicates the playbook JIT block in `~/.claude/CLAUDE.md`.
- Both `scripts/ccds-user-setup.sh` (bash) and `Install-Playbook.ps1` (PowerShell) now back up `CLAUDE.md` to `CLAUDE.md.ccds-backup-<timestamp>` before mutating, strip **all** marker-bounded ccds blocks, normalize trailing blank lines, and append exactly one fresh block.
- Marker matching is now whitespace- and CR-tolerant. The bash `awk` used strict `$0 == marker` equality, which silently failed against the mixed CRLF/LF lines a prior Windows install can leave behind — that was the actual root cause of the duplication observed locally.
- Adds a one-shot canary: if `## Playbook JIT Agent Loading` is detected *outside* markers (legacy pre-marker installs), the installer warns the user and points at the backup for manual cleanup.

## Test plan
Manual — covered with a scratch `HOME` against `scripts/ccds-user-setup.sh`:
- [x] Clean `HOME` (no `CLAUDE.md`) → file created with one block
- [x] Idempotent re-run on a single-block file → still one block, plus timestamped backup
- [x] File pre-seeded with **two** duplicate blocks + surrounding user content → collapses to one block, user content preserved
- [x] File with CRLF-only line terminators on marker lines → replaces correctly (this is the bug the issue describes)
- [x] File with legacy unmarked JIT content → canary warning fires; backup retained
- [ ] PowerShell parity not run locally (no Windows host); regex mirror of the bash logic, reviewed by inspection

## Notes
Out of scope:
- Cleaning up the `ccds_0.6.0_all.deb` and `claude_auto_completion/` paths in the working tree — left untouched.
- Auto-removal of legacy unmarked content — too lossy to do without explicit consent; the canary + backup is the safe seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)