### PR TITLE
chore: ignore .deb / .rpm build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,10 @@ Desktop.ini
 *.tmp
 *.bak
 
-# Release build output (produced by build-release.ps1)
+# Release build output (produced by build-release.ps1 / build-release.sh)
 dist/
+*.deb
+*.rpm
 
 # Git worktrees
 .worktrees/


### PR DESCRIPTION
## Summary
- `build-release.sh` produces `.deb` and `.rpm` packages via `fpm`. Existing `dist/` rule covers the ZIP / staging tree, but a manual `fpm` run at the repo root drops files like `ccds_0.6.0_all.deb` directly there.
- Adds `*.deb` and `*.rpm` to `.gitignore` so build artifacts don't pollute `git status`.

## Test plan
- [x] `git check-ignore -v ccds_0.6.0_all.deb` reports `.gitignore:22:*.deb`
- [x] `git status` no longer lists existing .deb / .rpm as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)