### PR TITLE
ci: allow claude[bot] to trigger Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,10 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Allow runs initiated by claude[bot] (e.g. when an in-PR fix is pushed
+          # by the bot and triggers `synchronize`). Without this the action errors
+          # with: "Workflow initiated by non-human actor: claude (type: Bot)".
+          allowed_bots: 'claude[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` rejects bot-initiated runs by default. When `claude[bot]` pushes a fix into a PR (e.g. the ShellCheck remediation on PR #5), the resulting `synchronize` event re-runs the review workflow and fails with:
  ```
  Workflow initiated by non-human actor: claude (type: Bot).
  Add bot to allowed_bots list or use '*' to allow all bots.
  ```
- Whitelisting exactly `claude[bot]` (not `*`) keeps the trust surface narrow — only the bot we intentionally let push code can also trigger reviews.
- `claude.yml` is left untouched; it only fires on `@claude` mentions in comments/issues/reviews, which can't be authored by `claude[bot]` in the first place.

## Test plan
- [ ] After merge, push a noop commit on PR #5 (or rebase it onto main) and confirm `claude-review` runs through to completion instead of erroring out.

## Notes
This unblocks PR #5 (`docs/claude-cli-completion-extras`), which currently has a red `claude-review` check from this exact failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)