### PR TITLE
feat(lint): process-skill check — iron law, rationalizations, trigger descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ any coding project regardless of stack — the request they answer is "make the 
 - Both installers ship the pack always-on (`GLOBAL_SKILLS` /
   `$Script:GlobalSkills`); `build-catalog.py` scopes the `loop-` prefix global;
   `lint-playbook.py` recognizes the prefix; CLAUDE.md prefix registry updated.
+- `lint-playbook.py` check 9 (`process-skill`): every `loop-*` skill must carry a
+  trigger-style description, exactly one `## Iron law`, and a `## Rationalizations`
+  table — the authoring rules become errors the day they become rules (5 new pytest
+  cases).
 
 ---
 

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,46 +1,39 @@
-# DEMO — innovation/loop-skills-pack
+# DEMO — innovation/loop-lint (stacked on innovation/loop-skills-pack)
 
-Proposal #1 from `INNOVATIONS.md` (2026-07-03): the `loop-` pack — six transferable
-agent-loop process skills, integrated end-to-end into the library toolchain.
+Proposal #5 from `INNOVATIONS.md` (2026-07-03): the process-skill lint dimension —
+ADR-0010's authoring rules become CI-enforced errors the same day they become rules.
+
+This branch **stacks on `innovation/loop-skills-pack`** (it lints that branch's
+skills); merge the pack first, then this.
 
 ## What works
 
-- **Six new skills** in `skills/loop-*`: `loop-verify`, `loop-debug`, `loop-review`,
-  `loop-parallel`, `loop-long-horizon` (+ bundled `references/state-files.md`
-  templates), `loop-compound`. Each follows ADR-0009 voice plus the new process-skill
-  rules (trigger-style description, one iron law, rationalization table — documented in
-  `docs/skill-authoring.md`).
-- **Catalog**: `loop-` prefix is scope=global (regenerated `catalog.json`: 115 entries).
-- **Marketplace**: new skills-only `ccds-loops` plugin (16 plugins total), category
-  `workflow`, installable standalone.
-- **Installers**: both `ccds-user-setup.sh` and `Install-Playbook.ps1` ship the pack
-  always-on to `~/.claude/skills/`.
-- **Lint + docs**: prefix registry (`CLAUDE.md`, `lint-playbook.py`), ADR-0010,
-  changelog, README, `sync-agents` and the managed CLAUDE.md block all updated.
+- `lint-playbook.py` check 9 (`process-skill`), errors on any `loop-*` skill that:
+  - lacks a trigger-style description (`Use when/before/after …`),
+  - does not have exactly one `## Iron law` section ("two laws is zero laws"),
+  - is missing the `## Rationalizations` table.
+- Domain skills (`saas-*`, `common-*`, …) are untouched by the check.
+- All six shipped `loop-*` skills pass; 5 new fixture tests prove each failure mode
+  fires (missing law, missing table, non-trigger description) and that compliant /
+  non-loop skills pass.
 
 ## How to try it
 
 ```bash
-# structural + semantic verification (all pass on this branch)
-python3 scripts/lint-playbook.py        # 0 errors, 0 warnings
-python3 -m pytest tests/ -q             # 17 passed (2 new: loop scope, loops plugin)
-bash verify-agents.sh                   # PASS
+python3 scripts/lint-playbook.py   # PASS on this branch (0 errors)
+python3 -m pytest tests/ -q        # 22 passed (17 from the pack branch + 5 new)
 
-# install the pack locally via the marketplace
-#   /plugin marketplace add /mnt/d/coding-projects/claude-code-dev-studio
-#   /plugin install ccds-loops@ccds
-# then in any project, e.g.: "wire up an overnight run" → loop-long-horizon triggers
+# see it catch a violation:
+sed -i 's/^## Iron law$/## Iron laws/' skills/loop-verify/SKILL.md
+python3 scripts/lint-playbook.py   # ERROR [process-skill] … exactly one '## Iron law'
+git checkout -- skills/loop-verify/SKILL.md
 ```
 
 ## What's stubbed / not included
 
-- Nothing is stubbed; the pack is complete.
-- Follow-on proposals not on this branch: enforcement hooks for `ccds-loops`
-  (INNOVATIONS #2), `ccds loop init` scaffolder (#3 — separate branch
-  `innovation/loop-init-scaffolder`), compliance pressure-tests (#4), process-skill
-  lint dimension (#5).
+Nothing stubbed. Everything in the loop-skills-pack DEMO also applies here.
 
 ## Next increment
 
-Add `## Iron law` / rationalization-table lint checks (INNOVATIONS #5) so the
-process-skill rules can't drift, then the `ccds-loops` SessionStart hook (#2).
+Enforcement hooks for `ccds-loops` (INNOVATIONS #2) and release-time compliance
+pressure-tests (#4) — the behavioral complement to this structural check.

--- a/docs/skill-authoring.md
+++ b/docs/skill-authoring.md
@@ -89,6 +89,9 @@ The loop itself is the concrete artifact (rule 6 above): numbered steps an agent
 follow mechanically, with thresholds ("after 3 failed fixes", "two review rounds")
 rather than adverbs.
 
+All three rules are enforced as errors by `lint-playbook.py` (check 9,
+`process-skill`) — the same lint-as-ratchet treatment ADR-0009 gave the voice rules.
+
 ## Conversion status
 
 All 88 in-scope skills are converted (the two reference conversions

--- a/scripts/lint-playbook.py
+++ b/scripts/lint-playbook.py
@@ -23,6 +23,11 @@ This linter checks that what the files SAY is true:
   8. skill-voice       Skill bodies carry no agent-era language (persona,
                        ownership blocks, orchestrator choreography, per-skill
                        Output Format). See docs/skill-authoring.md.
+  9. process-skill     loop-* process skills carry the compliance layer:
+                       trigger-style description ("Use when/before/after ..."),
+                       exactly one '## Iron law' section, and a
+                       '## Rationalizations' table (ADR-0010,
+                       docs/skill-authoring.md "Process skills").
 
 Exit codes: 0 = pass (warnings allowed), 1 = one or more errors, 2 = config error.
 
@@ -182,6 +187,32 @@ def check_skill_voice():
                 err("skill-voice", f"skills/{d}: {label} — see docs/skill-authoring.md")
 
 
+# --- 9: process-skill layer (loop-* skills) -----------------------------------
+# Process skills encode work loops; the rules exist because wording is what
+# holds under pressure (docs/skill-authoring.md "Process skills", ADR-0010).
+PROCESS_PREFIX = "loop-"
+TRIGGER_RE = re.compile(r'\bUse (when|before|after|proactively)\b')
+
+
+def check_process_skills():
+    for d in skill_dirs():
+        if not d.startswith(PROCESS_PREFIX):
+            continue
+        content = read(os.path.join(SKILLS_DIR, d, "SKILL.md"))
+        fm = frontmatter(content)
+        desc = field(fm, "description") if fm else ""
+        if not TRIGGER_RE.search(desc):
+            err("process-skill",
+                f"skills/{d}: description is not trigger-style — needs a 'Use when/before/after …' clause")
+        body = re.sub(r'^---\s*\n.*?\n---', '', content, count=1, flags=re.DOTALL)
+        laws = len(re.findall(r'^## Iron law\s*$', body, re.MULTILINE))
+        if laws != 1:
+            err("process-skill",
+                f"skills/{d}: needs exactly one '## Iron law' section (found {laws}) — two laws is zero laws")
+        if not re.search(r'^## Rationalizations\s*$', body, re.MULTILINE):
+            err("process-skill", f"skills/{d}: missing the '## Rationalizations' table")
+
+
 # --- 5 + 6 + 7: descriptions and models --------------------------------------
 def check_descriptions_and_models():
     agent_desc_chars = 0
@@ -222,6 +253,7 @@ def main():
     check_catalog_fresh()
     check_urls()
     check_skill_voice()
+    check_process_skills()
     check_descriptions_and_models()
 
     for w in warnings:

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -190,6 +190,55 @@ class TestLintPlaybook(FixtureCase):
         self.assertEqual(r.returncode, 1)
         self.assertIn("model-values", r.stdout)
 
+    LOOP_SKILL_BODY = """## Iron law
+
+**No completion claim without fresh evidence.**
+
+## Rationalizations
+
+| Excuse | Reality |
+|---|---|
+| "It compiled" | Stubs compile |
+"""
+
+    def write_loop_skill(self, description, body=None):
+        write(os.path.join(self.root, "skills", "loop-verify", "SKILL.md"),
+              SKILL_TMPL.format(name="loop-verify", description=description,
+                                body=body if body is not None else self.LOOP_SKILL_BODY))
+        self.regen_catalog()
+
+    def test_compliant_process_skill_passes(self):
+        self.write_loop_skill("Evidence gate. Use before claiming any task complete.")
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+
+    def test_process_skill_missing_iron_law_fails(self):
+        self.write_loop_skill("Evidence gate. Use before claiming any task complete.",
+                              body="## Rationalizations\n\n| Excuse | Reality |\n|---|---|\n")
+        r = self.lint()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("process-skill", r.stdout)
+        self.assertIn("Iron law", r.stdout)
+
+    def test_process_skill_missing_rationalizations_fails(self):
+        self.write_loop_skill("Evidence gate. Use before claiming any task complete.",
+                              body="## Iron law\n\n**No claims without evidence.**\n")
+        r = self.lint()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("Rationalizations", r.stdout)
+
+    def test_process_skill_untriggered_description_fails(self):
+        self.write_loop_skill("Explains how to verify work with evidence.")
+        r = self.lint()
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("trigger-style", r.stdout)
+
+    def test_domain_skill_not_held_to_process_rules(self):
+        # saas-billing has no iron law / rationalization table — that's fine.
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertNotIn("process-skill", r.stdout)
+
 
 @unittest.skipUnless(os.path.isfile(BUILD_MARKETPLACE),
                      "build-marketplace.py not on this branch yet")


### PR DESCRIPTION
## Summary

Adds `lint-playbook.py` check 9 (`process-skill`): every `loop-*` skill must carry a trigger-style description ("Use when/before/after …"), exactly one `## Iron law` section, and a `## Rationalizations` table. ADR-0010's authoring rules become CI-enforced errors the same day they become rules — the lint-as-ratchet pattern from ADR-0009.

## What changed and why

- `scripts/lint-playbook.py`: new `check_process_skills()` (~25 lines). Headings are matched anchored (`^## Iron law\s*$`) — a `## Iron laws` typo does not sneak past (caught live during verification). Domain skills are exempt.
- `docs/skill-authoring.md`: notes the rules are enforced by check 9.
- 5 fixture tests covering each failure mode plus compliant/non-loop passes.

## Verification

`pytest`: 22 passed · `lint-playbook.py` on the real tree: PASS (all six shipped loop skills conform) · deliberately breaking a heading (`## Iron law` → `## Iron laws`) makes the check fire, then restore → PASS.

## Post-merge

None; stacks cleanly on #26 (rebased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)