### PR TITLE
feat(cli): ccds doctor — proactive environment checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,41 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## Unreleased — 2026-07-03 — feat: ccds doctor
+
+### Added
+
+- **`ccds doctor`** (bash CLI): one command that proactively checks the whole
+  install for every class of environment bug this project has shipped
+  reactively — instead of discovering them one incident at a time. Nine
+  checks, each printing one `OK|WARN|FAIL` line with a concrete `remedy:` on
+  anything less than OK:
+  - **layout** — flags a dev-layout repo clone, where `ccds setup` fails
+    confusingly (it expects the packaged `<root>/agents` shape, not
+    `.claude/agents`), and says how to stage a release instead.
+  - **version** — compares the installed version against the latest GitHub
+    release, so an install can no longer silently sit on an old version
+    (this week's v0.9.2-vs-v0.10.1 incident). Offline/timeout is a WARN,
+    never a failure.
+  - **agents-installed / skills-installed** — detects silent no-op installs:
+    the core-agent sentinel and every cross-cutting skill (list read from
+    the setup script at runtime, so it cannot drift) must be present.
+  - **bom-scan / crlf-scan** — the historic UTF-8-BOM frontmatter breaker
+    (ADR-0001) and CRLF-corrupted shell scripts, caught before they bite.
+  - **claude-md-block** — exactly one ccds marker block in `~/.claude/CLAUDE.md`.
+  - **catalog** — `catalog.json` present and valid JSON.
+  - **path-and-duals** — warns when a system package (`/usr/share/ccds`) and
+    a per-user install (`~/.claude/playbook`) coexist, and names which one
+    this shell actually runs.
+
+  Exit codes: 0 = healthy (WARNs allowed), 1 = at least one FAIL, 2 = config
+  error. Covered by 6 fixture-based subprocess tests (synthetic `$HOME` +
+  staged install root; `CCDS_DOCTOR_RELEASE_URL` is a test-only override
+  that keeps the version check off the network). Follow-up: the PowerShell
+  twin (`ccds.ps1 doctor`) is intentionally not in this change.
+
+---
+
 ## v0.10.1 — 2026-07-03 — Windows parity: `ccds loop init` twin + dispatcher exit-code fix
 
 ### What changed

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -79,6 +79,12 @@ COMMANDS
   verify               Validate global agents and project skills
       --target <path>       Target path (default: current directory)
 
+  doctor               Run proactive environment health checks: layout shape,
+                       version drift vs the latest release, install
+                       completeness (agents, skills, CLAUDE.md block, catalog),
+                       BOM/CRLF corruption, PATH and dual-install conflicts.
+                       Exit 0 = healthy (WARNs allowed), 1 = failures found.
+
   lint                 Lint the playbook library's semantic invariants
                        (skill cross-refs, catalog freshness, URL/description
                        conventions). Requires a repo clone (dev layout).
@@ -108,6 +114,7 @@ EXAMPLES
   ccds sync game --dry-run
   ccds sync --clean
   ccds verify
+  ccds doctor
   ccds setup
   ccds loop init
 
@@ -202,6 +209,253 @@ cmd_verify() {
         exit 2
     fi
     exec "$VERIFY_SCRIPT" "$agents_path"
+}
+
+# ---------------------------------------------------------------------------
+# ccds doctor -- proactive environment health checks
+# ---------------------------------------------------------------------------
+# Every class of environment bug this project has shipped (BOM-broken
+# frontmatter, CRLF scripts, silent no-op installs, stale versions, dual
+# install roots) gets a proactive check here instead of a reactive fix.
+#
+# Contract:
+#   - each check prints exactly one line:  OK|WARN|FAIL  <name>: <detail>
+#     plus an indented 'remedy:' line on WARN/FAIL
+#   - exit 0 if no FAIL (WARNs allowed), 1 if any FAIL, 2 on config error
+#
+# CCDS_DOCTOR_RELEASE_URL is a TEST-ONLY override for the GitHub
+# latest-release endpoint, so tests can force the offline path
+# deterministically. Do not set it in normal use.
+
+DOC_OK=0; DOC_WARN=0; DOC_FAIL=0
+
+doc_line() {  # doc_line STATUS NAME DETAIL [REMEDY]
+    local status="$1" name="$2" detail="$3" remedy="${4:-}"
+    printf '%s  %s: %s\n' "$status" "$name" "$detail"
+    case "$status" in
+        OK)   DOC_OK=$((DOC_OK + 1)) ;;
+        WARN) DOC_WARN=$((DOC_WARN + 1)) ;;
+        FAIL) DOC_FAIL=$((DOC_FAIL + 1)) ;;
+        *)    echo "ERROR: doc_line: unknown status '$status'" >&2; exit 2 ;;
+    esac
+    if [[ "$status" != "OK" && -n "$remedy" ]]; then
+        printf '      remedy: %s\n' "$remedy"
+    fi
+}
+
+doc_check_layout() {
+    if [[ "$LAYOUT_KIND" == "dev" ]]; then
+        doc_line WARN layout \
+            "dev (repo clone at $INSTALL_ROOT); 'ccds setup' expects the packaged shape (<root>/agents, <root>/skills) -- this repo keeps agents in .claude/agents" \
+            "stage a release first (bash build-release.sh) or install via install-playbook.sh, then run 'ccds setup' from that tree"
+    else
+        doc_line OK layout "$LAYOUT_KIND ($INSTALL_ROOT)"
+    fi
+}
+
+doc_check_version() {
+    local installed url body latest
+    installed="$(installed_version)"
+    url="${CCDS_DOCTOR_RELEASE_URL:-https://api.github.com/repos/ggrace519/claude-code-dev-studio/releases/latest}"
+
+    if ! command -v curl >/dev/null 2>&1; then
+        doc_line WARN version \
+            "installed $installed; could not check latest release (curl not found)" \
+            "install curl to enable the update check"
+        return
+    fi
+    if ! body="$(curl -fsSL --max-time 5 -H 'User-Agent: ccds-doctor' "$url" 2>/dev/null)"; then
+        doc_line WARN version \
+            "installed $installed; could not check latest release (offline, timeout, or rate-limited)" \
+            "retry with network access, or check https://github.com/ggrace519/claude-code-dev-studio/releases"
+        return
+    fi
+    latest="$(printf '%s' "$body" \
+        | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+        | head -n1 | sed 's/.*"\([^"]*\)"$/\1/')"
+    if [[ -z "$latest" ]]; then
+        doc_line WARN version \
+            "installed $installed; could not parse latest release tag from $url" \
+            "check https://github.com/ggrace519/claude-code-dev-studio/releases"
+        return
+    fi
+
+    local vi="${installed#v}" vl="${latest#v}"
+    if [[ "$installed" == "dev" ]]; then
+        doc_line OK version "dev (repo clone; latest release is $latest)"
+    elif [[ "$vi" == "$vl" ]]; then
+        doc_line OK version "$installed (up to date with latest release $latest)"
+    elif [[ "$(printf '%s\n%s\n' "$vi" "$vl" | sort -V | head -n1)" == "$vi" ]]; then
+        doc_line WARN version \
+            "installed $installed is older than latest release $latest" \
+            "run 'ccds update'"
+    else
+        doc_line OK version "$installed (ahead of latest release $latest)"
+    fi
+}
+
+doc_check_agents() {
+    local dir="$HOME/.claude/agents"
+    if [[ -f "$dir/plan-architect.md" ]]; then
+        local n
+        n="$(find "$dir" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
+        doc_line OK agents-installed "core sentinel plan-architect.md present ($n agent file(s) in $dir)"
+    else
+        doc_line FAIL agents-installed \
+            "plan-architect.md missing from $dir -- the always-on agents are not installed" \
+            "run 'ccds setup'"
+    fi
+}
+
+doc_check_skills() {
+    # Read the authoritative GLOBAL_SKILLS list from the setup script at
+    # runtime -- never a second hardcoded copy that can drift.
+    if [[ ! -f "$SETUP_SCRIPT" ]]; then
+        doc_line WARN skills-installed \
+            "cannot determine expected skill list ($SETUP_SCRIPT not found)" \
+            "reinstall via 'ccds update' or the installer"
+        return
+    fi
+    local -a expected=()
+    mapfile -t expected < <(sed -n '/^GLOBAL_SKILLS=(/,/^)/p' "$SETUP_SCRIPT" \
+        | sed -e '1d' -e '$d' -e 's/#.*$//' -e 's/[[:space:]]//g' | grep -v '^$' || true)
+    if (( ${#expected[@]} == 0 )); then
+        doc_line WARN skills-installed \
+            "could not extract GLOBAL_SKILLS from $SETUP_SCRIPT" \
+            "reinstall via 'ccds update' or the installer"
+        return
+    fi
+    local name
+    local -a missing=()
+    for name in "${expected[@]}"; do
+        [[ -f "$HOME/.claude/skills/$name/SKILL.md" ]] || missing+=("$name")
+    done
+    if (( ${#missing[@]} == 0 )); then
+        doc_line OK skills-installed "all ${#expected[@]} cross-cutting skills present in $HOME/.claude/skills"
+    else
+        doc_line FAIL skills-installed \
+            "${#missing[@]}/${#expected[@]} cross-cutting skills missing from $HOME/.claude/skills: ${missing[*]}" \
+            "run 'ccds setup'"
+    fi
+}
+
+doc_check_bom() {
+    local f
+    local -a hits=()
+    for f in "$HOME/.claude/agents"/*.md "$HOME/.claude/skills"/*/SKILL.md; do
+        [[ -f "$f" ]] || continue
+        if [[ "$(head -c 3 "$f" | od -An -tx1 | tr -d ' \n')" == "efbbbf" ]]; then
+            hits+=("$f")
+        fi
+    done
+    if (( ${#hits[@]} == 0 )); then
+        doc_line OK bom-scan "no UTF-8 BOM in installed agents or skills"
+    else
+        doc_line FAIL bom-scan \
+            "${#hits[@]} installed file(s) start with a UTF-8 BOM, which makes Claude Code silently skip the frontmatter (ADR-0001): ${hits[*]}" \
+            "run 'ccds setup' to restore clean copies; re-save any hand-edited file as UTF-8 without BOM"
+    fi
+}
+
+doc_check_crlf() {
+    local -a hits=()
+    mapfile -t hits < <(find "$INSTALL_ROOT" -name '*.sh' -type f -not -path '*/.git/*' \
+        -exec grep -lI $'\r' {} + 2>/dev/null || true)
+    if (( ${#hits[@]} == 0 )); then
+        doc_line OK crlf-scan "no CR bytes in *.sh under $INSTALL_ROOT"
+    else
+        doc_line WARN crlf-scan \
+            "${#hits[@]} shell script(s) under $INSTALL_ROOT contain CR (CRLF) bytes: ${hits[*]}" \
+            "normalize to LF (e.g. sed -i 's/\\r\$//' <file>) or reinstall via 'ccds update'"
+    fi
+}
+
+doc_check_claude_block() {
+    local md="$HOME/.claude/CLAUDE.md"
+    if [[ ! -f "$md" ]]; then
+        doc_line FAIL claude-md-block "$md not found -- the ccds pointer block is not installed" "run 'ccds setup'"
+        return
+    fi
+    local nb ne
+    nb="$(grep -cF '# >>> ccds >>>' "$md" || true)"
+    ne="$(grep -cF '# <<< ccds <<<' "$md" || true)"
+    if [[ "$nb" == "1" && "$ne" == "1" ]]; then
+        doc_line OK claude-md-block "exactly one ccds marker block in $md"
+    else
+        doc_line FAIL claude-md-block \
+            "expected exactly one ccds block in $md; found $nb begin / $ne end marker(s)" \
+            "run 'ccds setup' (it strips duplicate/broken blocks and reinjects a single fresh one)"
+    fi
+}
+
+doc_check_catalog() {
+    local cat="$LIBRARY_ROOT/catalog.json"
+    if [[ ! -f "$cat" ]]; then
+        doc_line FAIL catalog "catalog.json not found at $cat" \
+            "reinstall via 'ccds update' (or regenerate with scripts/build-catalog.py in a repo clone)"
+        return
+    fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        doc_line WARN catalog \
+            "$cat present; python3 not found so JSON validity was not checked" \
+            "install python3 to enable the parse check"
+        return
+    fi
+    if python3 -c 'import json, sys; json.load(open(sys.argv[1], encoding="utf-8"))' "$cat" >/dev/null 2>&1; then
+        doc_line OK catalog "$cat parses as valid JSON"
+    else
+        doc_line FAIL catalog "$cat is not valid JSON" \
+            "regenerate with scripts/build-catalog.py or reinstall via 'ccds update'"
+    fi
+}
+
+doc_check_path_duals() {
+    local resolved dual=0
+    resolved="$(command -v ccds 2>/dev/null || true)"
+    [[ -d /usr/share/ccds && -d "$HOME/.claude/playbook" ]] && dual=1
+    if (( dual )); then
+        doc_line WARN path-and-duals \
+            "both /usr/share/ccds (system package) and $HOME/.claude/playbook (per-user) are installed; this shell runs: ${resolved:-<none -- ccds not on PATH>}" \
+            "keep one install: 'sudo apt remove ccds' for the system package, or 'ccds uninstall' from the per-user copy"
+    elif [[ -z "$resolved" ]]; then
+        doc_line WARN path-and-duals \
+            "'ccds' is not resolvable on PATH (this run used $SCRIPT_PATH)" \
+            "add $BIN_DIR to PATH (the installer normally does this) or re-run the installer"
+    else
+        doc_line OK path-and-duals "ccds resolves to $resolved"
+    fi
+}
+
+cmd_doctor() {
+    # Registry: check-name -> check function. Adding a check = one function
+    # plus one row here.
+    local -a checks=(
+        "layout:doc_check_layout"
+        "version:doc_check_version"
+        "agents-installed:doc_check_agents"
+        "skills-installed:doc_check_skills"
+        "bom-scan:doc_check_bom"
+        "crlf-scan:doc_check_crlf"
+        "claude-md-block:doc_check_claude_block"
+        "catalog:doc_check_catalog"
+        "path-and-duals:doc_check_path_duals"
+    )
+
+    echo "ccds doctor -- environment checks (version $(installed_version), $LAYOUT_KIND layout)"
+    echo
+    local entry
+    for entry in "${checks[@]}"; do
+        "${entry#*:}"
+    done
+    echo
+    echo '=== ccds doctor summary ==='
+    printf 'OK    : %d\nWARN  : %d\nFAIL  : %d\n' "$DOC_OK" "$DOC_WARN" "$DOC_FAIL"
+    if (( DOC_FAIL > 0 )); then
+        echo 'RESULT: FAIL'
+        exit 1
+    fi
+    echo 'RESULT: PASS'
+    exit 0
 }
 
 cmd_lint() {
@@ -386,6 +640,7 @@ COMMAND="${COMMAND//$'\r'/}"
 if   [[ "$COMMAND" == "setup"     ]]; then cmd_setup
 elif [[ "$COMMAND" == "sync"      ]]; then cmd_sync
 elif [[ "$COMMAND" == "verify"    ]]; then cmd_verify
+elif [[ "$COMMAND" == "doctor"    ]]; then cmd_doctor
 elif [[ "$COMMAND" == "lint"      ]]; then cmd_lint
 elif [[ "$COMMAND" == "loop"      ]]; then cmd_loop
 elif [[ "$COMMAND" == "update"    ]]; then cmd_update

--- a/scripts/ccds-completion.bash
+++ b/scripts/ccds-completion.bash
@@ -22,7 +22,7 @@ _ccds_completion() {
         cword=$COMP_CWORD
     }
 
-    local commands="sync verify loop update uninstall version help"
+    local commands="sync verify doctor loop update uninstall version help"
     local packs="game saas mobile ai dataplat ecom fintech devtool desktop ext embed media orch infra common"
     local sync_flags="--dry-run --write-adr --no-generalists --mode --target --help -h"
     local update_flags="--rollback --include-prerelease --dry-run --help -h"
@@ -34,7 +34,7 @@ _ccds_completion() {
     local i
     for ((i=1; i < cword; i++)); do
         case "${words[i]}" in
-            sync|verify|loop|update|uninstall|version|help)
+            sync|verify|doctor|loop|update|uninstall|version|help)
                 command="${words[i]}"
                 break
                 ;;
@@ -97,7 +97,7 @@ _ccds_completion() {
             fi
             return 0
             ;;
-        verify|uninstall|version|help)
+        verify|doctor|uninstall|version|help)
             mapfile -t COMPREPLY < <(compgen -W "$global_flags" -- "$cur")
             return 0
             ;;

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -541,6 +541,112 @@ class TestLoopInit(unittest.TestCase):
 
 
 @unittest.skipUnless(BASH and sys.platform != "win32",
+                     "ccds.sh is a bash dispatcher (POSIX shells only)")
+class TestCcdsDoctor(unittest.TestCase):
+    """`ccds doctor` proactive environment checks.
+
+    Stages an installed-layout copy of the dispatcher (bin/ + scripts/ +
+    catalog.json + version.txt) in a temp dir and points HOME at a synthetic
+    healthy ~/.claude, so every check runs against a controlled environment.
+    CCDS_DOCTOR_RELEASE_URL (test-only override, documented in bin/ccds.sh)
+    points the version check at an unreachable local port so tests never
+    touch the network and deterministically exercise the offline WARN path.
+    """
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="ccds-doctor-test-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+        # Stage an installed-layout root (scripts/Sync-AgentPacks.sh present,
+        # not under /usr/share/ccds -> LAYOUT_KIND="installed").
+        self.inst = os.path.join(self.root, "playbook")
+        os.makedirs(os.path.join(self.inst, "bin"))
+        os.makedirs(os.path.join(self.inst, "scripts"))
+        shutil.copy(os.path.join(REPO_ROOT, "bin", "ccds.sh"),
+                    os.path.join(self.inst, "bin", "ccds.sh"))
+        shutil.copy(os.path.join(REPO_ROOT, "Sync-AgentPacks.sh"),
+                    os.path.join(self.inst, "scripts", "Sync-AgentPacks.sh"))
+        shutil.copy(os.path.join(REPO_ROOT, "verify-agents.sh"),
+                    os.path.join(self.inst, "scripts", "verify-agents.sh"))
+        shutil.copy(os.path.join(SCRIPTS, "ccds-user-setup.sh"),
+                    os.path.join(self.inst, "scripts", "ccds-user-setup.sh"))
+        shutil.copy(os.path.join(REPO_ROOT, "catalog.json"),
+                    os.path.join(self.inst, "catalog.json"))
+        write(os.path.join(self.inst, "version.txt"), "0.0.1\n")
+
+        # Synthetic healthy HOME: core-agent sentinel, every global skill,
+        # exactly one ccds marker block.
+        self.home = os.path.join(self.root, "home")
+        write(os.path.join(self.home, ".claude", "agents", "plan-architect.md"),
+              "---\nname: plan-architect\ndescription: test\n---\nbody\n")
+        for name in self._global_skills():
+            write(os.path.join(self.home, ".claude", "skills", name, "SKILL.md"),
+                  f"---\nname: {name}\ndescription: test\n---\nbody\n")
+        write(os.path.join(self.home, ".claude", "CLAUDE.md"),
+              "# my own notes\n\n# >>> ccds >>>\nblock body\n# <<< ccds <<<\n")
+
+    @staticmethod
+    def _global_skills():
+        """Parse GLOBAL_SKILLS out of the setup script (same source doctor uses)."""
+        src = read(os.path.join(SCRIPTS, "ccds-user-setup.sh"))
+        block = src.split("GLOBAL_SKILLS=(", 1)[1].split(")", 1)[0]
+        return [ln.strip() for ln in block.splitlines()
+                if ln.strip() and not ln.strip().startswith("#")]
+
+    def doctor(self):
+        env = {**os.environ,
+               "HOME": self.home,
+               # unreachable (discard-port) URL: forces the offline WARN path
+               "CCDS_DOCTOR_RELEASE_URL": "http://127.0.0.1:9/releases/latest"}
+        return subprocess.run(
+            [BASH, os.path.join(self.inst, "bin", "ccds.sh"), "doctor"],
+            capture_output=True, text=True, env=env)
+
+    def test_healthy_home_passes(self):
+        r = self.doctor()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("RESULT: PASS", r.stdout)
+        self.assertIn("FAIL  : 0", r.stdout)
+
+    def test_missing_core_agent_fails(self):
+        os.remove(os.path.join(self.home, ".claude", "agents", "plan-architect.md"))
+        r = self.doctor()
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  agents-installed", r.stdout)
+        self.assertIn("remedy: run 'ccds setup'", r.stdout)
+
+    def test_missing_global_skill_fails(self):
+        shutil.rmtree(os.path.join(self.home, ".claude", "skills", "loop-compound"))
+        r = self.doctor()
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  skills-installed", r.stdout)
+        self.assertIn("loop-compound", r.stdout)
+
+    def test_bom_in_skill_fails(self):
+        p = os.path.join(self.home, ".claude", "skills", "loop-verify", "SKILL.md")
+        with open(p, "rb") as f:
+            content = f.read()
+        with open(p, "wb") as f:
+            f.write(b"\xef\xbb\xbf" + content)
+        r = self.doctor()
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  bom-scan", r.stdout)
+
+    def test_duplicate_marker_block_fails(self):
+        md = os.path.join(self.home, ".claude", "CLAUDE.md")
+        write(md, read(md) + "\n# >>> ccds >>>\ndupe\n# <<< ccds <<<\n")
+        r = self.doctor()
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  claude-md-block", r.stdout)
+
+    def test_offline_version_check_warns_not_fails(self):
+        r = self.doctor()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("WARN  version", r.stdout)
+        self.assertIn("could not check", r.stdout)
+
+
+@unittest.skipUnless(BASH and sys.platform != "win32",
                      "postinst is a bash maintainer script (POSIX shells only)")
 class TestDebPostinst(unittest.TestCase):
     """Regression tests for the Debian/RPM postinst per-user setup.


### PR DESCRIPTION
## Summary

Turns every environment-bug class this repo has shipped (BOM frontmatter, CRLF, silent no-op installs, stale versions, dual installs, dev-vs-packaged layout confusion) into proactive, table-driven checks: `ccds doctor` prints OK/WARN/FAIL per check with a remedy line, exits 0 unless something FAILs.

## What changed and why

- `cmd_doctor` in `bin/ccds.sh`: 9 checks (layout, version-vs-latest with offline-safe WARN, agents/skills installed, BOM scan, CRLF scan, CLAUDE.md marker block, catalog parse, PATH + dual-install detection). GLOBAL_SKILLS extracted from the setup script at runtime — no second copy to drift. Help/completion updated; PowerShell twin noted as follow-up in the changelog.
- 6 pytest cases incl. an offline version-check path via a test-only `CCDS_DOCTOR_RELEASE_URL` override.

## Verification

Real-machine run: 7 OK / 2 WARN / PASS — and it immediately caught a **genuine dual install on the maintainer's machine** (system deb + per-user copy). Independently re-run by the coordinating session with the same result. Suite: 50 passed; `bash -n` clean; ShellCheck in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)