### PR TITLE
feat(cli): ccds loop init — long-horizon loop scaffolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,21 @@ any coding project regardless of stack — the request they answer is "make the 
 
 ---
 
+## Unreleased — 2026-07-03 — feat: `ccds loop init` — long-horizon loop scaffolder
+
+### Added
+
+- New dispatcher subcommand `ccds loop init [--target <path>] [--dry-run]`
+  (bash; PowerShell twin to follow): scaffolds the long-horizon loop state-file
+  kit into `./.loop/` — `feature_list.json` (all `"passes": false`),
+  `progress.md`, `PROMPT.md` (one-task rule + completion promise), and an
+  `init.sh` health-check stub — then prints the capped while-loop and
+  `/ralph-loop` invocations. Refuses to overwrite an existing `.loop/`.
+  Companion to the `loop-long-horizon` skill (INNOVATIONS.md 2026-07-03 #3);
+  shell completion updated; covered by 4 new pytest cases.
+
+---
+
 ## v0.9.2 — 2026-06-18 — Fix: warn against editing inside the ccds `CLAUDE.md` block
 
 ### What changed

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,54 +1,41 @@
-# DEMO — innovation/loop-hooks (stacked on innovation/loop-skills-pack)
+# DEMO — innovation/loop-init-scaffolder
 
-Proposal #2 from `INNOVATIONS.md` (2026-07-03): make the loop skills mandatory
-instead of advisory — hooks in the `ccds-loops` plugin.
-
-Stacks on `innovation/loop-skills-pack`; merge the pack first.
+Proposal #3 from `INNOVATIONS.md` (2026-07-03, on branch
+`innovation/loop-skills-pack`): `ccds loop init` — one command that scaffolds the
+long-horizon loop state-file kit the `loop-long-horizon` skill teaches.
 
 ## What works
 
-- **SessionStart hook** (`startup|clear|compact`): injects a compact loop index into
-  context — which loop is non-optional in which situation, plus how to arm the stop
-  gate. Injected bootstrap, not routing luck (the superpowers load-bearing trick).
-- **Stop gate** (opt-in per project): put one command in `.claude/loop-gate.cmd`
-  (e.g. `npm test -- --reporter dot`) and the session cannot end while it fails —
-  exit-2 block with the failure tail fed back to the model. No gate file = no-op.
-  Only the first line of the file is executed. Claude Code's built-in
-  consecutive-block cap (default 8, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`) is the
-  runaway backstop.
-- **`plugin-extras/` mechanism** in `build-marketplace.py`: hand-authored plugin
-  components survive the `plugins/` regeneration (copied verbatim per plugin).
-- Hook JSON format verified against current docs (hooks.json at plugin root,
-  `${CLAUDE_PLUGIN_ROOT}` command paths, plain-stdout context injection, exit-2
-  Stop blocking).
+- `ccds loop init [--target <path>] [--dry-run]` creates `./.loop/` with
+  `feature_list.json` (sample entry, `"passes": false`), `progress.md` (append-only
+  log with entry template), `PROMPT.md` (one-task rule + `ALL FEATURES COMPLETE`
+  completion promise), and an `init.sh` health-check stub (deliberately `exit 1`
+  until the user fills in real build/smoke commands).
+- Prints the capped while-loop one-liner and the `/ralph-loop` equivalent, with the
+  sandbox warning.
+- Refuses to overwrite an existing `.loop/` (exit 2); `--dry-run` writes nothing;
+  unknown subcommands error cleanly. Shell completion knows `loop` / `init`.
 
 ## How to try it
 
 ```bash
-python3 -m pytest tests/ -q     # 23 passed (6 new hook/behavior cases)
-python3 scripts/lint-playbook.py
-
-# behavioral, by hand:
-bash plugins/ccds-loops/hooks/session-start.sh
-mkdir -p /tmp/p/.claude && echo false > /tmp/p/.claude/loop-gate.cmd
-echo '{}' | CLAUDE_PROJECT_DIR=/tmp/p bash plugins/ccds-loops/hooks/stop-gate.sh; echo $?   # 2 (blocks)
-echo true > /tmp/p/.claude/loop-gate.cmd
-echo '{}' | CLAUDE_PROJECT_DIR=/tmp/p bash plugins/ccds-loops/hooks/stop-gate.sh; echo $?   # 0
-
-# live: /plugin install ccds-loops@ccds, restart, and the loop index appears in context
+bash bin/ccds.sh loop init --target /tmp/some-project && ls /tmp/some-project/.loop
+python3 -m pytest tests/ -q     # 19 passed (4 new TestLoopInit cases)
+bash -n bin/ccds.sh             # syntax-clean (ShellCheck runs in CI)
 ```
 
-All script paths above were exercised on this branch (block/pass/no-gate/first-line-only).
+All of the above verified on this branch (create / refuse / dry-run / bad-subcommand
+each exercised against a scratch directory).
 
 ## What's stubbed / not included
 
-- Hooks are bash: Windows users need Git Bash on PATH (documented posture; PS twins
-  are a follow-up if demand shows).
-- Not verified end-to-end inside a live plugin-installed session (requires
-  install + restart); the hook scripts and shipped hooks.json are verified directly,
-  and the JSON contract was confirmed against current docs.
+- PowerShell twin (`ccds.ps1`) — follows the repo's bash-first convention for new
+  subcommands; noted for a follow-up.
+- Independent of the `innovation/loop-skills-pack` branch: the command works without
+  the skill pack (it references the skill by name in output text only). Both
+  branches add a `## Unreleased` changelog entry — trivial merge overlap.
 
 ## Next increment
 
-A `/loop-gate <command>` slash command in the plugin to arm/disarm the gate without
-hand-editing `.claude/loop-gate.cmd`.
+PowerShell `cmd_loop` twin, and `ccds loop status` (summarize `feature_list.json`
+pass counts + last progress entry).

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -266,21 +266,25 @@ stops the next iteration from re-walking this one's dead ends.
 EOF
 
     cat > "$loop_dir/PROMPT.md" <<'EOF'
-Work on the project in this directory.
+Work on the project in this directory. THE ONE UNBREAKABLE RULE: exactly ONE
+feature this run. Finishing early does not earn a second one.
 
 1. Read .loop/progress.md and .loop/feature_list.json. Run .loop/init.sh;
    if it fails, fixing it is this iteration's ONLY task.
-2. Pick the ONE highest-priority feature with "passes": false. Search the
-   codebase first — do not re-implement something that exists.
+2. Pick the ONE highest-priority feature with "passes": false. That id is
+   the only feature you may touch this run. Search the codebase first — do
+   not re-implement something that exists.
 3. Implement it COMPLETELY. No placeholders, no stubs, no simplified
    versions. A stub that compiles is a failure, not progress.
 4. Run the feature's verify command and read the output. Only then set
    "passes": true.
 5. Append an entry (what / why / next) to .loop/progress.md. Commit with a
    message naming the feature id.
-6. Do not start a second feature.
-
-When EVERY feature has "passes": true, output exactly: ALL FEATURES COMPLETE
+6. STOP. If other features remain "passes": false, do NOT start one — not
+   even a small one; the loop runs again with fresh context. End your reply
+   with exactly: ITERATION DONE
+7. Only if EVERY feature now has "passes": true, output exactly:
+   ALL FEATURES COMPLETE
 EOF
 
     cat > "$loop_dir/init.sh" <<'EOF'

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -86,6 +86,12 @@ COMMANDS
   setup                Install the 19 agents + cross-cutting skills, inject CLAUDE.md block
       --dry-run             Preview without writing
 
+  loop init            Scaffold the long-horizon loop state-file kit into ./.loop/
+                       (feature_list.json, progress.md, PROMPT.md, init.sh — see the
+                       loop-long-horizon skill)
+      --target <path>       Target project path (default: current directory)
+      --dry-run             Preview without writing
+
   update [tag]         Download and install a release (default: latest stable)
       --rollback            Restore the previous installed version
       --include-prerelease  Pick up release candidates when resolving 'latest'
@@ -103,6 +109,7 @@ EXAMPLES
   ccds sync --clean
   ccds verify
   ccds setup
+  ccds loop init
 
 LAYOUT
   Install location : $INSTALL_ROOT
@@ -208,6 +215,106 @@ cmd_lint() {
     exec python3 "$lint_script" "$INSTALL_ROOT"
 }
 
+# Scaffold the long-horizon loop state-file kit (loop-long-horizon skill).
+cmd_loop() {
+    local sub="${POSITIONAL[0]:-}"
+    if [[ "$sub" != "init" ]]; then
+        echo "ERROR: unknown loop subcommand '${sub:-<none>}'. Usage: ccds loop init [--target <path>] [--dry-run]" >&2
+        exit 2
+    fi
+    local target="${TARGET:-$PWD}"
+    local loop_dir="$target/.loop"
+
+    if [[ -e "$loop_dir" ]]; then
+        echo "ERROR: $loop_dir already exists -- refusing to overwrite an existing kit." >&2
+        echo "       Remove or rename it first if you really want to re-init." >&2
+        exit 2
+    fi
+    if (( DRY_RUN )); then
+        echo "DRY RUN -- would create $loop_dir/ with feature_list.json, progress.md, PROMPT.md, init.sh"
+        return
+    fi
+
+    mkdir -p "$loop_dir"
+
+    cat > "$loop_dir/feature_list.json" <<'EOF'
+{
+  "features": [
+    {
+      "id": "example-feature",
+      "description": "Replace me: one observable behavior, phrased so its absence is detectable",
+      "verify": "replace me: the command that proves this feature works",
+      "priority": 1,
+      "passes": false
+    }
+  ]
+}
+EOF
+
+    cat > "$loop_dir/progress.md" <<'EOF'
+# Loop progress log
+
+Append-only. One entry per iteration, newest last. The "why" line is the one that
+stops the next iteration from re-walking this one's dead ends.
+
+<!-- entry template:
+## <date> · iteration <n> · <feature-id>
+- Done: <what, with the verify evidence>
+- Why it took a detour: <the non-obvious part>
+- Next: <feature-id or note>
+-->
+EOF
+
+    cat > "$loop_dir/PROMPT.md" <<'EOF'
+Work on the project in this directory.
+
+1. Read .loop/progress.md and .loop/feature_list.json. Run .loop/init.sh;
+   if it fails, fixing it is this iteration's ONLY task.
+2. Pick the ONE highest-priority feature with "passes": false. Search the
+   codebase first — do not re-implement something that exists.
+3. Implement it COMPLETELY. No placeholders, no stubs, no simplified
+   versions. A stub that compiles is a failure, not progress.
+4. Run the feature's verify command and read the output. Only then set
+   "passes": true.
+5. Append an entry (what / why / next) to .loop/progress.md. Commit with a
+   message naming the feature id.
+6. Do not start a second feature.
+
+When EVERY feature has "passes": true, output exactly: ALL FEATURES COMPLETE
+EOF
+
+    cat > "$loop_dir/init.sh" <<'EOF'
+#!/usr/bin/env bash
+# Health check: must prove the project still BUILDS and minimally RUNS.
+# Replace the placeholders with this project's real commands.
+set -euo pipefail
+echo "TODO: replace with this project's build command" >&2
+echo "TODO: replace with this project's smoke check (the app actually serves/runs)" >&2
+exit 1
+EOF
+    chmod +x "$loop_dir/init.sh" 2>/dev/null || true  # exec bits unreliable on NTFS mounts
+
+    cat <<EOF
+==> Loop kit created in $loop_dir
+
+Next steps:
+  1. Fill .loop/feature_list.json with every unit of work (all "passes": false).
+  2. Make .loop/init.sh actually build + smoke-check this project.
+  3. Run the loop, capped -- never unbounded:
+
+     for i in \$(seq 1 40); do
+       cat .loop/PROMPT.md | claude -p --dangerously-skip-permissions && \\
+         grep -q '"passes": false' .loop/feature_list.json || break
+     done
+
+     or with the ralph-wiggum plugin:
+     /ralph-loop "\$(cat .loop/PROMPT.md)" --max-iterations 40 --completion-promise "ALL FEATURES COMPLETE"
+
+  Unattended runs belong in a sandbox (container/VM/worktree). See the
+  loop-long-horizon skill for the full discipline.
+EOF
+}
+
 INSTALLER_URL_SH='https://raw.githubusercontent.com/ggrace519/claude-code-dev-studio/main/install-playbook.sh'
 
 fetch_installer() {
@@ -276,6 +383,7 @@ if   [[ "$COMMAND" == "setup"     ]]; then cmd_setup
 elif [[ "$COMMAND" == "sync"      ]]; then cmd_sync
 elif [[ "$COMMAND" == "verify"    ]]; then cmd_verify
 elif [[ "$COMMAND" == "lint"      ]]; then cmd_lint
+elif [[ "$COMMAND" == "loop"      ]]; then cmd_loop
 elif [[ "$COMMAND" == "update"    ]]; then cmd_update
 elif [[ "$COMMAND" == "uninstall" ]]; then cmd_uninstall
 else

--- a/scripts/ccds-completion.bash
+++ b/scripts/ccds-completion.bash
@@ -22,7 +22,7 @@ _ccds_completion() {
         cword=$COMP_CWORD
     }
 
-    local commands="sync verify update uninstall version help"
+    local commands="sync verify loop update uninstall version help"
     local packs="game saas mobile ai dataplat ecom fintech devtool desktop ext embed media orch infra common"
     local sync_flags="--dry-run --write-adr --no-generalists --mode --target --help -h"
     local update_flags="--rollback --include-prerelease --dry-run --help -h"
@@ -34,7 +34,7 @@ _ccds_completion() {
     local i
     for ((i=1; i < cword; i++)); do
         case "${words[i]}" in
-            sync|verify|update|uninstall|version|help)
+            sync|verify|loop|update|uninstall|version|help)
                 command="${words[i]}"
                 break
                 ;;
@@ -86,6 +86,14 @@ _ccds_completion() {
         update)
             if [[ "$cur" == -* ]]; then
                 mapfile -t COMPREPLY < <(compgen -W "$update_flags" -- "$cur")
+            fi
+            return 0
+            ;;
+        loop)
+            if [[ "$cur" == -* ]]; then
+                mapfile -t COMPREPLY < <(compgen -W "--target --dry-run --help -h" -- "$cur")
+            else
+                mapfile -t COMPREPLY < <(compgen -W "init" -- "$cur")
             fi
             return 0
             ;;

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -368,6 +368,47 @@ GLOBAL_SKILLS = (
 
 
 @unittest.skipUnless(BASH and sys.platform != "win32",
+                     "ccds.sh is a bash dispatcher (POSIX shells only)")
+class TestLoopInit(unittest.TestCase):
+    """`ccds loop init` scaffolds the loop-long-horizon state-file kit."""
+
+    CCDS = os.path.join(REPO_ROOT, "bin", "ccds.sh")
+
+    def setUp(self):
+        self.target = tempfile.mkdtemp(prefix="ccds-loop-test-")
+        self.addCleanup(shutil.rmtree, self.target, ignore_errors=True)
+
+    def ccds(self, *args):
+        return subprocess.run([BASH, self.CCDS, *args],
+                              capture_output=True, text=True)
+
+    def test_scaffolds_kit(self):
+        r = self.ccds("loop", "init", "--target", self.target)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        loop = os.path.join(self.target, ".loop")
+        for f in ("feature_list.json", "progress.md", "PROMPT.md", "init.sh"):
+            self.assertTrue(os.path.isfile(os.path.join(loop, f)), f)
+        features = json.loads(read(os.path.join(loop, "feature_list.json")))
+        self.assertFalse(features["features"][0]["passes"])
+        self.assertIn("ALL FEATURES COMPLETE", read(os.path.join(loop, "PROMPT.md")))
+
+    def test_refuses_existing_kit(self):
+        self.assertEqual(self.ccds("loop", "init", "--target", self.target).returncode, 0)
+        r = self.ccds("loop", "init", "--target", self.target)
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("refusing to overwrite", r.stderr)
+
+    def test_dry_run_writes_nothing(self):
+        r = self.ccds("loop", "init", "--dry-run", "--target", self.target)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertFalse(os.path.exists(os.path.join(self.target, ".loop")))
+
+    def test_unknown_subcommand_fails(self):
+        r = self.ccds("loop", "bogus")
+        self.assertEqual(r.returncode, 2)
+
+
+@unittest.skipUnless(BASH and sys.platform != "win32",
                      "postinst is a bash maintainer script (POSIX shells only)")
 class TestDebPostinst(unittest.TestCase):
     """Regression tests for the Debian/RPM postinst per-user setup.


### PR DESCRIPTION
## Summary

New dispatcher subcommand: `ccds loop init [--target <path>] [--dry-run]` scaffolds the `.loop/` state-file kit the `loop-long-horizon` skill teaches — `feature_list.json` (all `"passes": false`), `progress.md`, `PROMPT.md` (one-task rule + completion promise), `init.sh` health-check stub — then prints the capped while-loop and `/ralph-loop` invocations.

## What changed and why

- `bin/ccds.sh`: `cmd_loop` (bash-first per repo convention; PS twin is a noted follow-up). Refuses to overwrite an existing `.loop/`; `--dry-run` writes nothing; only the kit's first line of `loop-gate`-style files is ever executed by companion tooling.
- PROMPT template carries the live-hardened one-task wording (bright-line header + STOP step with `ITERATION DONE` sentinel) — the softer wording measurably failed on a VM run (haiku did two features in one iteration).
- Shell completion knows `loop`/`init`; 4 pytest cases.

## Verification

`pytest`: 19 passed · `bash -n`: clean (ShellCheck in CI) · Live on the Debian VM: kit scaffolded, then a real two-feature Ralph loop ran with `--dangerously-skip-permissions` — one feature per iteration, `ITERATION DONE` → `ALL FEATURES COMPLETE`, per-feature commits, `Ran 3 tests … OK`.

## Post-merge

None; independent of the pack PR (#26) — references the skill by name in output text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)