### PR TITLE
ci: bump checkout to v5 in claude workflows (off Node 20)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## What
Follow-up to #22 / #23. Bump `actions/checkout@v4` → `@v5` in:

- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

## Why
`checkout@v4` runs on the deprecated Node.js 20 runtime. `@v5` declares
`using: node24` (verified against its `action.yml`). `ci.yml` and `release.yml`
already use `@v5`, so the repo is now uniformly on one checkout major.

`anthropics/claude-code-action@v1` in these workflows is a `composite` action — no
Node runtime — so it's unaffected.

## Rollout
Workflow-only; effective the next time these workflows run. No release involved.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
