### PR TITLE
fix(jit): warn against editing inside the ccds-managed CLAUDE.md block

### DIFF
--- a/scripts/jit-claude.md
+++ b/scripts/jit-claude.md
@@ -1,5 +1,8 @@
 # >>> ccds >>>
-# Managed by Claude Code Dev Studio. Edit via: ccds sync. Remove via: ccds uninstall
+# ⚠ ccds-managed block — do NOT edit between these markers. Everything here is
+# regenerated (your edits overwritten) on `ccds sync`/`ccds setup`. Put your own
+# instructions ABOVE or BELOW this block; that text is always preserved.
+# Update: ccds sync · Remove: ccds uninstall
 
 ## Claude Code Dev Studio
 


### PR DESCRIPTION
## What
Reword the ccds-managed block header injected into `~/.claude/CLAUDE.md` so it
explicitly warns against editing **between** the markers, and points users to
put their own instructions above or below the block.

## Why
The old header — "Edit via: ccds sync" — read as an invitation to add personal
notes inside the markers. Everything between `# >>> ccds >>>` and `# <<< ccds <<<`
is regenerated on every `ccds sync` / `ccds setup`, so those edits were silently
overwritten. Content outside the markers is always preserved (verified across all
shipped versions of `scripts/ccds-user-setup.sh`), so this was a UX footgun, not
data loss in the injection logic.

## Change
- `scripts/jit-claude.md`: new multi-line header — "do NOT edit between these
  markers … put your own instructions ABOVE or BELOW this block."

## Verification
- All 15 tests in `tests/test_playbook_scripts.py` pass.
- Confirmed empirically that user content above the markers survives the
  strip-and-reinject round-trip.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
