### PR TITLE
feat(hooks): PostToolUse tripwire for loop-* wording changes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/loop-skill-edited.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## Unreleased — 2026-07-04 — feat: repo hook makes the eval-cadence rule deterministic
+
+### Added
+
+- Repo-level PostToolUse hook (`.claude/settings.json` +
+  `scripts/hooks/loop-skill-edited.py`): editing any `loop-*` skill or the
+  compliance-eval scenarios injects a reminder that the live 6/6 baseline is
+  now unmeasured and must be re-run (`eval-loop-compliance.py --votes 3`)
+  before the next release. The loop-compound escalation ratchet applied to our
+  own process — the "re-run evals after wording changes" habit was prose; now
+  the trigger is deterministic. Tripwire, not gate: always exits 0; the live
+  eval itself stays release-time (API cost). Contributors approve the hook
+  once on first session in the repo.
+
+---
+
 ## v0.10.1 — 2026-07-03 — Windows parity: `ccds loop init` twin + dispatcher exit-code fix
 
 ### What changed

--- a/scripts/hooks/loop-skill-edited.py
+++ b/scripts/hooks/loop-skill-edited.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+PostToolUse hook: fire the release-cadence reminder when loop-* wording changes.
+
+The loop-* process skills have two enforcement layers: structural rules are
+lint-enforced (check 9), but the LIVE compliance baseline (6/6 scenarios,
+eval-loop-compliance.py) is a measured property of the wording and silently
+goes stale the moment the wording changes. This hook makes the trigger
+deterministic instead of a habit — the loop-compound escalation ratchet applied
+to our own process ("third occurrence: promote the prose rule to a hook").
+
+Wired in .claude/settings.json (repo-level, PostToolUse on Edit|Write). Reads
+the hook JSON on stdin; if the edited file is a loop-* skill body or one of the
+PROMPT-template sources, injects the reminder as additionalContext. Exit 0
+always — this is a tripwire, not a gate.
+"""
+
+import json
+import sys
+
+# Files whose wording the live compliance/loop baselines actually measure.
+WATCHED = (
+    "skills/loop-",                # any loop-* SKILL.md or bundled reference
+    "evals/loop-compliance/",      # scenario wording is half the measurement
+)
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # malformed input: stay silent, never break the edit
+    path = (payload.get("tool_input") or {}).get("file_path", "") or ""
+    norm = path.replace("\\", "/")
+    if not any(w in norm for w in WATCHED):
+        return 0
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": (
+                "loop-* wording changed (" + norm + "). The live compliance "
+                "baseline is now unmeasured for this wording. Before the next "
+                "release: run `python3 scripts/eval-loop-compliance.py "
+                "--votes 3 --model haiku` (spends ~18 API calls; release-time "
+                "cadence, not per-edit) and record the result. Structural "
+                "rules are covered by lint check 9; this reminder exists "
+                "because the live baseline is not."
+            ),
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -447,6 +447,42 @@ class TestExportHarness(unittest.TestCase):
         self.assertEqual(r.returncode, 2)
 
 
+LOOP_EDIT_HOOK = os.path.join(SCRIPTS, "hooks", "loop-skill-edited.py")
+
+
+@unittest.skipUnless(os.path.isfile(LOOP_EDIT_HOOK),
+                     "loop-skill-edited.py not on this branch yet")
+class TestLoopSkillEditedHook(unittest.TestCase):
+    """PostToolUse tripwire: reminds that the live compliance baseline goes
+    stale when loop-* wording changes. Tripwire, not gate: always exit 0."""
+
+    def hook(self, stdin_text):
+        return subprocess.run([sys.executable, LOOP_EDIT_HOOK],
+                              input=stdin_text, capture_output=True, text=True)
+
+    def test_fires_on_loop_skill_edit(self):
+        r = self.hook(json.dumps(
+            {"tool_input": {"file_path": "/x/skills/loop-verify/SKILL.md"}}))
+        self.assertEqual(r.returncode, 0)
+        out = json.loads(r.stdout)
+        self.assertIn("eval-loop-compliance.py",
+                      out["hookSpecificOutput"]["additionalContext"])
+
+    def test_fires_on_scenario_edit_windows_path(self):
+        r = self.hook(json.dumps(
+            {"tool_input": {"file_path": "D:\\r\\evals\\loop-compliance\\scenarios.json"}}))
+        self.assertIn("additionalContext", r.stdout)
+
+    def test_silent_on_non_loop_edit(self):
+        r = self.hook(json.dumps(
+            {"tool_input": {"file_path": "/x/skills/saas-billing/SKILL.md"}}))
+        self.assertEqual((r.returncode, r.stdout), (0, ""))
+
+    def test_silent_on_malformed_input(self):
+        r = self.hook("not json at all")
+        self.assertEqual((r.returncode, r.stdout), (0, ""))
+
+
 PACKAGING = os.path.join(REPO_ROOT, "packaging")
 POSTINST = os.path.join(PACKAGING, "postinst")
 USER_SETUP = os.path.join(SCRIPTS, "ccds-user-setup.sh")


### PR DESCRIPTION
## Summary

Promotes the last prose rule from the loop-pack effort to something deterministic — its own `loop-compound` escalation ratchet applied to our process. Editing any `loop-*` skill (or the compliance-eval scenarios) now injects a context reminder that the live 6/6 baseline is unmeasured for the new wording and must be re-run before the next release.

## What changed and why

- `scripts/hooks/loop-skill-edited.py` + checked-in `.claude/settings.json` (PostToolUse, Edit|Write). Tripwire, not gate: always exit 0, silent on non-loop edits and malformed input; handles Windows paths. The live eval itself stays release-time (~18 API calls) — only the *trigger* is automated.
- Contributors approve the repo hook once on first session; noted in the changelog entry.

## Verification

Script driven through all four input cases (loop skill → JSON additionalContext; scenarios via Windows path → fires; non-loop edit → silent 0; garbage stdin → silent 0). 4 pytest cases; suite: 44 passed. In-session firing can't be verified from the session that authored it (hooks snapshot at session start) — the settings.json shape matches the documented PostToolUse contract, and the next session in this repo exercises it for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)