### PR TITLE
fix(deb/rpm): reliably run per-user setup in postinst

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ Default prefix: `$HOME/.claude/playbook`. Override with `--prefix`, pin a versio
 
 Both installers accept `--dry-run` / `-DryRun`, `--local-zip <path>` / `-LocalZip <path>` (install from a locally built ZIP), and `--token` / `-Token` (GitHub token for rate-limited or private-repo environments).
 
+**Linux native packages (`.deb` / `.rpm`):**
+
+Each release also ships a `.deb` (Debian/Ubuntu) and `.rpm` (RHEL/Fedora) attached to the GitHub Release.
+
+```bash
+sudo apt install ./ccds_<version>_all.deb     # Debian/Ubuntu
+sudo dnf install ./ccds-<version>-1.noarch.rpm # RHEL/Fedora
+```
+
+The package installs the shared library to `/usr/share/ccds` and the `ccds` launcher to `/usr/bin/ccds`. Because the agents/skills/`CLAUDE.md` block are **per-user** (they live under `~/.claude/`), per-user setup runs for the installing user automatically when the package can identify them (`sudo`, polkit/GUI installers, or a login terminal).
+
+If you install from a bare root shell or a headless/CI/Docker context, the package cannot tell which user to set up — run setup yourself once per user:
+
+```bash
+ccds setup          # copies the 19 agents + cross-cutting skills, injects the CLAUDE.md block
+```
+
+Setup also runs automatically the first time that user runs `ccds sync <packs>` or `ccds verify`. Updates and removal go through the system package manager (`apt`/`dnf`); `ccds update` and `ccds uninstall` are no-ops for package installs and print the right command.
+
 ## Update / rollback / uninstall
 
 Once installed, the dispatcher delegates these to a fresh copy of the installer fetched from `main`, so bug fixes to the installer propagate automatically.

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,8 +1,16 @@
 #!/bin/bash
 # postinst -- ccds Debian/RPM post-install script
-# Runs as root. Per-user setup (the 19 always-on agents + cross-cutting skills +
-# CLAUDE.md block) is handled lazily by 'ccds setup' or on first 'ccds sync/verify'.
-# If SUDO_USER is set (interactive sudo install), we run setup for that user now.
+# Runs as root. The package only installs the *system* library to
+# /usr/share/ccds and the 'ccds' launcher to /usr/bin. The per-user payload
+# (the 19 always-on agents + cross-cutting skills + the ~/.claude/CLAUDE.md
+# block) lives under each user's $HOME, so it is set up per-user.
+#
+# We try to run that per-user setup automatically for the human who triggered
+# the install. dpkg/apt run maintainer scripts as root and DO NOT reliably set
+# $SUDO_USER (it is empty for root shells, `sudo -i`, gdebi/GUI installers,
+# Docker/CI, unattended-upgrades), so we probe several sources. If we still
+# cannot identify a human user, we print clear instructions -- and the ccds
+# dispatcher also runs setup lazily on first use as a safety net.
 
 set -e
 
@@ -16,16 +24,57 @@ chmod 755 "$INSTALL_ROOT/bin/ccds.sh"   2>/dev/null || true
 # Agents and data files: world-readable (644)
 chmod -R a+rX "$INSTALL_ROOT"           2>/dev/null || true
 
-# If installed interactively via sudo, set up for the calling user immediately.
-if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
-    echo "==> Running per-user setup for $SUDO_USER..."
-    su - "$SUDO_USER" -c "bash '$SETUP_SCRIPT' '$INSTALL_ROOT'" || true
-else
+print_manual_instructions() {
     echo ""
     echo "ccds installed to $INSTALL_ROOT"
     echo ""
-    echo "Run the following once to set up your Claude Code environment:"
+    echo "Per-user setup did not run automatically. Each user runs once:"
     echo "  ccds setup"
     echo ""
-    echo "Or just run 'ccds sync <packs>' — setup runs automatically on first use."
+    echo "(Setup also runs automatically the first time you 'ccds sync <packs>'.)"
+}
+
+# ---------------------------------------------------------------------------
+# Identify the human user to set up for. dpkg runs us as root, so we must
+# discover the *invoking* user. Probe, in order of reliability:
+#   1. SUDO_USER  -- set by `sudo apt install ./ccds.deb` / `sudo dpkg -i`
+#   2. PKEXEC_UID -- set by polkit-based GUI installers
+#   3. logname    -- the login name on the controlling terminal
+# Reject root / empty -- root has no ~/.claude worth populating here.
+# ---------------------------------------------------------------------------
+TARGET_USER=""
+for candidate in \
+    "${SUDO_USER:-}" \
+    "$( [[ -n "${PKEXEC_UID:-}" ]] && getent passwd "$PKEXEC_UID" 2>/dev/null | cut -d: -f1 )" \
+    "$(logname 2>/dev/null || true)"
+do
+    if [[ -n "$candidate" && "$candidate" != "root" ]] && getent passwd "$candidate" >/dev/null 2>&1; then
+        TARGET_USER="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$TARGET_USER" ]]; then
+    print_manual_instructions
+    exit 0
 fi
+
+echo "==> Running per-user setup for $TARGET_USER..."
+
+# runuser (util-linux) drops privileges without PAM auth and without a login
+# shell -- the correct tool for maintainer scripts. Fall back to `su -` where
+# runuser is unavailable. We deliberately do NOT mask the exit status: a failed
+# setup must be visible, not silently reported as a successful install.
+rc=0
+if command -v runuser >/dev/null 2>&1; then
+    runuser -u "$TARGET_USER" -- bash "$SETUP_SCRIPT" "$INSTALL_ROOT" || rc=$?
+else
+    su - "$TARGET_USER" -c "bash '$SETUP_SCRIPT' '$INSTALL_ROOT'" || rc=$?
+fi
+
+if (( rc != 0 )); then
+    echo "WARN: per-user setup for $TARGET_USER exited with status $rc." >&2
+    print_manual_instructions
+fi
+
+exit 0

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -10,6 +10,7 @@ CLI tools, so the tests exercise them exactly the way CI and users do.
 Run: python3 -m unittest discover -s tests -v
 """
 
+import getpass
 import json
 import os
 import shutil
@@ -212,6 +213,120 @@ class TestBuildMarketplace(unittest.TestCase):
             # restore the checked-in (unversioned) tree
             subprocess.run(["git", "-C", REPO_ROOT, "checkout", "--", ".claude-plugin", "plugins"],
                            capture_output=True)
+
+
+PACKAGING = os.path.join(REPO_ROOT, "packaging")
+POSTINST = os.path.join(PACKAGING, "postinst")
+USER_SETUP = os.path.join(SCRIPTS, "ccds-user-setup.sh")
+BASH = shutil.which("bash")
+
+# Cross-cutting skills the per-user setup installs to ~/.claude/skills/.
+# Mirrors GLOBAL_SKILLS in scripts/ccds-user-setup.sh.
+GLOBAL_SKILLS = (
+    "playbook-conventions", "sync-agents", "api-design", "ux-design",
+    "security-checklist", "code-review-checklist", "common-a11y",
+    "common-i18n", "common-privacy", "common-notifications",
+    "common-product-analytics",
+)
+
+
+@unittest.skipUnless(BASH and sys.platform != "win32",
+                     "postinst is a bash maintainer script (POSIX shells only)")
+class TestDebPostinst(unittest.TestCase):
+    """Regression tests for the Debian/RPM postinst per-user setup.
+
+    Stages the package library exactly as build-release.sh does
+    (/usr/share/ccds layout), then drives packaging/postinst against it with
+    a patched INSTALL_ROOT and PATH stubs for the privilege-drop tools — so
+    the test never needs root and never touches the real $HOME.
+
+    Guards the bug where the postinst only populated ~/.claude when $SUDO_USER
+    was set, silently installing nothing for root-shell / GUI / CI / Docker
+    installs.
+    """
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="ccds-deb-test-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+        # Stage the package library: /usr/share/ccds/{agents,skills,scripts}
+        self.pkg = os.path.join(self.root, "usr", "share", "ccds")
+        os.makedirs(os.path.join(self.pkg, "agents"))
+        os.makedirs(os.path.join(self.pkg, "scripts"))
+        for md in os.listdir(os.path.join(REPO_ROOT, ".claude", "agents")):
+            if md.endswith(".md"):
+                shutil.copy(os.path.join(REPO_ROOT, ".claude", "agents", md),
+                            os.path.join(self.pkg, "agents", md))
+        shutil.copytree(os.path.join(REPO_ROOT, "skills"),
+                        os.path.join(self.pkg, "skills"))
+        shutil.copy(USER_SETUP, os.path.join(self.pkg, "scripts", "ccds-user-setup.sh"))
+        shutil.copy(os.path.join(SCRIPTS, "jit-claude.md"),
+                    os.path.join(self.pkg, "scripts", "jit-claude.md"))
+
+        # postinst hardcodes INSTALL_ROOT=/usr/share/ccds; point it at our stage.
+        with open(POSTINST, encoding="utf-8") as f:
+            src = f.read()
+        patched = src.replace('INSTALL_ROOT="/usr/share/ccds"',
+                              'INSTALL_ROOT="%s"' % self.pkg)
+        self.assertIn('INSTALL_ROOT="%s"' % self.pkg, patched,
+                      "postinst INSTALL_ROOT assignment changed shape")
+        self.postinst = os.path.join(self.root, "postinst")
+        with open(self.postinst, "w", encoding="utf-8", newline="\n") as f:
+            f.write(patched)
+
+        self.home = os.path.join(self.root, "home")
+        os.makedirs(self.home)
+        self.stubbin = os.path.join(self.root, "stubbin")
+        os.makedirs(self.stubbin)
+
+    def _stub(self, name, body):
+        path = os.path.join(self.stubbin, name)
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write("#!/bin/bash\n" + body + "\n")
+        os.chmod(path, 0o755)
+
+    def _run(self, env_overrides):
+        env = {"HOME": self.home, "PATH": self.stubbin + os.pathsep + os.environ["PATH"]}
+        env.update(env_overrides)
+        return subprocess.run([BASH, self.postinst],
+                              capture_output=True, text=True, env=env)
+
+    def test_syntax_valid(self):
+        r = subprocess.run([BASH, "-n", POSTINST], capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_identifiable_user_populates_home(self):
+        # runuser stub: "runuser -u USER -- bash SETUP ROOT" -> drop first 3 args,
+        # exec the rest in-process so setup runs against our fake $HOME.
+        self._stub("runuser", 'shift 3\nexec "$@"')
+        # Use the real current user so the postinst's `getent passwd` probe accepts
+        # the candidate; the runuser stub keeps execution in-process (no real drop).
+        r = self._run({"SUDO_USER": getpass.getuser()})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("Running per-user setup", r.stdout)
+
+        agents = os.path.join(self.home, ".claude", "agents")
+        self.assertTrue(os.path.isdir(agents), r.stdout + r.stderr)
+        self.assertEqual(len([f for f in os.listdir(agents) if f.endswith(".md")]), 19)
+
+        skills = os.path.join(self.home, ".claude", "skills")
+        for name in GLOBAL_SKILLS:
+            self.assertTrue(os.path.isfile(os.path.join(skills, name, "SKILL.md")),
+                            "missing cross-cutting skill: " + name)
+
+        claude_md = read(os.path.join(self.home, ".claude", "CLAUDE.md"))
+        self.assertIn("# >>> ccds >>>", claude_md)
+        self.assertIn("# <<< ccds <<<", claude_md)
+
+    def test_headless_root_prints_instructions_and_no_op(self):
+        # No identifiable user: SUDO_USER/PKEXEC_UID unset, logname fails.
+        self._stub("logname", "exit 1")
+        r = self._run({})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("ccds setup", r.stdout)
+        # The bug under test: nothing must be silently half-installed, but also
+        # the install must not error out — ~/.claude stays untouched here.
+        self.assertFalse(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The `.deb`/`.rpm` `postinst` only copied the 19 agents, cross-cutting skills, and the `~/.claude/CLAUDE.md` block when `$SUDO_USER` was set. For root-shell, `sudo -i`, `gdebi`/GUI, Docker/CI, and unattended-upgrades installs that variable is empty, so the package **silently installed nothing into `~/.claude`** — i.e. "the deb install does not actually install the agents and skills". Even when `$SUDO_USER` was set, `su - … || true` swallowed any failure, so a broken setup still reported success. The `.deb`/`.rpm` path was also undocumented in the README despite every release shipping both.

Reproduced with `fakeroot dpkg-deb`: `SUDO_USER`-unset install → empty `~/.claude`.

## Fix

`packaging/postinst` now:
- probes `SUDO_USER` → `PKEXEC_UID` (polkit/GUI) → `logname` (login terminal) to identify the human user, validating each candidate against `passwd`;
- drops privileges with `runuser` (no PAM/login shell), falling back to `su -`;
- surfaces a non-zero setup exit instead of masking it with `|| true`;
- prints clear `ccds setup` instructions when no user can be identified (truly headless installs) — where the dispatcher's existing lazy first-run on `ccds sync`/`verify` remains the safety net.

Plus:
- **README**: documents the `.deb`/`.rpm` install workflow and the per-user setup behavior.
- **tests**: `TestDebPostinst` stages the package library (`/usr/share/ccds` layout) and drives the real `postinst` for both the identifiable-user path (asserts 19 agents + 11 cross-cutting skills + CLAUDE.md block land in a fake `$HOME`) and the headless path (instructions + exit 0, nothing copied), using PATH stubs for `runuser`/`logname` so it needs no root.

## Verification

- Full `unittest` suite green (15 tests, incl. 3 new).
- `bash -n` clean on `postinst`; real `.deb` builds and `dpkg-deb` confirms the maintainer scripts are packaged.
- The per-user setup script itself was already correct and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)