### PR TITLE
docs(hooks): post-release verification notes — headless stop-gate footgun + live Cursor activation

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -35,9 +35,12 @@ codex exec --sandbox read-only "I just committed a fix and it compiles. May I te
 
 ## What's stubbed / not included
 
-- Cursor export is structurally valid per the .mdc format but not yet exercised
-  inside a live Cursor session (Cursor is installed but rule attachment is
-  interactive); the AGENTS.md path is the live-verified one.
+- ~~Cursor export not yet exercised live~~ **Confirmed 2026-07-03** (manual test,
+  Cursor 3.2.16): with the exported `.cursor/rules` in a project, Cursor's agent
+  attached `loop-verify.mdc` on a bare "it compiles, should I say done?" prompt,
+  quoted the iron law and the top two rationalization rows nearly verbatim,
+  refused the claim, and walked the loop's steps — both export targets are now
+  activation-verified in their real harnesses.
 - Release workflow doesn't attach export ZIPs yet — wire that up once the pack has
   merged and the export format has a release to ride on.
 - Exports only `loop-*` deliberately; widen to `common-*`/domain skills if adoption

--- a/plugin-extras/ccds-loops/hooks/stop-gate.sh
+++ b/plugin-extras/ccds-loops/hooks/stop-gate.sh
@@ -7,6 +7,13 @@
 # so the model keeps working; when it passes, the turn ends normally. Remove
 # the file to disarm. Claude Code's built-in consecutive-block cap
 # (CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, default 8) is the runaway backstop.
+#
+# Headless runs: in `claude -p` the default permission mode denies the tools
+# the model needs to SATISFY the gate (write a file, run the fix), so it gets
+# blocked to the cap and the run ends with an empty printed result. Pass a
+# permission mode that allows the check to be satisfied, e.g.
+#   claude -p "..." --permission-mode acceptEdits
+# (measured live against the v0.10.0 GitHub-published plugin, 2026-07-03).
 set -u
 
 cat > /dev/null  # drain the hook's stdin JSON; the gate needs none of it

--- a/plugins/ccds-loops/hooks/stop-gate.sh
+++ b/plugins/ccds-loops/hooks/stop-gate.sh
@@ -7,6 +7,13 @@
 # so the model keeps working; when it passes, the turn ends normally. Remove
 # the file to disarm. Claude Code's built-in consecutive-block cap
 # (CLAUDE_CODE_STOP_HOOK_BLOCK_CAP, default 8) is the runaway backstop.
+#
+# Headless runs: in `claude -p` the default permission mode denies the tools
+# the model needs to SATISFY the gate (write a file, run the fix), so it gets
+# blocked to the cap and the run ends with an empty printed result. Pass a
+# permission mode that allows the check to be satisfied, e.g.
+#   claude -p "..." --permission-mode acceptEdits
+# (measured live against the v0.10.0 GitHub-published plugin, 2026-07-03).
 set -u
 
 cat > /dev/null  # drain the hook's stdin JSON; the gate needs none of it


### PR DESCRIPTION
## Summary

Two documentation updates from v0.10.0 release testing.

## What changed and why

- `stop-gate.sh` header (source + regenerated plugin copy): in headless `claude -p` runs the default permission mode denies the tools needed to *satisfy* the gate, so the model blocks to the cap and the run ends with an **empty printed result** — a silent-failure footgun. Documented the `--permission-mode acceptEdits` requirement. Measured live both ways against the GitHub-published plugin.
- `DEMO.md`: the Cursor `.mdc` export is now **activation-verified live** (manual test, Cursor 3.2.16): the exported `loop-verify` rule attached on description-match and the agent quoted the iron law + rationalization rows verbatim while refusing an unverified done-claim.

## Verification

`pytest`: 40 passed · lint PASS · marketplace regen byte-stable. Both documented behaviors observed live on 2026-07-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)