### PR TITLE
feat(hooks): ccds-loops enforcement — SessionStart loop index + opt-in stop gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ any coding project regardless of stack — the request they answer is "make the 
 
 ---
 
+## Unreleased — 2026-07-03 — feat: ccds-loops enforcement hooks
+
+### Added
+
+- The `ccds-loops` plugin now ships hooks (`plugin-extras/ccds-loops/hooks/`,
+  copied into the generated plugin by `build-marketplace.py`'s new plugin-extras
+  mechanism): a **SessionStart** hook injects a 10-line loop index on
+  startup/clear/compact — the superpowers lesson that injected bootstraps, not
+  routing luck, are what make process skills load-bearing — and an opt-in **Stop
+  gate**: put one command in `.claude/loop-gate.cmd` and the session cannot end
+  while it fails (exit-2 block with the failure tail fed back; Claude Code's
+  built-in consecutive-block cap is the runaway backstop; remove the file to
+  disarm). Bash hooks — Windows requires Git Bash. 6 new pytest cases.
+
+---
+
 ## v0.9.2 — 2026-06-18 — Fix: warn against editing inside the ccds `CLAUDE.md` block
 
 ### What changed

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,39 +1,54 @@
-# DEMO — innovation/loop-lint (stacked on innovation/loop-skills-pack)
+# DEMO — innovation/loop-hooks (stacked on innovation/loop-skills-pack)
 
-Proposal #5 from `INNOVATIONS.md` (2026-07-03): the process-skill lint dimension —
-ADR-0010's authoring rules become CI-enforced errors the same day they become rules.
+Proposal #2 from `INNOVATIONS.md` (2026-07-03): make the loop skills mandatory
+instead of advisory — hooks in the `ccds-loops` plugin.
 
-This branch **stacks on `innovation/loop-skills-pack`** (it lints that branch's
-skills); merge the pack first, then this.
+Stacks on `innovation/loop-skills-pack`; merge the pack first.
 
 ## What works
 
-- `lint-playbook.py` check 9 (`process-skill`), errors on any `loop-*` skill that:
-  - lacks a trigger-style description (`Use when/before/after …`),
-  - does not have exactly one `## Iron law` section ("two laws is zero laws"),
-  - is missing the `## Rationalizations` table.
-- Domain skills (`saas-*`, `common-*`, …) are untouched by the check.
-- All six shipped `loop-*` skills pass; 5 new fixture tests prove each failure mode
-  fires (missing law, missing table, non-trigger description) and that compliant /
-  non-loop skills pass.
+- **SessionStart hook** (`startup|clear|compact`): injects a compact loop index into
+  context — which loop is non-optional in which situation, plus how to arm the stop
+  gate. Injected bootstrap, not routing luck (the superpowers load-bearing trick).
+- **Stop gate** (opt-in per project): put one command in `.claude/loop-gate.cmd`
+  (e.g. `npm test -- --reporter dot`) and the session cannot end while it fails —
+  exit-2 block with the failure tail fed back to the model. No gate file = no-op.
+  Only the first line of the file is executed. Claude Code's built-in
+  consecutive-block cap (default 8, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`) is the
+  runaway backstop.
+- **`plugin-extras/` mechanism** in `build-marketplace.py`: hand-authored plugin
+  components survive the `plugins/` regeneration (copied verbatim per plugin).
+- Hook JSON format verified against current docs (hooks.json at plugin root,
+  `${CLAUDE_PLUGIN_ROOT}` command paths, plain-stdout context injection, exit-2
+  Stop blocking).
 
 ## How to try it
 
 ```bash
-python3 scripts/lint-playbook.py   # PASS on this branch (0 errors)
-python3 -m pytest tests/ -q        # 22 passed (17 from the pack branch + 5 new)
+python3 -m pytest tests/ -q     # 23 passed (6 new hook/behavior cases)
+python3 scripts/lint-playbook.py
 
-# see it catch a violation:
-sed -i 's/^## Iron law$/## Iron laws/' skills/loop-verify/SKILL.md
-python3 scripts/lint-playbook.py   # ERROR [process-skill] … exactly one '## Iron law'
-git checkout -- skills/loop-verify/SKILL.md
+# behavioral, by hand:
+bash plugins/ccds-loops/hooks/session-start.sh
+mkdir -p /tmp/p/.claude && echo false > /tmp/p/.claude/loop-gate.cmd
+echo '{}' | CLAUDE_PROJECT_DIR=/tmp/p bash plugins/ccds-loops/hooks/stop-gate.sh; echo $?   # 2 (blocks)
+echo true > /tmp/p/.claude/loop-gate.cmd
+echo '{}' | CLAUDE_PROJECT_DIR=/tmp/p bash plugins/ccds-loops/hooks/stop-gate.sh; echo $?   # 0
+
+# live: /plugin install ccds-loops@ccds, restart, and the loop index appears in context
 ```
+
+All script paths above were exercised on this branch (block/pass/no-gate/first-line-only).
 
 ## What's stubbed / not included
 
-Nothing stubbed. Everything in the loop-skills-pack DEMO also applies here.
+- Hooks are bash: Windows users need Git Bash on PATH (documented posture; PS twins
+  are a follow-up if demand shows).
+- Not verified end-to-end inside a live plugin-installed session (requires
+  install + restart); the hook scripts and shipped hooks.json are verified directly,
+  and the JSON contract was confirmed against current docs.
 
 ## Next increment
 
-Enforcement hooks for `ccds-loops` (INNOVATIONS #2) and release-time compliance
-pressure-tests (#4) — the behavioral complement to this structural check.
+A `/loop-gate <command>` slash command in the plugin to arm/disarm the gate without
+hand-editing `.claude/loop-gate.cmd`.

--- a/plugin-extras/ccds-loops/hooks/hooks.json
+++ b/plugin-extras/ccds-loops/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-gate.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin-extras/ccds-loops/hooks/session-start.sh
+++ b/plugin-extras/ccds-loops/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ccds-loops SessionStart hook — inject the loop index as context.
+# Plain stdout on exit 0 is added to the session's context (hooks reference).
+# The injection is what makes the loops load-bearing instead of routing luck:
+# descriptions alone under-trigger when the model is mid-task.
+set -u
+cat <<'EOF'
+The ccds-loops process skills are installed. When one applies, using it is not
+optional:
+- About to claim done/fixed/working/passing -> loop-verify (fresh evidence from the real system first)
+- Bug or failing test with an unproven cause -> loop-debug (no fix without a proven root cause)
+- Implementation ready for pre-merge review -> loop-review (fresh-context reviewer; never grade your own work)
+- Work splits into 3+ independent pieces -> loop-parallel (written file ownership; one build/test lane)
+- Task will outlive one context window / unattended run -> loop-long-horizon (state in files; ONE task per iteration)
+- User correction, review finding, or repeated mistake -> loop-compound (write the rule where the next session reads it)
+Optional stop gate: put one command in .claude/loop-gate.cmd — the session cannot
+end while it fails (remove the file to disarm).
+EOF
+exit 0

--- a/plugin-extras/ccds-loops/hooks/stop-gate.sh
+++ b/plugin-extras/ccds-loops/hooks/stop-gate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ccds-loops Stop hook — the "give Claude a check it can run" gate, packaged.
+#
+# Opt-in per project: create .claude/loop-gate.cmd containing ONE command line
+# (e.g. "npm test -- --reporter dot" or "python3 -m pytest -q"). While the
+# command fails, this hook blocks turn-end (exit 2) and feeds the failure back
+# so the model keeps working; when it passes, the turn ends normally. Remove
+# the file to disarm. Claude Code's built-in consecutive-block cap
+# (CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, default 8) is the runaway backstop.
+set -u
+
+cat > /dev/null  # drain the hook's stdin JSON; the gate needs none of it
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+gate="$proj/.claude/loop-gate.cmd"
+[[ -f "$gate" ]] || exit 0
+
+cmd="$(head -n 1 "$gate" | tr -d '\r')"
+[[ -n "$cmd" ]] || exit 0
+
+out="$(cd "$proj" && bash -c "$cmd" 2>&1)"
+status=$?
+(( status == 0 )) && exit 0
+
+{
+    printf 'loop-gate: check failed (exit %s): %s\n' "$status" "$cmd"
+    printf '%s\n' "$out" | tail -n 15
+    printf 'The session cannot end while the gate fails (loop-verify: no done claims without fresh evidence). Fix the failure, or ask the user to remove .claude/loop-gate.cmd if the gate itself is wrong.\n'
+} >&2
+exit 2

--- a/plugins/ccds-loops/hooks/hooks.json
+++ b/plugins/ccds-loops/hooks/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-gate.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/ccds-loops/hooks/session-start.sh
+++ b/plugins/ccds-loops/hooks/session-start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ccds-loops SessionStart hook — inject the loop index as context.
+# Plain stdout on exit 0 is added to the session's context (hooks reference).
+# The injection is what makes the loops load-bearing instead of routing luck:
+# descriptions alone under-trigger when the model is mid-task.
+set -u
+cat <<'EOF'
+The ccds-loops process skills are installed. When one applies, using it is not
+optional:
+- About to claim done/fixed/working/passing -> loop-verify (fresh evidence from the real system first)
+- Bug or failing test with an unproven cause -> loop-debug (no fix without a proven root cause)
+- Implementation ready for pre-merge review -> loop-review (fresh-context reviewer; never grade your own work)
+- Work splits into 3+ independent pieces -> loop-parallel (written file ownership; one build/test lane)
+- Task will outlive one context window / unattended run -> loop-long-horizon (state in files; ONE task per iteration)
+- User correction, review finding, or repeated mistake -> loop-compound (write the rule where the next session reads it)
+Optional stop gate: put one command in .claude/loop-gate.cmd — the session cannot
+end while it fails (remove the file to disarm).
+EOF
+exit 0

--- a/plugins/ccds-loops/hooks/stop-gate.sh
+++ b/plugins/ccds-loops/hooks/stop-gate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ccds-loops Stop hook — the "give Claude a check it can run" gate, packaged.
+#
+# Opt-in per project: create .claude/loop-gate.cmd containing ONE command line
+# (e.g. "npm test -- --reporter dot" or "python3 -m pytest -q"). While the
+# command fails, this hook blocks turn-end (exit 2) and feeds the failure back
+# so the model keeps working; when it passes, the turn ends normally. Remove
+# the file to disarm. Claude Code's built-in consecutive-block cap
+# (CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, default 8) is the runaway backstop.
+set -u
+
+cat > /dev/null  # drain the hook's stdin JSON; the gate needs none of it
+
+proj="${CLAUDE_PROJECT_DIR:-$PWD}"
+gate="$proj/.claude/loop-gate.cmd"
+[[ -f "$gate" ]] || exit 0
+
+cmd="$(head -n 1 "$gate" | tr -d '\r')"
+[[ -n "$cmd" ]] || exit 0
+
+out="$(cd "$proj" && bash -c "$cmd" 2>&1)"
+status=$?
+(( status == 0 )) && exit 0
+
+{
+    printf 'loop-gate: check failed (exit %s): %s\n' "$status" "$cmd"
+    printf '%s\n' "$out" | tail -n 15
+    printf 'The session cannot end while the gate fails (loop-verify: no done claims without fresh evidence). Fix the failure, or ask the user to remove .claude/loop-gate.cmd if the gate itself is wrong.\n'
+} >&2
+exit 2

--- a/scripts/build-marketplace.py
+++ b/scripts/build-marketplace.py
@@ -51,6 +51,10 @@ AGENTS_DIR = os.path.join(REPO_ROOT, ".claude", "agents")
 SKILLS_DIR = os.path.join(REPO_ROOT, "skills")
 PLUGINS_DIR = os.path.join(REPO_ROOT, "plugins")
 MARKETPLACE_DIR = os.path.join(REPO_ROOT, ".claude-plugin")
+# Hand-authored per-plugin components (hooks/, commands/, ...) that survive
+# the plugins/ regeneration: plugin-extras/<plugin-name>/ is copied verbatim
+# into the generated plugin directory.
+EXTRAS_DIR = os.path.join(REPO_ROOT, "plugin-extras")
 
 CORE_AGENTS = ["plan-architect", "pr-code-reviewer", "secure-auditor",
                "test-writer-runner", "deploy-checklist"]
@@ -119,6 +123,9 @@ def build_plugin(name, description, agents, skill_names, version):
         copy_agent(a, plugin_dir)
     for s in skill_names:
         copy_skill(s, plugin_dir)
+    extras = os.path.join(EXTRAS_DIR, name)
+    if os.path.isdir(extras):
+        shutil.copytree(extras, plugin_dir, dirs_exist_ok=True)
     entry = {
         "name": name,
         # Explicit relative path rather than pluginRoot + bare name: identical

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -275,6 +275,15 @@ class TestBuildMarketplace(unittest.TestCase):
         self.assertEqual(shipped, ["loop-compound", "loop-debug", "loop-long-horizon",
                                    "loop-parallel", "loop-review", "loop-verify"])
 
+    def test_loops_plugin_ships_hooks(self):
+        r = run(BUILD_MARKETPLACE, REPO_ROOT)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        hooks_dir = os.path.join(REPO_ROOT, "plugins", "ccds-loops", "hooks")
+        hooks = json.loads(read(os.path.join(hooks_dir, "hooks.json")))
+        self.assertEqual(sorted(hooks["hooks"].keys()), ["SessionStart", "Stop"])
+        for script in ("session-start.sh", "stop-gate.sh"):
+            self.assertTrue(os.path.isfile(os.path.join(hooks_dir, script)), script)
+
     def test_explicit_version_pins_plugins(self):
         try:
             r = run(BUILD_MARKETPLACE, REPO_ROOT, "--version", "0.0.0-test")
@@ -286,6 +295,60 @@ class TestBuildMarketplace(unittest.TestCase):
             # restore the checked-in (unversioned) tree
             subprocess.run(["git", "-C", REPO_ROOT, "checkout", "--", ".claude-plugin", "plugins"],
                            capture_output=True)
+
+
+HOOKS_SRC = os.path.join(REPO_ROOT, "plugin-extras", "ccds-loops", "hooks")
+
+
+@unittest.skipUnless(shutil.which("bash") and sys.platform != "win32"
+                     and os.path.isdir(HOOKS_SRC),
+                     "hook scripts are bash (POSIX shells only)")
+class TestLoopHooks(unittest.TestCase):
+    """Behavioral tests for the ccds-loops hook scripts (source tree —
+    plugins/ is a generated copy of these)."""
+
+    def setUp(self):
+        self.proj = tempfile.mkdtemp(prefix="ccds-hooks-test-")
+        self.addCleanup(shutil.rmtree, self.proj, ignore_errors=True)
+        os.makedirs(os.path.join(self.proj, ".claude"))
+
+    def hook(self, script):
+        return subprocess.run(
+            ["bash", os.path.join(HOOKS_SRC, script)],
+            input="{}", capture_output=True, text=True,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": self.proj})
+
+    def set_gate(self, line):
+        write(os.path.join(self.proj, ".claude", "loop-gate.cmd"), line + "\n")
+
+    def test_session_start_emits_loop_index(self):
+        r = self.hook("session-start.sh")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for name in ("loop-verify", "loop-debug", "loop-review", "loop-parallel",
+                     "loop-long-horizon", "loop-compound"):
+            self.assertIn(name, r.stdout)
+
+    def test_stop_gate_noop_without_gate_file(self):
+        self.assertEqual(self.hook("stop-gate.sh").returncode, 0)
+
+    def test_stop_gate_blocks_on_failing_check(self):
+        self.set_gate("echo boom >&2; exit 3")
+        r = self.hook("stop-gate.sh")
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("loop-gate: check failed (exit 3)", r.stderr)
+        self.assertIn("boom", r.stderr)
+
+    def test_stop_gate_allows_on_passing_check(self):
+        self.set_gate("true")
+        self.assertEqual(self.hook("stop-gate.sh").returncode, 0)
+
+    def test_stop_gate_runs_first_line_only(self):
+        canary = os.path.join(self.proj, "canary")
+        write(os.path.join(self.proj, ".claude", "loop-gate.cmd"),
+              f"true\ntouch {canary}\n")
+        r = self.hook("stop-gate.sh")
+        self.assertEqual(r.returncode, 0)
+        self.assertFalse(os.path.exists(canary), "second line must not run")
 
 
 PACKAGING = os.path.join(REPO_ROOT, "packaging")


### PR DESCRIPTION
## Summary

Makes the loop skills mandatory instead of advisory: the `ccds-loops` plugin now ships hooks. A SessionStart hook injects a 10-line loop index on startup/clear/compact (injected bootstrap, not routing luck — the superpowers load-bearing trick), and an opt-in Stop gate blocks turn-end while a project-defined check fails.

## What changed and why

- `plugin-extras/ccds-loops/hooks/` — `hooks.json` + `session-start.sh` + `stop-gate.sh`. Gate is opt-in per project: one command in `.claude/loop-gate.cmd`; only its first line executes; no file = no-op; Claude Code's consecutive-block cap (default 8) is the runaway backstop. Bash hooks — Windows needs Git Bash (documented).
- `build-marketplace.py` — new `plugin-extras/` mechanism: hand-authored plugin components survive the `plugins/` regeneration.
- 6 pytest cases covering every gate path.

## Verification

`pytest`: 28 passed · lint PASS · marketplace regen byte-stable. **Live on the Debian VM**: plugin installed via `claude plugin install ccds-loops@ccds`; a real session quoted the injected loop index (all six skills); the Stop gate blocked a trivial turn and the model created the gated file to satisfy the check before the session ended. Hook JSON contract verified against current docs.

## Post-merge

None. Stacks on #26 (rebased onto main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)