### PR TITLE
chore(ci): render install body from template + pin LF on jit-claude.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,12 @@
 *.md text
 *.json text
 
+# The JIT block injected into ~/.claude/CLAUDE.md must always be LF — the
+# bash installer's awk-based marker matcher is CR-tolerant since v0.6.1, but
+# planting CRLF in users' CLAUDE.md leaves a mixed-ending file and trips
+# any third-party tool that assumes a single line terminator.
+scripts/jit-claude.md text eol=lf
+
 # Binary defensive markers (no binaries currently in repo).
 *.png binary
 *.jpg binary

--- a/.github/release-body.md.tmpl
+++ b/.github/release-body.md.tmpl
@@ -1,0 +1,68 @@
+## Install
+
+### Linux — Debian / Ubuntu (`.deb`)
+
+```bash
+curl -fsSLO https://github.com/__REPO__/releases/download/__VERSION__/ccds___VERSION_BARE___all.deb
+sudo dpkg -i ccds___VERSION_BARE___all.deb
+ccds verify
+```
+
+### Linux — Fedora / RHEL / openSUSE (`.rpm`)
+
+```bash
+curl -fsSLO https://github.com/__REPO__/releases/download/__VERSION__/ccds-__VERSION_BARE__-1.noarch.rpm
+sudo rpm -i ccds-__VERSION_BARE__-1.noarch.rpm   # or: sudo dnf install ./ccds-__VERSION_BARE__-1.noarch.rpm
+ccds verify
+```
+
+### Windows — PowerShell 5.1 or 7+ (online installer)
+
+```powershell
+iwr -UseBasicParsing https://raw.githubusercontent.com/__REPO__/main/Install-Playbook.ps1 | iex
+```
+
+Pin this release: append `-Version __VERSION__`. Default prefix: `%USERPROFILE%\.claude\playbook`.
+
+### Linux / macOS — bash (online installer)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/__REPO__/main/install-playbook.sh | bash
+```
+
+Pin this release: append `-s -- --version __VERSION__`. Default prefix: `$HOME/.claude/playbook`.
+
+### Manual ZIP install
+
+Download `ccds-__VERSION__.zip` and `ccds-__VERSION__.zip.sha256`, then:
+
+```powershell
+Install-Playbook.ps1 -LocalZip .\ccds-__VERSION__.zip      # Windows
+```
+
+```bash
+./install-playbook.sh --local-zip ./ccds-__VERSION__.zip   # Linux/macOS
+```
+
+The installer verifies the ZIP against the sidecar SHA256 before staging.
+
+## Update / uninstall
+
+```bash
+ccds update                  # latest stable
+ccds update __VERSION__           # pin a tag
+ccds update --rollback       # restore previous install
+ccds uninstall
+```
+
+## Verify the download
+
+```bash
+sha256sum -c ccds-__VERSION__.zip.sha256
+# Or compare against the asset digests:
+# .deb  __DEB_SHA__
+# .rpm  __RPM_SHA__
+# .zip  __ZIP_SHA__
+```
+
+---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-zip, build-packages]
     steps:
+      - name: Checkout (for release body template)
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/release-body.md.tmpl
+          sparse-checkout-cone-mode: false
+
       - name: Download ZIP artifacts
         uses: actions/download-artifact@v4
         with:
@@ -123,12 +130,48 @@ jobs:
       - name: List release artifacts
         run: ls -lh dist/
 
+      - name: Render release body from template
+        id: body
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.build-zip.outputs.version }}"
+          VERSION_BARE="${VERSION#v}"
+          DEB="dist/ccds_${VERSION_BARE}_all.deb"
+          RPM="dist/ccds-${VERSION_BARE}-1.noarch.rpm"
+          ZIP="dist/ccds-${VERSION}.zip"
+          for f in "$DEB" "$RPM" "$ZIP"; do
+            [[ -f "$f" ]] || { echo "Asset missing: $f" >&2; exit 1; }
+          done
+          DEB_SHA=$(sha256sum "$DEB" | awk '{print $1}')
+          RPM_SHA=$(sha256sum "$RPM" | awk '{print $1}')
+          ZIP_SHA=$(sha256sum "$ZIP" | awk '{print $1}')
+          REPO_ESCAPED="${{ github.repository }}"
+          cp .github/release-body.md.tmpl release-body.md
+          sed -i \
+            -e "s|__VERSION__|${VERSION}|g" \
+            -e "s|__VERSION_BARE__|${VERSION_BARE}|g" \
+            -e "s|__REPO__|${REPO_ESCAPED}|g" \
+            -e "s|__DEB_SHA__|${DEB_SHA}|g" \
+            -e "s|__RPM_SHA__|${RPM_SHA}|g" \
+            -e "s|__ZIP_SHA__|${ZIP_SHA}|g" \
+            release-body.md
+          # Sanity: every placeholder must be resolved.
+          if grep -nE '__[A-Z_]+__' release-body.md; then
+            echo "Unresolved placeholders in release-body.md" >&2
+            exit 1
+          fi
+          echo "--- rendered release body ---"
+          cat release-body.md
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name:               ${{ needs.build-zip.outputs.version }}
           name:                   ${{ needs.build-zip.outputs.version }}
           prerelease:             ${{ needs.build-zip.outputs.prerelease }}
+          # body_path is prepended to the auto-generated "What's Changed" section.
+          body_path:              release-body.md
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |


### PR DESCRIPTION
## Summary
Two release-pipeline gaps surfaced when cutting `v0.6.1`:

1. **`release.yml` only auto-generates the "What's Changed" PR list.** The rich install-instructions block on `v0.5.0` / `v0.6.0` was applied by hand after publish, and that step was forgotten on `v0.6.1` (the body had to be patched after the fact). Every future release would have the same gap.
2. **The Windows ZIP build was bundling `scripts/jit-claude.md` with CRLF line terminators.** `actions/checkout@v5` on `windows-latest` defaults to `core.autocrlf=true`. The bash installer's marker matcher is CR-tolerant since `v0.6.1`, but every ZIP install kept planting mixed-ending content into users' `CLAUDE.md` — the same root cause as issue #2.

## Changes

- **`.github/release-body.md.tmpl`** — versioned install / verify / update body. Uses `__VERSION__`, `__VERSION_BARE__`, `__REPO__`, `__DEB_SHA__`, `__RPM_SHA__`, `__ZIP_SHA__` placeholders so the rendering step doesn't have to know the asset naming convention.
- **`.github/workflows/release.yml`** — new "Render release body from template" step in the publish job:
  - Sparse-checks the template (1 file)
  - Computes SHA256 of each staged artifact
  - `sed`-substitutes the placeholders
  - Fails the build if any `__PLACEHOLDER__` survives
  - Passes `body_path: release-body.md` to `softprops/action-gh-release@v2`; the action concatenates the auto "What's Changed" PR list below it
- **`.gitattributes`** — `scripts/jit-claude.md text eol=lf` forces LF on every checkout, including Windows runners. The blob was already LF in the index; this just keeps it that way through Windows' `core.autocrlf`.

## Test plan
- [x] Smoke-tested the `sed` substitution locally against the actual `v0.6.1` asset SHA256s — all placeholders resolved
- [x] `.gitattributes` change verified with `git ls-files --eol scripts/jit-claude.md` → `i/lf w/lf attr/text eol=lf`
- [x] Workflow YAML manually inspected (no yamllint locally)
- [ ] **End-to-end verification only fires on next tag push.** Suggest cutting `v0.6.2` (or any patch tag) immediately after merge and confirming:
  - The release body opens with the "Install" section (not just "What's Changed")
  - Asset SHA256 lines match what's printed by `sha256sum` on the published artifacts
  - `unzip -p ccds-v*.zip scripts/jit-claude.md | file -` reports `ASCII text` (LF) rather than `ASCII text, with CRLF line terminators`

## Notes
This PR doesn't retroactively fix `v0.6.1` — the existing release page is already patched by hand. It just prevents the same drift from recurring on `v0.6.2`+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)