### PR TITLE
chore: gitignore project-staged .claude/skills/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dist/
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Project-staged domain skills (ccds sync / sync-agents output — per-clone state)
+.claude/skills/


### PR DESCRIPTION
## Summary

`sync-agents` / `ccds sync` stage domain skills into `.claude/skills/` per clone (dogfooding in this repo: devtool-* + orch-*); without an ignore rule they show as untracked dirt in every contributor's `git status`.

## Verification

`git status --porcelain` clean with skills staged; `git check-ignore` confirms the path matches; checked-in `.claude/agents/` and `.claude/settings.json` unaffected (rule is `.claude/skills/` only). No changelog entry — contributor-workspace hygiene with no user-observable effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)