### PR TITLE
ci(release): bump artifact/release actions off deprecated Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           Write-Host "SHA256    : $actual"
 
       - name: Upload ZIP artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zip-artifacts
           path: |
@@ -93,7 +93,7 @@ jobs:
           echo "RPM: $(du -h "$RPM" | cut -f1)  $RPM"
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pkg-artifacts
           path: |
@@ -116,13 +116,13 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Download ZIP artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: zip-artifacts
           path: dist/
 
       - name: Download package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pkg-artifacts
           path: dist/
@@ -165,7 +165,7 @@ jobs:
           cat release-body.md
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name:               ${{ needs.build-zip.outputs.version }}
           name:                   ${{ needs.build-zip.outputs.version }}


### PR DESCRIPTION
## What
Bump the `Release` workflow's pinned actions off the deprecated Node.js 20 runtime:

- `actions/upload-artifact@v4` → `@v7` (2 occurrences)
- `actions/download-artifact@v4` → `@v8` (2 occurrences)
- `softprops/action-gh-release@v2` → `@v3`

## Why
GitHub flagged these as Node 20 (force-run on Node 24) during the v0.9.2 release run.
See #22.

## Safety
Each target major declares `using: node24` and retains the inputs this workflow uses
(`name`/`path` for the artifact actions; `tag_name`, `name`, `prerelease`, `body_path`,
`generate_release_notes`, `fail_on_unmatched_files`, `files` for the release action) —
verified against each action's `action.yml` at the pinned major.

## Rollout
Workflow-only change; it takes effect on the next `v*` tag push. **No release now.**

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
