### PR TITLE
docs(extras): claude CLI shell completion + per-OS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ See `Get-Help .\Sync-AgentPacks.ps1 -Full` or `./Sync-AgentPacks.sh --help`.
 
 Pack contents, agent counts, and trigger conditions are documented in `CLAUDE.md`.
 
+## Extras
+
+### Shell completion for the `claude` CLI
+
+Optional, opt-in tab-completion for the Claude Code CLI itself — independent of the playbook. See [`claude_auto_completion/README.md`](./claude_auto_completion/README.md) for per-OS install instructions.
+
+```bash
+# Linux / macOS / WSL (per-user)
+./claude_auto_completion/Linux/claude-autocomplete.sh
+```
+
+```powershell
+# Windows (PowerShell 5.1 / 7+)
+. .\claude_auto_completion\Windows\install-claude-completion.ps1
+```
+
 ## Requirements
 
 - Claude Code CLI (v2.1.113+ recommended — flat agent discovery)

--- a/claude_auto_completion/Linux/claude-autocomplete.sh
+++ b/claude_auto_completion/Linux/claude-autocomplete.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# install-claude-completion.sh
+# Installs the claude CLI bash completion script.
+#
+# Usage:
+#   ./install-claude-completion.sh           # per-user install
+#   sudo ./install-claude-completion.sh -s   # system-wide install
+
+set -euo pipefail
+
+SRC="$(dirname "$(readlink -f "$0")")/claude-completion.bash"
+SCOPE="user"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -s|--system) SCOPE="system" ;;
+        -h|--help)
+            sed -n '2,11p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+if [[ ! -f "$SRC" ]]; then
+    echo "ERROR: claude-completion.bash not found next to installer ($SRC)" >&2
+    exit 1
+fi
+
+if [[ "$SCOPE" == "system" ]]; then
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: system install requires root. Re-run with sudo." >&2
+        exit 1
+    fi
+    DEST_DIR="/etc/bash_completion.d"
+    DEST="$DEST_DIR/claude"
+else
+    DEST_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
+    DEST="$DEST_DIR/claude"
+fi
+
+mkdir -p "$DEST_DIR"
+install -m 0644 "$SRC" "$DEST"
+
+echo "Installed: $DEST"
+
+# Verify bash-completion is available
+if ! command -v _init_completion >/dev/null 2>&1; then
+    if [[ -r /usr/share/bash-completion/bash_completion ]]; then
+        echo "Note: bash-completion is installed but not loaded in this shell."
+    else
+        echo "WARNING: bash-completion package not found." >&2
+        echo "  Debian/Ubuntu: sudo apt install bash-completion" >&2
+    fi
+fi
+
+# Ensure completion is loaded in user's bashrc
+if [[ "$SCOPE" == "user" ]] && [[ -f "$HOME/.bashrc" ]]; then
+    if ! grep -q "bash-completion/bash_completion\|/etc/bash_completion" "$HOME/.bashrc" 2>/dev/null; then
+        echo
+        echo "Add the following to ~/.bashrc if completion does not load on next shell:"
+        echo '  [[ -r /usr/share/bash-completion/bash_completion ]] && . /usr/share/bash-completion/bash_completion'
+    fi
+fi
+
+echo
+echo "Activate now with:  source \"$DEST\""
+echo "Or open a new shell."

--- a/claude_auto_completion/Linux/claude-completion.bash
+++ b/claude_auto_completion/Linux/claude-completion.bash
@@ -1,0 +1,201 @@
+# bash completion for the Claude Code CLI (`claude`)
+# Source: https://code.claude.com/docs/en/cli-reference
+#
+# Install (per-user):
+#   mkdir -p ~/.local/share/bash-completion/completions
+#   cp claude-completion.bash ~/.local/share/bash-completion/completions/claude
+#
+# Install (system-wide, requires root):
+#   sudo cp claude-completion.bash /etc/bash_completion.d/claude
+#
+# Then start a new shell or: source ~/.local/share/bash-completion/completions/claude
+
+_claude_completion() {
+    local cur prev words cword
+    _init_completion -n = || return
+
+    # ---- Subcommands (first positional after `claude`) ----
+    local subcommands="update install auth agents auto-mode mcp plugin plugins \
+remote-control setup-token ultrareview"
+
+    # ---- Top-level flags ----
+    local global_flags="\
+--add-dir --agent --agents --allow-dangerously-skip-permissions --allowedTools \
+--append-system-prompt --append-system-prompt-file --bare --betas --channels \
+--chrome --continue -c --dangerously-load-development-channels \
+--dangerously-skip-permissions --debug --debug-file --disable-slash-commands \
+--disallowedTools --effort --exclude-dynamic-system-prompt-sections \
+--fallback-model --fork-session --from-pr --ide --init --init-only \
+--include-hook-events --include-partial-messages --input-format --json-schema \
+--maintenance --max-budget-usd --max-turns --mcp-config --model --name -n \
+--no-chrome --no-session-persistence --output-format --permission-mode \
+--permission-prompt-tool --plugin-dir --print -p --remote --remote-control --rc \
+--remote-control-session-name-prefix --replay-user-messages --resume -r \
+--session-id --setting-sources --settings --strict-mcp-config --system-prompt \
+--system-prompt-file --teleport --teammate-mode --tmux --tools --verbose \
+--version -v --worktree -w --help -h"
+
+    # ---- Enum values for specific flags ----
+    local models="sonnet opus haiku claude-sonnet-4-6 claude-opus-4-6 \
+claude-haiku-4-5 claude-sonnet-4-7 claude-opus-4-7"
+    local permission_modes="default acceptEdits plan auto dontAsk bypassPermissions"
+    local effort_levels="low medium high xhigh max"
+    local output_formats="text json stream-json"
+    local input_formats="text stream-json"
+    local teammate_modes="auto in-process tmux"
+    local setting_sources="user project local"
+    local auth_subs="login logout status"
+    local auto_mode_subs="defaults config"
+    local mcp_subs="add remove list get serve add-json add-from-claude-desktop reset-project-choices"
+    local plugin_subs="install uninstall list update enable disable marketplace"
+    local install_versions="stable latest"
+
+    # ---- Determine the active subcommand (if any) ----
+    local subcommand=""
+    local i
+    for ((i=1; i < cword; i++)); do
+        case "${words[i]}" in
+            update|install|auth|agents|auto-mode|mcp|plugin|plugins|\
+remote-control|setup-token|ultrareview)
+                subcommand="${words[i]}"
+                break
+                ;;
+        esac
+    done
+
+    # ---- Value completion: previous token expects an argument ----
+    case "$prev" in
+        --model|--fallback-model)
+            COMPREPLY=( $(compgen -W "$models" -- "$cur") )
+            return 0
+            ;;
+        --permission-mode)
+            COMPREPLY=( $(compgen -W "$permission_modes" -- "$cur") )
+            return 0
+            ;;
+        --effort)
+            COMPREPLY=( $(compgen -W "$effort_levels" -- "$cur") )
+            return 0
+            ;;
+        --output-format)
+            COMPREPLY=( $(compgen -W "$output_formats" -- "$cur") )
+            return 0
+            ;;
+        --input-format)
+            COMPREPLY=( $(compgen -W "$input_formats" -- "$cur") )
+            return 0
+            ;;
+        --teammate-mode)
+            COMPREPLY=( $(compgen -W "$teammate_modes" -- "$cur") )
+            return 0
+            ;;
+        --setting-sources)
+            # Comma-separated; offer the three values, user post-processes
+            COMPREPLY=( $(compgen -W "$setting_sources" -- "$cur") )
+            return 0
+            ;;
+        --add-dir|--plugin-dir|--worktree|-w)
+            _filedir -d
+            return 0
+            ;;
+        --settings|--mcp-config|--system-prompt-file|--append-system-prompt-file|--debug-file)
+            _filedir
+            return 0
+            ;;
+        --agents|--system-prompt|--append-system-prompt|--betas|--name|-n|\
+--session-id|--from-pr|--max-turns|--max-budget-usd|--allowedTools|\
+--disallowedTools|--tools|--agent|--debug|--channels|--json-schema|\
+--permission-prompt-tool|--remote|--remote-control-session-name-prefix)
+            # Free-form values; no completion
+            return 0
+            ;;
+    esac
+
+    # ---- Subcommand-specific completion ----
+    case "$subcommand" in
+        auth)
+            # Complete the auth subcommand and its flags
+            local auth_flags="--email --sso --console --text"
+            local auth_sub=""
+            for ((i=1; i < cword; i++)); do
+                case "${words[i]}" in
+                    login|logout|status) auth_sub="${words[i]}"; break ;;
+                esac
+            done
+            if [[ -z "$auth_sub" ]]; then
+                COMPREPLY=( $(compgen -W "$auth_subs" -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -W "$auth_flags" -- "$cur") )
+            fi
+            return 0
+            ;;
+        auto-mode)
+            COMPREPLY=( $(compgen -W "$auto_mode_subs" -- "$cur") )
+            return 0
+            ;;
+        mcp)
+            local mcp_sub=""
+            for ((i=1; i < cword; i++)); do
+                case "${words[i]}" in
+                    add|remove|list|get|serve|add-json|add-from-claude-desktop|reset-project-choices)
+                        mcp_sub="${words[i]}"; break ;;
+                esac
+            done
+            if [[ -z "$mcp_sub" ]]; then
+                COMPREPLY=( $(compgen -W "$mcp_subs" -- "$cur") )
+            fi
+            return 0
+            ;;
+        plugin|plugins)
+            local plug_sub=""
+            for ((i=1; i < cword; i++)); do
+                case "${words[i]}" in
+                    install|uninstall|list|update|enable|disable|marketplace)
+                        plug_sub="${words[i]}"; break ;;
+                esac
+            done
+            if [[ -z "$plug_sub" ]]; then
+                COMPREPLY=( $(compgen -W "$plugin_subs" -- "$cur") )
+            fi
+            return 0
+            ;;
+        install)
+            # Only complete version once
+            if [[ "$cur" != -* ]]; then
+                COMPREPLY=( $(compgen -W "$install_versions" -- "$cur") )
+            fi
+            return 0
+            ;;
+        ultrareview)
+            local ur_flags="--json --timeout"
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "$ur_flags" -- "$cur") )
+            fi
+            return 0
+            ;;
+        remote-control)
+            local rc_flags="--name --remote-control-session-name-prefix"
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "$rc_flags $global_flags" -- "$cur") )
+            fi
+            return 0
+            ;;
+        update|agents|setup-token)
+            # No subcommand args; allow flags only
+            if [[ "$cur" == -* ]]; then
+                COMPREPLY=( $(compgen -W "$global_flags" -- "$cur") )
+            fi
+            return 0
+            ;;
+    esac
+
+    # ---- No active subcommand: complete subcommands + flags ----
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$global_flags" -- "$cur") )
+    elif [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+    fi
+    return 0
+}
+
+complete -F _claude_completion claude

--- a/claude_auto_completion/Linux/claude-completion.bash
+++ b/claude_auto_completion/Linux/claude-completion.bash
@@ -66,32 +66,32 @@ remote-control|setup-token|ultrareview)
     # ---- Value completion: previous token expects an argument ----
     case "$prev" in
         --model|--fallback-model)
-            COMPREPLY=( $(compgen -W "$models" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$models" -- "$cur")
             return 0
             ;;
         --permission-mode)
-            COMPREPLY=( $(compgen -W "$permission_modes" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$permission_modes" -- "$cur")
             return 0
             ;;
         --effort)
-            COMPREPLY=( $(compgen -W "$effort_levels" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$effort_levels" -- "$cur")
             return 0
             ;;
         --output-format)
-            COMPREPLY=( $(compgen -W "$output_formats" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$output_formats" -- "$cur")
             return 0
             ;;
         --input-format)
-            COMPREPLY=( $(compgen -W "$input_formats" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$input_formats" -- "$cur")
             return 0
             ;;
         --teammate-mode)
-            COMPREPLY=( $(compgen -W "$teammate_modes" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$teammate_modes" -- "$cur")
             return 0
             ;;
         --setting-sources)
             # Comma-separated; offer the three values, user post-processes
-            COMPREPLY=( $(compgen -W "$setting_sources" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$setting_sources" -- "$cur")
             return 0
             ;;
         --add-dir|--plugin-dir|--worktree|-w)
@@ -123,14 +123,14 @@ remote-control|setup-token|ultrareview)
                 esac
             done
             if [[ -z "$auth_sub" ]]; then
-                COMPREPLY=( $(compgen -W "$auth_subs" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$auth_subs" -- "$cur")
             else
-                COMPREPLY=( $(compgen -W "$auth_flags" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$auth_flags" -- "$cur")
             fi
             return 0
             ;;
         auto-mode)
-            COMPREPLY=( $(compgen -W "$auto_mode_subs" -- "$cur") )
+            mapfile -t COMPREPLY < <(compgen -W "$auto_mode_subs" -- "$cur")
             return 0
             ;;
         mcp)
@@ -142,7 +142,7 @@ remote-control|setup-token|ultrareview)
                 esac
             done
             if [[ -z "$mcp_sub" ]]; then
-                COMPREPLY=( $(compgen -W "$mcp_subs" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$mcp_subs" -- "$cur")
             fi
             return 0
             ;;
@@ -155,35 +155,35 @@ remote-control|setup-token|ultrareview)
                 esac
             done
             if [[ -z "$plug_sub" ]]; then
-                COMPREPLY=( $(compgen -W "$plugin_subs" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$plugin_subs" -- "$cur")
             fi
             return 0
             ;;
         install)
             # Only complete version once
             if [[ "$cur" != -* ]]; then
-                COMPREPLY=( $(compgen -W "$install_versions" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$install_versions" -- "$cur")
             fi
             return 0
             ;;
         ultrareview)
             local ur_flags="--json --timeout"
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=( $(compgen -W "$ur_flags" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$ur_flags" -- "$cur")
             fi
             return 0
             ;;
         remote-control)
             local rc_flags="--name --remote-control-session-name-prefix"
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=( $(compgen -W "$rc_flags $global_flags" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$rc_flags $global_flags" -- "$cur")
             fi
             return 0
             ;;
         update|agents|setup-token)
             # No subcommand args; allow flags only
             if [[ "$cur" == -* ]]; then
-                COMPREPLY=( $(compgen -W "$global_flags" -- "$cur") )
+                mapfile -t COMPREPLY < <(compgen -W "$global_flags" -- "$cur")
             fi
             return 0
             ;;
@@ -191,9 +191,9 @@ remote-control|setup-token|ultrareview)
 
     # ---- No active subcommand: complete subcommands + flags ----
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "$global_flags" -- "$cur") )
+        mapfile -t COMPREPLY < <(compgen -W "$global_flags" -- "$cur")
     elif [[ $cword -eq 1 ]]; then
-        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+        mapfile -t COMPREPLY < <(compgen -W "$subcommands" -- "$cur")
     fi
     return 0
 }

--- a/claude_auto_completion/README.md
+++ b/claude_auto_completion/README.md
@@ -1,0 +1,185 @@
+# Shell completion for the `claude` CLI
+
+Tab-completion for the [Claude Code](https://code.claude.com) command-line tool — subcommands, global flags, and enum values like `--model`, `--permission-mode`, `--effort`, `--output-format`, etc.
+
+> These scripts are **independent of the Claude Code Dev Studio playbook**. Install them only if you want shell completion; nothing else in this repo depends on them.
+
+```
+claude_auto_completion/
+├── Linux/                           # bash, also works in WSL and macOS bash
+│   ├── claude-completion.bash       # the completion definitions
+│   └── claude-autocomplete.sh       # installer (per-user or system-wide)
+└── Windows/                         # PowerShell 5.1 and 7+
+    ├── claude-completion.ps1        # the argument completer
+    └── install-claude-completion.ps1 # installer (per-user)
+```
+
+---
+
+## Linux / macOS / WSL (bash)
+
+### Install (per-user, recommended)
+
+```bash
+cd claude_auto_completion/Linux
+./claude-autocomplete.sh
+```
+
+This copies `claude-completion.bash` to `~/.local/share/bash-completion/completions/claude` (respecting `$XDG_DATA_HOME` if set).
+
+### Install (system-wide)
+
+```bash
+cd claude_auto_completion/Linux
+sudo ./claude-autocomplete.sh --system
+```
+
+This installs to `/etc/bash_completion.d/claude` and is picked up by every user on the host.
+
+### Activate
+
+Open a new shell, or source the file in the current one:
+
+```bash
+source ~/.local/share/bash-completion/completions/claude   # per-user
+# or
+source /etc/bash_completion.d/claude                       # system-wide
+```
+
+Then try:
+
+```bash
+claude --<TAB>
+claude auth <TAB>
+claude --model <TAB>
+```
+
+### Prerequisites
+
+- `bash` 4+
+- The `bash-completion` package, providing `_init_completion`:
+  - Debian / Ubuntu: `sudo apt install bash-completion`
+  - Fedora / RHEL: `sudo dnf install bash-completion`
+  - macOS (Homebrew): `brew install bash-completion@2` and follow its post-install instructions
+- If your `~/.bashrc` doesn't already load bash-completion, add:
+  ```bash
+  [[ -r /usr/share/bash-completion/bash_completion ]] && . /usr/share/bash-completion/bash_completion
+  ```
+
+The installer prints a reminder if it detects bash-completion is missing or not loaded.
+
+### Uninstall
+
+```bash
+rm ~/.local/share/bash-completion/completions/claude          # per-user
+sudo rm /etc/bash_completion.d/claude                         # system-wide
+```
+
+---
+
+## Windows (PowerShell 5.1 / 7+)
+
+### Install
+
+From a PowerShell prompt:
+
+```powershell
+cd claude_auto_completion\Windows
+. .\install-claude-completion.ps1
+```
+
+The installer:
+
+1. Copies `claude-completion.ps1` to `<profile-dir>\completions\claude-completion.ps1` next to your `CurrentUserAllHosts` profile.
+2. Adds a marker-bounded loader block to `$PROFILE.CurrentUserAllHosts` so the completer is picked up by **every host** — `pwsh`, `powershell.exe`, ISE, the VS Code PowerShell extension, etc.
+3. Dot-sources the completer into the current session, so you can use it immediately.
+
+Use `-Force` to overwrite an existing copy:
+
+```powershell
+. .\install-claude-completion.ps1 -Force
+```
+
+### Activate
+
+The installer activates the completer in the current session. For new sessions, the profile loads it automatically. If your execution policy blocks profile scripts, either fix the policy:
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+…or dot-source the script manually in each session:
+
+```powershell
+. $env:USERPROFILE\Documents\PowerShell\completions\claude-completion.ps1
+```
+
+Then try:
+
+```powershell
+claude --<TAB>
+claude auth <TAB>
+claude --model <TAB>
+```
+
+### Uninstall
+
+```powershell
+$dest = Join-Path (Split-Path -Parent $PROFILE.CurrentUserAllHosts) 'completions\claude-completion.ps1'
+Remove-Item -LiteralPath $dest -ErrorAction SilentlyContinue
+
+# Strip the loader block from the profile (between the markers)
+$profilePath = $PROFILE.CurrentUserAllHosts
+if (Test-Path $profilePath) {
+    $content = Get-Content -LiteralPath $profilePath -Raw
+    $cleaned = [regex]::Replace($content, "(?s)\r?\n?# >>> claude-completion >>>.*?# <<< claude-completion <<<\r?\n?", '')
+    [System.IO.File]::WriteAllText($profilePath, $cleaned, [System.Text.UTF8Encoding]::new($false))
+}
+```
+
+---
+
+## What gets completed
+
+Both scripts cover the same surface area:
+
+| Position | Completion |
+|---|---|
+| First positional after `claude` | Subcommands: `update`, `install`, `auth`, `agents`, `auto-mode`, `mcp`, `plugin`/`plugins`, `remote-control`, `setup-token`, `ultrareview` |
+| `claude auth <TAB>` | `login`, `logout`, `status` |
+| `claude mcp <TAB>` | `add`, `remove`, `list`, `get`, `serve`, `add-json`, `add-from-claude-desktop`, `reset-project-choices` |
+| `claude plugin <TAB>` | `install`, `uninstall`, `list`, `update`, `enable`, `disable`, `marketplace` |
+| `claude install <TAB>` | `stable`, `latest` |
+| Any `--<TAB>` | All documented top-level flags |
+| `--model` / `--fallback-model` | `sonnet`, `opus`, `haiku`, plus pinned versions like `claude-sonnet-4-7` |
+| `--permission-mode` | `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions` |
+| `--effort` | `low`, `medium`, `high`, `xhigh`, `max` |
+| `--output-format` | `text`, `json`, `stream-json` |
+| `--input-format` | `text`, `stream-json` |
+| `--teammate-mode` | `auto`, `in-process`, `tmux` |
+| `--setting-sources` | `user`, `project`, `local` |
+| `--add-dir`, `--plugin-dir`, `--worktree`, `-w` | Directory completion |
+| `--settings`, `--mcp-config`, `--system-prompt-file`, `--append-system-prompt-file`, `--debug-file` | File completion |
+
+The catalog tracks the public CLI reference at <https://code.claude.com/docs/en/cli-reference>. If a future Claude Code release adds new subcommands or flags, update the arrays in both scripts to match.
+
+---
+
+## Troubleshooting
+
+**`claude --<TAB>` doesn't expand on Linux**
+- Confirm bash-completion is loaded: `type _init_completion` should print a function.
+- Confirm the file is in place: `ls ~/.local/share/bash-completion/completions/claude`.
+- Open a fresh shell — the installer doesn't reload the current shell.
+
+**Completion expands subcommands but not flags / values**
+- Some shells run an older bash. Verify with `bash --version` (need 4+).
+- macOS ships bash 3.2 by default — install bash 4+ via Homebrew or use the bash-completion@2 package.
+
+**PowerShell completer doesn't fire**
+- Check the loader block exists: `Select-String '# >>> claude-completion >>>' $PROFILE.CurrentUserAllHosts`
+- Check execution policy: `Get-ExecutionPolicy -Scope CurrentUser` — if it's `Restricted`, profile scripts won't run.
+- Confirm the completer is registered: `Get-PSReadlineKeyHandler` and try `claude <TAB>` after `Register-ArgumentCompleter` has run.
+
+**I want completions for a specific Claude Code version**
+- The flag and subcommand lists are static. Pull the latest CLI reference and edit the arrays at the top of `claude-completion.bash` / `claude-completion.ps1`.

--- a/claude_auto_completion/Windows/claude-completion.ps1
+++ b/claude_auto_completion/Windows/claude-completion.ps1
@@ -1,0 +1,199 @@
+# claude-completion.ps1
+# PowerShell argument completer for the Claude Code CLI (`claude`)
+# Source: https://code.claude.com/docs/en/cli-reference
+#
+# Install (current user):
+#   . .\install-claude-completion.ps1
+#
+# Or load manually for the current session:
+#   . .\claude-completion.ps1
+#
+# Tested on PowerShell 5.1 and 7+.
+
+Register-ArgumentCompleter -Native -CommandName claude -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    # ---- Token model ----
+    # CommandElements[0] is `claude` itself.
+    $elements = @($commandAst.CommandElements | ForEach-Object { $_.ToString() })
+    $tokenCount = $elements.Count
+
+    # The "previous" token is the one immediately before the cursor.
+    # If $wordToComplete is non-empty, the last element IS the partial we're typing.
+    if ($wordToComplete -and $tokenCount -ge 1 -and $elements[$tokenCount - 1] -eq $wordToComplete) {
+        $prev = if ($tokenCount -ge 2) { $elements[$tokenCount - 2] } else { '' }
+    } else {
+        $prev = if ($tokenCount -ge 1) { $elements[$tokenCount - 1] } else { '' }
+    }
+
+    # ---- Catalog ----
+    $subcommands = @(
+        'update','install','auth','agents','auto-mode','mcp','plugin','plugins',
+        'remote-control','setup-token','ultrareview'
+    )
+
+    $globalFlags = @(
+        '--add-dir','--agent','--agents','--allow-dangerously-skip-permissions',
+        '--allowedTools','--append-system-prompt','--append-system-prompt-file',
+        '--bare','--betas','--channels','--chrome','--continue','-c',
+        '--dangerously-load-development-channels','--dangerously-skip-permissions',
+        '--debug','--debug-file','--disable-slash-commands','--disallowedTools',
+        '--effort','--exclude-dynamic-system-prompt-sections','--fallback-model',
+        '--fork-session','--from-pr','--ide','--init','--init-only',
+        '--include-hook-events','--include-partial-messages','--input-format',
+        '--json-schema','--maintenance','--max-budget-usd','--max-turns',
+        '--mcp-config','--model','--name','-n','--no-chrome',
+        '--no-session-persistence','--output-format','--permission-mode',
+        '--permission-prompt-tool','--plugin-dir','--print','-p','--remote',
+        '--remote-control','--rc','--remote-control-session-name-prefix',
+        '--replay-user-messages','--resume','-r','--session-id',
+        '--setting-sources','--settings','--strict-mcp-config','--system-prompt',
+        '--system-prompt-file','--teleport','--teammate-mode','--tmux','--tools',
+        '--verbose','--version','-v','--worktree','-w','--help','-h'
+    )
+
+    $models           = @('sonnet','opus','haiku','claude-sonnet-4-6','claude-opus-4-6','claude-haiku-4-5','claude-sonnet-4-7','claude-opus-4-7')
+    $permissionModes  = @('default','acceptEdits','plan','auto','dontAsk','bypassPermissions')
+    $effortLevels     = @('low','medium','high','xhigh','max')
+    $outputFormats    = @('text','json','stream-json')
+    $inputFormats     = @('text','stream-json')
+    $teammateModes    = @('auto','in-process','tmux')
+    $settingSources   = @('user','project','local')
+    $authSubs         = @('login','logout','status')
+    $autoModeSubs     = @('defaults','config')
+    $mcpSubs          = @('add','remove','list','get','serve','add-json','add-from-claude-desktop','reset-project-choices')
+    $pluginSubs       = @('install','uninstall','list','update','enable','disable','marketplace')
+    $installVersions  = @('stable','latest')
+
+    # ---- Helpers ----
+    function Complete-FromList {
+        param([string[]]$Candidates, [string]$Word, [string]$Tip = '')
+        $Candidates |
+            Where-Object { $_ -like "$Word*" } |
+            ForEach-Object {
+                $tip = if ($Tip) { $Tip } else { $_ }
+                [System.Management.Automation.CompletionResult]::new(
+                    $_, $_, 'ParameterValue', $tip
+                )
+            }
+    }
+
+    function Complete-Path {
+        param([string]$Word, [switch]$DirectoryOnly)
+        $base = if ($Word) { $Word } else { '.' }
+        try {
+            $parent = Split-Path -Path $base -Parent
+            $leaf   = Split-Path -Path $base -Leaf
+            if (-not $parent) { $parent = '.' }
+            if (-not $leaf -and $base.EndsWith([IO.Path]::DirectorySeparatorChar)) { $leaf = '' }
+            $items = Get-ChildItem -LiteralPath $parent -Filter "$leaf*" -ErrorAction SilentlyContinue
+            if ($DirectoryOnly) { $items = $items | Where-Object { $_.PSIsContainer } }
+            $items | ForEach-Object {
+                $p = if ($parent -eq '.') { $_.Name } else { Join-Path $parent $_.Name }
+                if ($_.PSIsContainer) { $p = "$p$([IO.Path]::DirectorySeparatorChar)" }
+                [System.Management.Automation.CompletionResult]::new(
+                    $p, $_.Name, 'ProviderItem', $_.FullName
+                )
+            }
+        } catch { }
+    }
+
+    # ---- Detect active subcommand ----
+    $subcommand = $null
+    for ($i = 1; $i -lt $tokenCount; $i++) {
+        $tok = $elements[$i]
+        if ($tok -eq $wordToComplete) { break }
+        if ($subcommands -contains $tok) { $subcommand = $tok; break }
+    }
+
+    # ---- Value completion based on previous flag ----
+    switch -Regex ($prev) {
+        '^(--model|--fallback-model)$'                                   { return Complete-FromList $models $wordToComplete }
+        '^--permission-mode$'                                            { return Complete-FromList $permissionModes $wordToComplete }
+        '^--effort$'                                                     { return Complete-FromList $effortLevels $wordToComplete }
+        '^--output-format$'                                              { return Complete-FromList $outputFormats $wordToComplete }
+        '^--input-format$'                                               { return Complete-FromList $inputFormats $wordToComplete }
+        '^--teammate-mode$'                                              { return Complete-FromList $teammateModes $wordToComplete }
+        '^--setting-sources$'                                            { return Complete-FromList $settingSources $wordToComplete }
+        '^(--add-dir|--plugin-dir|--worktree|-w)$'                       { return Complete-Path $wordToComplete -DirectoryOnly }
+        '^(--settings|--mcp-config|--system-prompt-file|--append-system-prompt-file|--debug-file)$' {
+            return Complete-Path $wordToComplete
+        }
+        # Free-form values: explicitly return nothing so PowerShell does not
+        # fall back to filename completion for opaque arguments.
+        '^(--agents|--system-prompt|--append-system-prompt|--betas|--name|-n|--session-id|--from-pr|--max-turns|--max-budget-usd|--allowedTools|--disallowedTools|--tools|--agent|--debug|--channels|--json-schema|--permission-prompt-tool|--remote|--remote-control-session-name-prefix)$' {
+            return @()
+        }
+    }
+
+    # ---- Subcommand-specific dispatch ----
+    switch ($subcommand) {
+        'auth' {
+            $authSub = $null
+            for ($i = 1; $i -lt $tokenCount; $i++) {
+                if ($authSubs -contains $elements[$i]) { $authSub = $elements[$i]; break }
+            }
+            if (-not $authSub) {
+                return Complete-FromList $authSubs $wordToComplete
+            } else {
+                return Complete-FromList @('--email','--sso','--console','--text') $wordToComplete
+            }
+        }
+        'auto-mode' {
+            return Complete-FromList $autoModeSubs $wordToComplete
+        }
+        'mcp' {
+            $mcpSub = $null
+            for ($i = 1; $i -lt $tokenCount; $i++) {
+                if ($mcpSubs -contains $elements[$i]) { $mcpSub = $elements[$i]; break }
+            }
+            if (-not $mcpSub) {
+                return Complete-FromList $mcpSubs $wordToComplete
+            }
+            return @()
+        }
+        { $_ -in 'plugin','plugins' } {
+            $plugSub = $null
+            for ($i = 1; $i -lt $tokenCount; $i++) {
+                if ($pluginSubs -contains $elements[$i]) { $plugSub = $elements[$i]; break }
+            }
+            if (-not $plugSub) {
+                return Complete-FromList $pluginSubs $wordToComplete
+            }
+            return @()
+        }
+        'install' {
+            if (-not $wordToComplete.StartsWith('-')) {
+                return Complete-FromList $installVersions $wordToComplete
+            }
+            return @()
+        }
+        'ultrareview' {
+            if ($wordToComplete.StartsWith('-')) {
+                return Complete-FromList @('--json','--timeout') $wordToComplete
+            }
+            return @()
+        }
+        'remote-control' {
+            if ($wordToComplete.StartsWith('-')) {
+                return Complete-FromList (@('--name','--remote-control-session-name-prefix') + $globalFlags) $wordToComplete
+            }
+            return @()
+        }
+        { $_ -in 'update','agents','setup-token' } {
+            if ($wordToComplete.StartsWith('-')) {
+                return Complete-FromList $globalFlags $wordToComplete
+            }
+            return @()
+        }
+    }
+
+    # ---- No subcommand: complete subcommands or flags ----
+    if ($wordToComplete.StartsWith('-')) {
+        return Complete-FromList $globalFlags $wordToComplete
+    }
+    if ($tokenCount -le 2) {
+        return Complete-FromList $subcommands $wordToComplete
+    }
+    return @()
+}

--- a/claude_auto_completion/Windows/install-claude-completion.ps1
+++ b/claude_auto_completion/Windows/install-claude-completion.ps1
@@ -1,0 +1,71 @@
+# install-claude-completion.ps1
+# Installs the claude CLI argument completer into the current user's PowerShell profile.
+#
+# Usage:
+#   . .\install-claude-completion.ps1
+#
+# Or with -Force to overwrite an existing copy:
+#   . .\install-claude-completion.ps1 -Force
+
+[CmdletBinding()]
+param(
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$source    = Join-Path $scriptDir 'claude-completion.ps1'
+
+if (-not (Test-Path -LiteralPath $source)) {
+    Write-Error "claude-completion.ps1 not found next to installer ($source)"
+    return
+}
+
+# Destination: per-user, alongside the profile so it's portable across hosts.
+$destDir  = Join-Path (Split-Path -Parent $PROFILE.CurrentUserAllHosts) 'completions'
+$destFile = Join-Path $destDir 'claude-completion.ps1'
+
+if (-not (Test-Path -LiteralPath $destDir)) {
+    New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+}
+
+if ((Test-Path -LiteralPath $destFile) -and -not $Force) {
+    Write-Host "Updating existing: $destFile"
+} else {
+    Write-Host "Installing to: $destFile"
+}
+Copy-Item -LiteralPath $source -Destination $destFile -Force
+
+# Use CurrentUserAllHosts so it loads in pwsh, ISE, VSCode, etc.
+$profilePath = $PROFILE.CurrentUserAllHosts
+$profileDir  = Split-Path -Parent $profilePath
+if (-not (Test-Path -LiteralPath $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+}
+if (-not (Test-Path -LiteralPath $profilePath)) {
+    New-Item -ItemType File -Path $profilePath -Force | Out-Null
+}
+
+$loaderLine = ". `"$destFile`""
+$marker     = '# >>> claude-completion >>>'
+$endMarker  = '# <<< claude-completion <<<'
+
+$existing = Get-Content -LiteralPath $profilePath -Raw -ErrorAction SilentlyContinue
+if ($existing -and $existing.Contains($marker)) {
+    Write-Host "Profile already loads claude-completion: $profilePath"
+} else {
+    $block = @"
+
+$marker
+if (Test-Path '$destFile') { . '$destFile' }
+$endMarker
+"@
+    Add-Content -LiteralPath $profilePath -Value $block
+    Write-Host "Added loader to: $profilePath"
+}
+
+# Load it into the current session immediately
+. $destFile
+Write-Host ""
+Write-Host "Activated for this session. Try:  claude --<TAB>"


### PR DESCRIPTION
## Summary
- Brings the **shell completion scripts for the `claude` CLI** under version control at their final path (`claude_auto_completion/`). They were created in earlier commits, then a "Moved completion scripts to their own dir" commit deleted them at the old path without re-adding them at the new one — so they were sitting on disk untracked.
- Adds `claude_auto_completion/README.md` with full per-OS install / activate / uninstall / troubleshooting instructions.
- Adds an "Extras" pointer in the main `README.md` so people can find the feature without spelunking.
- Independent of the playbook — opt-in. Nothing else in the repo depends on these scripts.

## Coverage
| Platform | Files |
|---|---|
| Linux / macOS / WSL (bash) | `claude-completion.bash`, `claude-autocomplete.sh` (per-user or `--system`) |
| Windows (PowerShell 5.1 / 7+) | `claude-completion.ps1`, `install-claude-completion.ps1` (CurrentUserAllHosts profile) |

Both scripts cover the same surface area: subcommands (`auth`, `mcp`, `plugin`, `ultrareview`, …), all top-level flags, and enum value completion for `--model`, `--permission-mode`, `--effort`, `--output-format`, `--input-format`, `--teammate-mode`, `--setting-sources`. Directory completion for `--add-dir` / `--plugin-dir` / `--worktree`, file completion for `--settings` / `--mcp-config` / `--system-prompt-file` etc.

## Test plan
- [x] Markdown renders cleanly on GitHub (preview)
- [ ] `./claude_auto_completion/Linux/claude-autocomplete.sh` per-user install on a fresh shell, then `claude --<TAB>` expands flags
- [ ] `./claude_auto_completion/Linux/claude-autocomplete.sh --system` (root) installs to `/etc/bash_completion.d/claude` and works for a second user
- [ ] `. .\claude_auto_completion\Windows\install-claude-completion.ps1` on PowerShell 7+ installs the loader and `claude --<TAB>` expands in a fresh session
- [ ] Re-running the PowerShell installer is idempotent (marker block not duplicated in `$PROFILE.CurrentUserAllHosts`)
- [ ] Uninstall snippet in the README cleanly removes the loader block

## Notes
- This PR does **not** touch the playbook installer or the JIT block logic — it only adds a sibling extras directory and a doc pointer.
- If a future Claude Code release adds new subcommands or flags, update the static arrays at the top of `claude-completion.bash` and `claude-completion.ps1` to keep the catalog in sync with <https://code.claude.com/docs/en/cli-reference>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)