### PR TITLE
fix(cli): ccds.ps1 error paths now exit 2 as documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## Unreleased — 2026-07-03 — fix: ccds.ps1 error paths now exit 2 as documented
+
+### Fixed
+
+- All six `Write-Error "..."; exit 2` paths in `bin/ccds.ps1` (unknown command,
+  `verify` without agents, `lint` prerequisites, sync-script resolution, the
+  top-level catch) actually exited **1**: under `$ErrorActionPreference='Stop'`
+  a bare `Write-Error` is terminating, so the `exit 2` was dead code and the
+  PowerShell dispatcher disagreed with the bash twin on every error path.
+  Now `-ErrorAction Continue` at each site; measured before/after with real
+  Windows PowerShell 5.1 (1→2 on both testable paths, happy paths unchanged).
+  Closes #33; found while building the `loop init` twin.
+
+---
+
 ## Unreleased — 2026-07-03 — feat: PowerShell twin for `ccds loop init`
 
 ### Added

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -45,6 +45,9 @@ param(
     $RemainingArgs
 )
 
+# Error paths use `Write-Error ... -ErrorAction Continue; exit 2` — under
+# ErrorActionPreference='Stop' a bare Write-Error is TERMINATING (script dies
+# with exit 1 and the exit 2 is dead code). See #33.
 $ErrorActionPreference = 'Stop'
 
 # ---------------------------------------------------------------------------
@@ -72,7 +75,7 @@ if (Test-Path -LiteralPath $installedSync) {
     $libraryRoot  = $installRoot   # Sync-AgentPacks.ps1 looks for .\claude\agents under this
     $layoutKind   = 'dev'
 } else {
-    Write-Error "Cannot locate Sync-AgentPacks.ps1. Checked: $installedSync, $devSync"
+    Write-Error "Cannot locate Sync-AgentPacks.ps1. Checked: $installedSync, $devSync" -ErrorAction Continue
     exit 2
 }
 
@@ -242,7 +245,7 @@ function Invoke-VerifyCommand {
     $agentsPath = Join-Path $target '.claude\agents'
 
     if (-not (Test-Path -LiteralPath $agentsPath)) {
-        Write-Error "No .claude\agents\ found under $target"
+        Write-Error "No .claude\agents\ found under $target" -ErrorAction Continue
         exit 2
     }
 
@@ -256,13 +259,13 @@ function Invoke-VerifyCommand {
 function Invoke-LintCommand {
     $lintScript = Join-Path $installRoot 'scripts\lint-playbook.py'
     if (-not (Test-Path -LiteralPath $lintScript)) {
-        Write-Error "lint-playbook.py not found at $lintScript. 'ccds lint' validates the library source; run it from a repo clone."
+        Write-Error "lint-playbook.py not found at $lintScript. 'ccds lint' validates the library source; run it from a repo clone." -ErrorAction Continue
         exit 2
     }
     $python = Get-Command python3 -ErrorAction SilentlyContinue
     if (-not $python) { $python = Get-Command python -ErrorAction SilentlyContinue }
     if (-not $python) {
-        Write-Error "python3 is required for lint"
+        Write-Error "python3 is required for lint" -ErrorAction Continue
         exit 2
     }
     & $python.Source $lintScript $installRoot
@@ -508,7 +511,7 @@ try {
     $argList = if ($null -eq $RemainingArgs) { @() } else { Expand-RemainingArgs -InputArgs $RemainingArgs }
     $opts = ConvertTo-Hashtable -Arguments $argList
 } catch {
-    Write-Error $_
+    Write-Error $_ -ErrorAction Continue
     exit 2
 }
 
@@ -520,7 +523,7 @@ switch ($Command) {
     'update'     { Invoke-UpdateCommand -Opts $opts }
     'uninstall'  { Invoke-UninstallCommand }
     default {
-        Write-Error "Unknown command: $Command. Run 'ccds help' for usage."
+        Write-Error "Unknown command: $Command. Run 'ccds help' for usage." -ErrorAction Continue
         exit 2
     }
 }


### PR DESCRIPTION
## Summary

Fixes #33: every `Write-Error "..."; exit 2` path in `bin/ccds.ps1` actually exited 1 — under `$ErrorActionPreference='Stop'` a bare `Write-Error` is terminating, making the `exit 2` dead code and putting the PowerShell dispatcher out of contract with the bash twin on all error paths.

## What changed and why

`-ErrorAction Continue` at the six affected sites (unknown command, `verify` without agents dir, both `lint` prerequisites, sync-script resolution, top-level catch), plus a comment at the `$ErrorActionPreference` declaration so the constraint is visible where the trap is set. Matches the pattern the `loop` command already used.

## Verification

RED→GREEN on real Windows PowerShell 5.1 via powershell.exe: `unknown-command` and `verify` (no agents dir) both exited **1 before, 2 after**; happy paths regression-checked (`version` → 0, `loop init` → 0 with all 4 files). `pytest`: 40 passed. PSScriptAnalyzer in CI.

## Post-merge

Closes #33 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)