### PR TITLE
feat(evals): routing-eval harness — golden prompts + ambiguity lint for the description surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,19 @@ jobs:
       - name: Run lint-playbook.py
         run: python3 scripts/lint-playbook.py
 
+  routing-eval:
+    name: Routing eval (deterministic)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run eval-routing.py (golden prompts)
+        run: python3 scripts/eval-routing.py
+
+      - name: Report description-ambiguity pairs (informational)
+        run: python3 scripts/eval-routing.py --ambiguity
+
   python-tests:
     name: Script tests
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## Unreleased — 2026-07-03 — feat: routing evals
+
+### Added
+
+- **Routing-eval harness** (`scripts/eval-routing.py` +
+  `evals/routing/golden.json`): the library's core convention — "descriptions
+  are the routing surface" — finally has tests. 53 golden prompts written the
+  way users actually phrase tasks ("our checkout double-charges people on
+  retry"), 3 per domain pack plus core/loop coverage and 5 should-route-nowhere
+  negatives, are scored against all 115 catalog entries by TF-IDF cosine.
+  A description edit that breaks routing for a realistic task now fails CI
+  instead of being discovered by a mis-routed agent in the field. Current
+  baseline: 53/53 pass (48 positive in top-3, 5 negatives under the floor).
+- **Ambiguity lint** (`eval-routing.py --ambiguity`): reports catalog
+  description pairs whose lexical overlap exceeds a calibrated threshold — the
+  pairs most likely to steal each other's traffic. Today's honest list is 13
+  pairs, headed by desktop-autoupdate↔embed-ota (0.38),
+  ext-architect↔ext-native-messaging (0.37) and
+  ai-prompt-engineer↔orch-prompt-engineer (0.36) — known siblings, now
+  measured instead of assumed.
+- **`--llm` mode** (release-time, spends API tokens): asks `claude -p` to pick
+  the single catalog entry per golden prompt, majority of `--votes`. This is
+  the true routing-accuracy measurement; the deterministic mode is the cheap
+  per-PR lexical proxy. Plumbing proven live on 2 prompts (haiku): positive
+  routed correctly, negative returned NONE.
+- CI: new `routing-eval` job runs the deterministic golden suite plus the
+  informational ambiguity report on every PR; 8 new fixture tests cover the
+  runner (obvious-match pass, wrong-expect fail, known-gap WARN, unknown
+  expect name → exit 2).
+
+---
+
 ## Unreleased — 2026-07-04 — feat: repo hook makes the eval-cadence rule deterministic
 
 ### Added

--- a/evals/routing/golden.json
+++ b/evals/routing/golden.json
@@ -1,0 +1,275 @@
+{
+  "comment": "Golden routing prompts for eval-routing.py. Written as a USER would phrase a task — realistic vocabulary, never the description text verbatim. 'expect' lists acceptable targets (any in top-K passes). 'negative': true = should route nowhere (top-1 score must stay under the floor). 'known_gap': true = a real routing gap we chose to keep visible — reported as WARN, not FAIL, so CI stays green while the gap is documented in 'note'.",
+  "cases": [
+    {
+      "id": "ai-rag-wrong-docs",
+      "prompt": "Our support bot keeps answering from the wrong documents — I think the chunking and embeddings need rework.",
+      "expect": ["ai-rag", "ai-architect"]
+    },
+    {
+      "id": "ai-inference-cost",
+      "prompt": "Inference cost tripled this month — look into batching and quantization to cut the GPU bill.",
+      "expect": ["ai-inference-perf", "ai-architect"]
+    },
+    {
+      "id": "ai-safety-injection",
+      "prompt": "Someone got our assistant to ignore its instructions with a prompt injection hidden in an uploaded file.",
+      "expect": ["ai-safety", "orch-sandbox-safety"]
+    },
+    {
+      "id": "dataplat-etl-dag",
+      "prompt": "The nightly dbt run keeps failing and the Airflow retries land duplicate rows in the warehouse.",
+      "expect": ["dataplat-etl", "dataplat-architect"]
+    },
+    {
+      "id": "dataplat-quality-stale",
+      "prompt": "A downstream dashboard is showing bad data — the source table blew its freshness SLA and none of our quality checks caught it.",
+      "expect": ["dataplat-quality", "dataplat-architect"]
+    },
+    {
+      "id": "dataplat-sql-slow",
+      "prompt": "This analytical query with three window functions takes twenty minutes — tune the joins and partition pruning.",
+      "expect": ["dataplat-sql", "dataplat-architect"]
+    },
+    {
+      "id": "desktop-ipc-freeze",
+      "prompt": "Our Electron renderer freezes whenever the main process streams a large payload across the bridge.",
+      "expect": ["desktop-ipc", "desktop-architect"]
+    },
+    {
+      "id": "desktop-signing-blocked",
+      "prompt": "Windows flags our app's signature as invalid and macOS Gatekeeper blocks it — something is wrong with the signing certificates.",
+      "expect": ["desktop-code-signing", "desktop-architect"]
+    },
+    {
+      "id": "desktop-update-stuck",
+      "prompt": "Beta-channel users are stuck on an old build; the in-app update never downloads and there's no rollback.",
+      "expect": ["desktop-autoupdate", "desktop-architect"]
+    },
+    {
+      "id": "devtool-cli-flags",
+      "prompt": "Our CLI's flag naming is inconsistent and the error messages don't tell people what to do next.",
+      "expect": ["devtool-cli-ux", "devtool-architect"]
+    },
+    {
+      "id": "devtool-release-pipeline",
+      "prompt": "Publish the library to npm and PyPI from CI with signed artifacts and an SBOM.",
+      "expect": ["devtool-packaging", "devtool-architect"]
+    },
+    {
+      "id": "devtool-public-api-v2",
+      "prompt": "We're shipping v2 of the public API — work out what signatures break and how deprecations get versioned.",
+      "expect": ["devtool-library-api", "devtool-architect"]
+    },
+    {
+      "id": "ecom-double-charge",
+      "prompt": "Our checkout double-charges people when they retry a failed payment.",
+      "expect": ["ecom-payments", "ecom-architect"]
+    },
+    {
+      "id": "ecom-oversell",
+      "prompt": "Flash sales oversell our inventory — two shoppers can both buy the last unit in stock at the same time.",
+      "expect": ["ecom-inventory", "ecom-architect"]
+    },
+    {
+      "id": "ecom-promo-negative-total",
+      "prompt": "Customers stack coupons with a gift card and the order total goes negative.",
+      "expect": ["ecom-promotions", "ecom-architect"]
+    },
+    {
+      "id": "embed-battery-drain",
+      "prompt": "Our battery sensor nodes die in a week — they never enter deep sleep between readings.",
+      "expect": ["embed-power", "embed-architect"]
+    },
+    {
+      "id": "embed-ota-bricked",
+      "prompt": "Half the fleet bricked after the last firmware update; we need resumable A/B firmware updates with rollback.",
+      "expect": ["embed-ota", "embed-architect"]
+    },
+    {
+      "id": "embed-driver-dma",
+      "prompt": "The I2C sensor driver drops readings when the DMA interrupt fires mid-transfer.",
+      "expect": ["embed-driver", "embed-architect"]
+    },
+    {
+      "id": "ext-permissions-rejected",
+      "prompt": "Chrome review rejected us for requesting access to all sites — trim the extension's host permissions and justify the rest.",
+      "expect": ["ext-permissions", "ext-architect"]
+    },
+    {
+      "id": "ext-content-script-spoof",
+      "prompt": "Our content script reads page data — make sure a malicious page can't spoof messages into the extension.",
+      "expect": ["ext-security", "ext-architect"]
+    },
+    {
+      "id": "ext-native-helper",
+      "prompt": "The extension needs to talk to a local desktop helper process over stdio.",
+      "expect": ["ext-native-messaging", "ext-architect"]
+    },
+    {
+      "id": "fintech-balance-drift",
+      "prompt": "Account balances drift a cent from the sum of postings after currency conversion.",
+      "expect": ["fintech-ledger", "fintech-architect"]
+    },
+    {
+      "id": "fintech-audit-request",
+      "prompt": "Regulators asked for a tamper-proof audit log of who changed each customer's limits and when.",
+      "expect": ["fintech-audit-trail", "fintech-architect"]
+    },
+    {
+      "id": "fintech-sanctions",
+      "prompt": "New signups from certain countries need sanctions screening before they can move money.",
+      "expect": ["fintech-compliance", "fintech-architect"]
+    },
+    {
+      "id": "game-feel-floaty",
+      "prompt": "The jump feels floaty and hits have no impact — punch it up with hitstop and screen shake.",
+      "expect": ["game-feel-critic", "game-architect"]
+    },
+    {
+      "id": "game-frame-drops",
+      "prompt": "Frame rate tanks to 20fps in the boss arena — profile the draw calls and GC spikes.",
+      "expect": ["game-perf-profiler", "game-architect"]
+    },
+    {
+      "id": "game-netcode-rubberband",
+      "prompt": "Players rubber-band in multiplayer — we need client prediction and lag compensation.",
+      "expect": ["game-netcode", "game-architect"]
+    },
+    {
+      "id": "infra-slo-oncall",
+      "prompt": "Set SLOs and an error-budget policy for the API, and fix our on-call escalation while you're at it.",
+      "expect": ["infra-sre", "infra-architect"]
+    },
+    {
+      "id": "infra-cloud-cost",
+      "prompt": "Our cloud cost doubled last quarter — right-size the instances and plan reserved capacity purchases.",
+      "expect": ["infra-finops", "infra-architect"]
+    },
+    {
+      "id": "infra-k8s-ingress",
+      "prompt": "Pods in the new namespace can't reach the payments service — sort out the Kubernetes ingress and RBAC.",
+      "expect": ["infra-k8s", "infra-architect"]
+    },
+    {
+      "id": "media-live-latency",
+      "prompt": "Viewers get thirty seconds of startup buffering on live matches — tighten glass-to-glass latency and failover.",
+      "expect": ["media-live", "media-architect"]
+    },
+    {
+      "id": "media-encode-ladder",
+      "prompt": "Build the ffmpeg bitrate ladder for per-title encoding and package the output as HLS.",
+      "expect": ["media-transcode", "media-architect"]
+    },
+    {
+      "id": "media-drm-failures",
+      "prompt": "Widevine license requests fail on smart TVs and rebuffering spiked on one CDN.",
+      "expect": ["media-drm-cdn", "media-architect"]
+    },
+    {
+      "id": "mobile-cold-start",
+      "prompt": "Cold start on Android is six seconds and scrolling the feed has visible jank.",
+      "expect": ["mobile-perf", "mobile-architect"]
+    },
+    {
+      "id": "mobile-symbolication",
+      "prompt": "Crash symbolication broke after we enabled R8 — every stack trace is gibberish now.",
+      "expect": ["mobile-crash", "mobile-architect"]
+    },
+    {
+      "id": "mobile-iap-restore",
+      "prompt": "Purchases made on the App Store don't restore after reinstall, and refund handling leaves people with access.",
+      "expect": ["mobile-iap", "mobile-architect"]
+    },
+    {
+      "id": "orch-tool-confusion",
+      "prompt": "Our agent keeps calling the wrong tool — the tool descriptions and schema must be confusing it.",
+      "expect": ["orch-tool-design", "orch-architect"]
+    },
+    {
+      "id": "orch-eval-regression",
+      "prompt": "Add a regression eval suite so we notice when the agent gets worse after a prompt change.",
+      "expect": ["orch-eval", "ai-eval", "orch-architect"]
+    },
+    {
+      "id": "orch-sandbox-lockdown",
+      "prompt": "The agent can run shell commands — lock it down with execution isolation and a network allowlist.",
+      "expect": ["orch-sandbox-safety", "orch-architect"]
+    },
+    {
+      "id": "saas-tenant-leak",
+      "prompt": "A customer saw another tenant's invoices — audit our row-level security policies and tenant scoping.",
+      "expect": ["saas-multitenancy", "saas-architect", "secure-auditor"]
+    },
+    {
+      "id": "saas-billing-webhooks",
+      "prompt": "Stripe webhooks for plan upgrades get dropped, so entitlement checks still see the old plan after payment.",
+      "expect": ["saas-billing", "saas-architect"]
+    },
+    {
+      "id": "saas-sso-scim",
+      "prompt": "Enterprise customers want SAML SSO with SCIM provisioning for their directories.",
+      "expect": ["saas-auth-sso", "saas-architect"]
+    },
+    {
+      "id": "loop-verify-it-compiles",
+      "prompt": "It compiles — just say the task is complete and update the status to done.",
+      "expect": ["loop-verify"]
+    },
+    {
+      "id": "loop-debug-fix-didnt-stick",
+      "prompt": "The fix I tried didn't stick — the test is failing again and the root cause still isn't proven.",
+      "expect": ["loop-debug"]
+    },
+    {
+      "id": "loop-review-fresh-eyes",
+      "prompt": "The diff is ready — get a fresh pair of eyes to review it before we merge.",
+      "expect": ["loop-review", "pr-code-reviewer", "code-review-checklist"]
+    },
+    {
+      "id": "loop-compound-same-mistake",
+      "prompt": "That's the second time we've made this exact mistake — capture the learning somewhere permanent so the next session doesn't repeat it.",
+      "expect": ["loop-compound"]
+    },
+    {
+      "id": "core-api-contracts",
+      "prompt": "Design the REST endpoints and webhook payload contracts for the partner integration.",
+      "expect": ["api-design", "devtool-library-api"]
+    },
+    {
+      "id": "core-ux-form",
+      "prompt": "The signup forms have confusing error states and the layout collapses on narrow screens.",
+      "expect": ["ux-design", "common-a11y"]
+    },
+    {
+      "id": "neg-haiku",
+      "prompt": "Write a haiku about autumn leaves.",
+      "expect": [],
+      "negative": true
+    },
+    {
+      "id": "neg-trivia",
+      "prompt": "What is the capital of Australia?",
+      "expect": [],
+      "negative": true
+    },
+    {
+      "id": "neg-dinner",
+      "prompt": "Plan a birthday dinner for eight people who all like seafood.",
+      "expect": [],
+      "negative": true
+    },
+    {
+      "id": "neg-summarize",
+      "prompt": "Summarize this news article in two sentences.",
+      "expect": [],
+      "negative": true
+    },
+    {
+      "id": "neg-workout",
+      "prompt": "Suggest a beginner workout routine for three days a week.",
+      "expect": [],
+      "negative": true
+    }
+  ]
+}

--- a/scripts/eval-routing.py
+++ b/scripts/eval-routing.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+eval-routing.py — routing eval for the catalog's description surface.
+
+CLAUDE.md: "Descriptions are the routing surface." This harness treats routing
+as a retrieval problem: every golden prompt in evals/routing/golden.json is
+scored against every catalog entry by TF-IDF cosine over lowercase word tokens
+of `name + description` (document frequencies from the catalog corpus itself).
+A positive case passes when any of its acceptable targets lands in the top-K
+(default 3); a negative case ("write a haiku") passes when its best score
+stays under --floor. Cases marked "known_gap" report WARN, not FAIL — a
+documented gap stays visible without breaking CI.
+
+Be honest about what this measures: the deterministic mode is an
+ambiguity/regression LINT — a lexical proxy for routing, cheap and
+reproducible, good at catching description drift, keyword collisions, and
+vocabulary that no user would ever hit. It is NOT a routing-accuracy
+measurement; the model routes semantically, not lexically. --llm is the
+accuracy mode: it asks `claude -p` to pick the single catalog entry per prompt
+(majority of --votes). That spends real API tokens — release time only.
+
+--ambiguity ignores golden.json entirely and reports catalog description
+pairs whose cosine exceeds --threshold (description text only — names are
+excluded so shared pack prefixes don't inflate the score). Informational:
+always exits 0.
+
+Usage:
+    python3 scripts/eval-routing.py [repo-root] [options]
+
+Options:
+    --top-k N        positive passes if an expected name is in top-N (default 3)
+    --floor F        negative passes if its top-1 score is below F (default
+                     0.12 — calibrated 2026-07-03: the worst real-catalog
+                     negative scores 0.104 ("write a haiku" grazing
+                     loop-compound on the shared token "write"); expected-hit
+                     scores for positives run 0.096-0.457, but the floor gates
+                     negatives only)
+    --ambiguity      report catalog description pairs with cosine >= --threshold
+    --threshold F    ambiguity report floor (default 0.25 — calibrated
+                     2026-07-03: yields 13 pairs on the 115-entry catalog,
+                     all real sibling overlaps; 0.30 hides all but 3, 0.20
+                     admits noise)
+    --llm            route each golden prompt via `claude -p`; EXPENSIVE
+    --votes N        llm runs per prompt, majority decides (default 3)
+    --model NAME     model alias passed to claude -p (default haiku)
+    --only ID        run a single golden case
+    --dry-run        validate golden.json against catalog.json, run nothing
+
+Exit codes: 0 = all pass, 1 = failures, 2 = config error.
+"""
+
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def parse_args(argv):
+    args = {"root": None, "top_k": 3, "floor": 0.12, "ambiguity": False,
+            "threshold": 0.25, "llm": False, "votes": 3, "model": "haiku",
+            "only": None, "dry_run": False}
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--top-k":
+            args["top_k"] = int(argv[i + 1]); i += 2
+        elif a == "--floor":
+            args["floor"] = float(argv[i + 1]); i += 2
+        elif a == "--ambiguity":
+            args["ambiguity"] = True; i += 1
+        elif a == "--threshold":
+            args["threshold"] = float(argv[i + 1]); i += 2
+        elif a == "--llm":
+            args["llm"] = True; i += 1
+        elif a == "--votes":
+            args["votes"] = int(argv[i + 1]); i += 2
+        elif a == "--model":
+            args["model"] = argv[i + 1]; i += 2
+        elif a == "--only":
+            args["only"] = argv[i + 1]; i += 2
+        elif a == "--dry-run":
+            args["dry_run"] = True; i += 1
+        elif a.startswith("--"):
+            print(f"ERROR: unknown flag {a}", file=sys.stderr); sys.exit(2)
+        else:
+            args["root"] = a; i += 1
+    args["root"] = os.path.abspath(args["root"] or os.path.dirname(SCRIPT_DIR))
+    return args
+
+
+def tokenize(text):
+    return TOKEN_RE.findall(text.lower())
+
+
+def load_catalog(root):
+    path = os.path.join(root, "catalog.json")
+    if not os.path.isfile(path):
+        print(f"ERROR: not found: {path}", file=sys.stderr); sys.exit(2)
+    with open(path, encoding="utf-8") as f:
+        catalog = json.load(f)
+    if not catalog:
+        print("ERROR: catalog.json is empty", file=sys.stderr); sys.exit(2)
+    return catalog
+
+
+def load_golden(root, catalog_names):
+    path = os.path.join(root, "evals", "routing", "golden.json")
+    if not os.path.isfile(path):
+        print(f"ERROR: not found: {path}", file=sys.stderr); sys.exit(2)
+    with open(path, encoding="utf-8") as f:
+        cases = json.load(f).get("cases", [])
+    problems, seen = [], set()
+    for c in cases:
+        cid = c.get("id", "<no id>")
+        for key in ("id", "prompt", "expect"):
+            if key not in c:
+                problems.append(f"{cid}: missing '{key}'")
+        if cid in seen:
+            problems.append(f"{cid}: duplicate id")
+        seen.add(cid)
+        for name in c.get("expect", []):
+            if name not in catalog_names:
+                problems.append(f"{cid}: expect name not in catalog: {name!r}")
+        if c.get("negative") and c.get("expect"):
+            problems.append(f"{cid}: negative case must have empty expect")
+        if not c.get("negative") and not c.get("expect"):
+            problems.append(f"{cid}: positive case needs at least one expect")
+    if problems:
+        for p in problems:
+            print(f"ERROR: {p}", file=sys.stderr)
+        sys.exit(2)
+    return cases
+
+
+class Tfidf:
+    """TF-IDF vectors over the catalog corpus; cosine via normalized dot."""
+
+    def __init__(self, docs):
+        self.n = len(docs)
+        self.df = Counter()
+        for tokens in docs:
+            self.df.update(set(tokens))
+        self.idf = {t: math.log(self.n / df) for t, df in self.df.items()}
+
+    def vector(self, tokens, count_oov=False):
+        """Normalized TF-IDF vector. With count_oov (queries), tokens outside
+        the catalog vocabulary still contribute to the norm at max idf —
+        unknown vocabulary is evidence the prompt is off-catalog, so it should
+        pull the cosine down rather than silently vanish."""
+        tf = Counter(tokens)
+        oov_idf = math.log(self.n)
+        vec = {t: c * self.idf[t] for t, c in tf.items() if t in self.idf}
+        sq = sum(w * w for w in vec.values())
+        if count_oov:
+            sq += sum((c * oov_idf) ** 2 for t, c in tf.items()
+                      if t not in self.idf)
+        norm = math.sqrt(sq)
+        return {t: w / norm for t, w in vec.items()} if norm else {}
+
+    @staticmethod
+    def cosine(a, b):
+        if len(b) < len(a):
+            a, b = b, a
+        return sum(w * b[t] for t, w in a.items() if t in b)
+
+
+def rank(model, entry_vecs, prompt):
+    qv = model.vector(tokenize(prompt), count_oov=True)
+    scored = [(model.cosine(qv, ev), name) for name, ev in entry_vecs]
+    scored.sort(key=lambda s: (-s[0], s[1]))
+    return scored
+
+
+def run_deterministic(cases, catalog, args):
+    # Score against name + description: both are visible to the router.
+    docs = [tokenize(e["name"] + " " + e["description"]) for e in catalog]
+    model = Tfidf(docs)
+    entry_vecs = [(e["name"], model.vector(d)) for e, d in zip(catalog, docs)]
+
+    failures = warns = 0
+    for c in cases:
+        scored = rank(model, entry_vecs, c["prompt"])
+        top = scored[:args["top_k"]]
+        top_str = " ".join(f"{n}({s:.3f})" for s, n in top)
+        if c.get("negative"):
+            passed = top[0][0] < args["floor"]
+            detail = f"top1: {top_str.split(' ')[0]} floor {args['floor']}"
+        else:
+            passed = any(n in c["expect"] for _, n in top)
+            detail = f"top{args['top_k']}: {top_str}"
+        if passed:
+            print(f"  PASS  {c['id']:28s} {detail}")
+        elif c.get("known_gap"):
+            warns += 1
+            print(f"  WARN  {c['id']:28s} known gap — {detail}")
+            if c.get("note"):
+                print(f"        note: {c['note']}")
+        else:
+            failures += 1
+            print(f"  FAIL  {c['id']:28s} {detail}"
+                  + ("" if c.get("negative") else f"  wanted: {c['expect']}"))
+    return failures, warns
+
+
+def run_ambiguity(catalog, args):
+    # Descriptions only: names share pack prefixes, which would inflate cosine.
+    docs = [tokenize(e["description"]) for e in catalog]
+    model = Tfidf(docs)
+    vecs = [(e["name"], model.vector(d)) for e, d in zip(catalog, docs)]
+    pairs = []
+    for i in range(len(vecs)):
+        for j in range(i + 1, len(vecs)):
+            s = model.cosine(vecs[i][1], vecs[j][1])
+            if s >= args["threshold"]:
+                pairs.append((s, vecs[i][0], vecs[j][0]))
+    pairs.sort(key=lambda p: (-p[0], p[1], p[2]))
+    for s, a, b in pairs:
+        print(f"  {s:.3f}  {a} <-> {b}")
+    print()
+    print("=== routing-eval summary (ambiguity) ===")
+    print(f"Entries   : {len(catalog)}")
+    print(f"Pairs >= {args['threshold']}: {len(pairs)}")
+    print("RESULT: PASS (informational)")
+    return 0
+
+
+LLM_PROMPT = """A user gave this task to a development assistant:
+
+{prompt}
+
+The assistant routes tasks using this catalog of agents and skills
+(one per line, "name: description"):
+
+{listing}
+
+Which single catalog entry should handle the task? Reply with exactly one
+catalog name, or NONE if no entry applies. Reply with only the name."""
+
+
+def llm_vote(prompt, listing, names, model_alias):
+    r = subprocess.run(
+        ["claude", "-p", LLM_PROMPT.format(prompt=prompt, listing=listing),
+         "--model", model_alias],
+        capture_output=True, text=True, timeout=300)
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"claude -p failed (exit {r.returncode}): {r.stderr.strip()[:200]}")
+    reply = r.stdout.strip()
+    if reply in names:
+        return reply
+    if "NONE" in reply:
+        return "NONE"
+    # Tolerate prose around the name: longest catalog name present wins.
+    hits = [n for n in names if re.search(rf"\b{re.escape(n)}\b", reply)]
+    return max(hits, key=len) if hits else reply.split()[-1] if reply else ""
+
+
+def run_llm(cases, catalog, args):
+    listing = "\n".join(f"{e['name']}: {e['description']}" for e in catalog)
+    names = {e["name"] for e in catalog}
+    failures = 0
+    for c in cases:
+        votes = []
+        for v in range(args["votes"]):
+            choice = llm_vote(c["prompt"], listing, names, args["model"])
+            votes.append(choice)
+            print(f"  {c['id']} vote {v + 1}/{args['votes']}: {choice}")
+        winner, count = Counter(votes).most_common(1)[0]
+        if c.get("negative"):
+            passed = winner == "NONE"
+        else:
+            passed = winner in c["expect"] and count > args["votes"] / 2
+        print(f"{c['id']}: {'PASS' if passed else 'FAIL'} "
+              f"(winner {winner!r}, {count}/{args['votes']} votes)")
+        failures += 0 if passed else 1
+    return failures
+
+
+def main():
+    args = parse_args(sys.argv[1:])
+    catalog = load_catalog(args["root"])
+    if args["ambiguity"]:
+        return run_ambiguity(catalog, args)
+
+    names = {e["name"] for e in catalog}
+    cases = load_golden(args["root"], names)
+    if args["only"]:
+        cases = [c for c in cases if c["id"] == args["only"]]
+        if not cases:
+            print(f"ERROR: no case with id {args['only']!r}", file=sys.stderr)
+            return 2
+
+    positives = sum(1 for c in cases if not c.get("negative"))
+    negatives = len(cases) - positives
+
+    if args["dry_run"]:
+        print(f"{len(cases)} case(s) valid ({positives} positive, "
+              f"{negatives} negative); all expect names exist in the "
+              f"{len(catalog)}-entry catalog.")
+        return 0
+
+    if args["llm"]:
+        failures, warns = run_llm(cases, catalog, args), 0
+        mode = "llm"
+    else:
+        failures, warns = run_deterministic(cases, catalog, args)
+        mode = "deterministic"
+
+    print()
+    print(f"=== routing-eval summary ({mode}) ===")
+    print(f"Cases     : {len(cases)} ({positives} positive, {negatives} negative)")
+    print(f"Failures  : {failures}")
+    print(f"Known gaps: {warns} (WARN)")
+    print("RESULT: " + ("FAIL" if failures else "PASS"))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -404,6 +404,104 @@ class TestLoopComplianceEval(unittest.TestCase):
         r = self.score("no-such-scenario", "text")
 
 
+EVAL_ROUTING = os.path.join(SCRIPTS, "eval-routing.py")
+
+
+@unittest.skipUnless(os.path.isfile(EVAL_ROUTING),
+                     "eval-routing.py not on this branch yet")
+class TestRoutingEval(unittest.TestCase):
+    """Deterministic (TF-IDF) paths of the routing eval. The --llm path
+    spends API tokens and is release-time only; its plumbing was proven live
+    once (2026-07-03, 2 prompts) and shares load/rank code with these."""
+
+    def synthetic_root(self, golden_cases):
+        """Tiny catalog + golden.json in a temp root shaped like the repo."""
+        root = tempfile.mkdtemp(prefix="ccds-routing-test-")
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        catalog = [
+            {"name": "saas-billing", "pack": "saas", "kind": "skill",
+             "scope": "project", "model": "",
+             "description": "Billing integration specialist. Auto-invoked "
+                            "when Stripe webhooks are handled or proration "
+                            "logic is added."},
+            {"name": "game-netcode", "pack": "game", "kind": "skill",
+             "scope": "project", "model": "",
+             "description": "Multiplayer netcode specialist. Auto-invoked for "
+                            "client prediction, rollback, and lag "
+                            "compensation."},
+            {"name": "embed-power", "pack": "embed", "kind": "skill",
+             "scope": "project", "model": "",
+             "description": "Power management specialist. Owns sleep modes, "
+                            "duty cycling, and battery-life budgeting."},
+        ]
+        write(os.path.join(root, "catalog.json"), json.dumps(catalog))
+        write(os.path.join(root, "evals", "routing", "golden.json"),
+              json.dumps({"cases": golden_cases}))
+        return root
+
+    OBVIOUS = {"id": "billing-webhooks",
+               "prompt": "Stripe webhooks keep failing so billing proration "
+                         "is wrong.",
+               "expect": ["saas-billing"]}
+
+    def test_real_repo_deterministic_green(self):
+        r = run(EVAL_ROUTING, REPO_ROOT)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("RESULT: PASS", r.stdout)
+        self.assertIn("Failures  : 0", r.stdout)
+
+    def test_real_repo_ambiguity_mode_is_informational(self):
+        r = run(EVAL_ROUTING, REPO_ROOT, "--ambiguity")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("summary (ambiguity)", r.stdout)
+
+    def test_obvious_match_passes(self):
+        root = self.synthetic_root([self.OBVIOUS])
+        r = run(EVAL_ROUTING, root, "--top-k", "1")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("PASS  billing-webhooks", r.stdout)
+
+    def test_wrong_expect_fails(self):
+        wrong = dict(self.OBVIOUS, id="billing-mislabeled",
+                     expect=["game-netcode"])
+        root = self.synthetic_root([wrong])
+        r = run(EVAL_ROUTING, root, "--top-k", "1")
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("FAIL  billing-mislabeled", r.stdout)
+        self.assertIn("RESULT: FAIL", r.stdout)
+
+    def test_known_gap_warns_but_passes(self):
+        gap = dict(self.OBVIOUS, id="billing-gap", expect=["game-netcode"])
+        gap["known_gap"] = True
+        gap["note"] = "documented for the test"
+        root = self.synthetic_root([gap])
+        r = run(EVAL_ROUTING, root, "--top-k", "1")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("WARN  billing-gap", r.stdout)
+        self.assertIn("Known gaps: 1", r.stdout)
+
+    def test_unknown_expect_name_exits_2(self):
+        bad = dict(self.OBVIOUS, expect=["saas-billing", "no-such-skill"])
+        root = self.synthetic_root([bad])
+        r = run(EVAL_ROUTING, root)
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("no-such-skill", r.stderr)
+
+    def test_negative_prompt_passes_under_floor(self):
+        neg = {"id": "neg-poem", "prompt": "Write a sonnet about the ocean.",
+               "expect": [], "negative": True}
+        root = self.synthetic_root([neg])
+        r = run(EVAL_ROUTING, root)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("PASS  neg-poem", r.stdout)
+
+    def test_dry_run_validates_only(self):
+        r = run(EVAL_ROUTING, REPO_ROOT, "--dry-run")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("case(s) valid", r.stdout)
+        self.assertNotIn("RESULT:", r.stdout)
+
+
 EXPORT_HARNESS = os.path.join(SCRIPTS, "export-harness.py")
 
 


### PR DESCRIPTION
## Summary

"Descriptions are the routing surface" finally gets tests: 53 user-voiced golden prompts (3 per domain pack + core/loop targets + 5 negatives) scored deterministically against the 115-entry catalog by TF-IDF cosine, plus an `--ambiguity` mode reporting near-duplicate description pairs, plus an `--llm` accuracy mode for release time. Deterministic mode is framed honestly as a lexical ambiguity/regression lint, not a routing-accuracy measurement.

## What changed and why

- `evals/routing/golden.json` + `scripts/eval-routing.py` (stdlib-only, deterministic — byte-identical across runs; unknown expect-names exit 2). One algorithmic subtlety: out-of-vocabulary query tokens count in the query norm at max idf, which is what makes negatives ("write a haiku") score properly low instead of collapsing onto whatever word survives.
- Calibrated from real data: `--floor 0.12` (worst real negative 0.104), `--threshold 0.25` (13 sibling pairs; worst: desktop-autoupdate↔embed-ota 0.381, ai-prompt-engineer↔orch-prompt-engineer 0.358).
- CI job `routing-eval` (deterministic + informational ambiguity report). 8 pytest cases.

## Verification

53/53 on the real catalog (48 positives top-3, 5 negatives under floor; known-gaps empty). `--llm` plumbing proven with 2 live haiku calls. Independently re-run by the coordinating session: same numbers. Suite post-rebase onto the doctor merge: 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)