### PR TITLE
release: v0.9.1 — fix .deb/.rpm per-user setup

### DIFF
--- a/.github/release-body.md.tmpl
+++ b/.github/release-body.md.tmpl
@@ -16,6 +16,8 @@ sudo rpm -i ccds-__VERSION_BARE__-1.noarch.rpm   # or: sudo dnf install ./ccds-_
 ccds verify
 ```
 
+> The package installs the shared library to `/usr/share/ccds` and the `ccds` launcher to `/usr/bin`. Per-user setup (the 19 agents + cross-cutting skills + `~/.claude/CLAUDE.md` block) runs automatically for the installing user. If you install from a bare root shell or a headless/CI/Docker context, run `ccds setup` once per user (it also runs automatically on first `ccds sync`).
+
 ### Windows — PowerShell 5.1 or 7+ (online installer)
 
 ```powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## v0.9.1 — 2026-06-16 — Fix: `.deb`/`.rpm` per-user setup
+
+### What changed
+
+Patch release fixing the Linux native packages (PR #17). The v0.9.0 (and earlier) `.deb`/`.rpm` only copied the 19 agents, cross-cutting skills, and the `~/.claude/CLAUDE.md` block when `$SUDO_USER` was set. Installing from a root shell, `sudo -i`, `gdebi`/GUI installers, Docker/CI, or unattended-upgrades left that variable empty, so the package **silently installed nothing into `~/.claude`** — the package looked installed (`ccds` on `PATH`) but Claude Code saw no agents or skills. Even when `$SUDO_USER` was set, `su - … || true` swallowed any failure, so a broken setup still reported success.
+
+### Fixes
+
+- `packaging/postinst` now probes `SUDO_USER` → `PKEXEC_UID` (polkit/GUI installers) → `logname` (login terminal) to identify the human user, validating each candidate against `passwd`; drops privileges with `runuser` (no PAM/login shell), falling back to `su -`; and **surfaces a non-zero setup exit instead of masking it**. When no user can be identified (truly headless installs) it prints clear `ccds setup` instructions — and the dispatcher's lazy first-run on `ccds sync`/`verify` remains the safety net.
+- `README.md` documents the `.deb`/`.rpm` install workflow and the per-user setup behavior (previously absent despite every release shipping both packages).
+- `tests/test_playbook_scripts.py` adds `TestDebPostinst` (3 tests, 15 total): stages the package library and drives the real `postinst` for both the identifiable-user path (asserts 19 agents + 11 cross-cutting skills + the `CLAUDE.md` block land in a fake `$HOME`) and the headless path (instructions + exit 0, nothing copied), using `PATH` stubs so it needs no root.
+
+No agent, skill, catalog, or marketplace content changed; this release is packaging-only. The ZIP installer and the plugin-marketplace channel were unaffected by the bug.
+
 ## v0.9.0 — 2026-06-12 — Native plugin marketplace, skill-voice rewrite, lint + tests
 
 ### What changed


### PR DESCRIPTION
Docs + release prep for **v0.9.1**, a packaging-only patch that fixes the `.deb`/`.rpm` per-user setup landed in #17.

- **CHANGELOG.md** — adds the v0.9.1 entry (postinst probes `SUDO_USER`→`PKEXEC_UID`→`logname`, uses `runuser`, surfaces failures; README + tests).
- **`.github/release-body.md.tmpl`** — notes that the package runs per-user setup automatically and that headless/root/CI installs run `ccds setup` once.

After merge, tagging `v0.9.1` triggers the release workflow to build and publish the fixed `.deb`/`.rpm`/ZIP. No agent/skill/catalog/marketplace content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)