### PR TITLE
feat(cli): PowerShell doctor + setup twins, and the cli-parity lint ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## Unreleased — 2026-07-03 — feat: PowerShell doctor + cli-parity lint
+
+New standing rule from the maintainer: **"fixes and releases should be for
+every outlet"** — the bash and PowerShell dispatchers must expose the same
+command surface, forever, in the same PR.
+
+### Added
+
+- **`ccds doctor` on PowerShell** (`bin/ccds.ps1`): twin of the bash doctor
+  shipped in #40 — same 9 checks (layout, version-vs-latest with the same
+  offline-safe WARN and `CCDS_DOCTOR_RELEASE_URL` test override,
+  agents-installed sentinel, skills-installed, BOM scan per ADR-0001, CRLF
+  scan scoped to `*.sh`, CLAUDE.md marker block, catalog JSON parse via
+  `ConvertFrom-Json` — no python dependency, PATH + dual-install), same
+  output contract (`OK|WARN|FAIL  name: detail` + indented remedy, summary
+  block, exit 0/1). The expected skill list is extracted at runtime from
+  `Install-Playbook.ps1` (`$Script:GlobalSkills`) or, in installed layouts,
+  `scripts/ccds-user-setup.sh` — never a third copy that can drift. All
+  error paths are non-terminating (the #33/#36 `Write-Error` lesson).
+- **`ccds setup` on PowerShell**: per-user setup (agents + cross-cutting
+  skills + CLAUDE.md pointer block, `--dry-run` supported) so the PS
+  dispatcher's command surface matches bash — previously Windows users could
+  only get the per-user layer via the full installer.
+- **cli-parity lint check** (`scripts/lint-playbook.py` check 10): parses the
+  command set from both dispatchers' real dispatch structures (bash
+  `elif [[ "$COMMAND" == ... ]]` chain, PowerShell `switch ($Command)` block)
+  and errors on any command present in one but not the other — the standing
+  rule is now enforced by CI, not memory. 5 new fixture tests (suite: 66).
+
+### Docs
+
+- CLAUDE.md Conventions: "CLI changes ship in both dispatchers (bash +
+  PowerShell) in the same PR — the cli-parity lint check enforces the
+  command surface."
+
+---
+
 ## Unreleased — 2026-07-03 — feat: routing evals
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,8 @@ skills — no domain agent; skills-only, like `common-`).
   `catalog.json` from the files via `scripts/build-catalog.py` after any change.
 - **Layout:** agents are flat `.claude/agents/<name>.md`; skills are
   `skills/<name>/SKILL.md`. Claude Code does not recurse `.claude/agents/` (ADR-0001).
+- **CLI changes ship in both dispatchers (bash + PowerShell) in the same PR** — the
+  cli-parity lint check enforces the command surface.
 
 ---
 

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -27,6 +27,8 @@
     ccds sync game --dry-run
     ccds sync --clean
     ccds verify
+    ccds doctor
+    ccds setup
     ccds loop init
     ccds update
     ccds version
@@ -105,6 +107,16 @@ COMMANDS
   verify               Validate global agents and project skills
       --target <path>       Target path (default: current directory)
 
+  doctor               Run proactive environment health checks: layout shape,
+                       version drift vs the latest release, install
+                       completeness (agents, skills, CLAUDE.md block, catalog),
+                       BOM/CRLF corruption, PATH and dual-install conflicts.
+                       Exit 0 = healthy (WARNs allowed), 1 = failures found.
+
+  setup                Install the always-on agents + cross-cutting skills into
+                       %USERPROFILE%\.claude\, inject the CLAUDE.md block
+      --dry-run             Preview without writing
+
   lint                 Lint the playbook library's semantic invariants
                        (skill cross-refs, catalog freshness, URL/description
                        conventions). Requires a repo clone (dev layout).
@@ -131,6 +143,8 @@ EXAMPLES
   ccds sync game --dry-run
   ccds sync --clean
   ccds verify
+  ccds doctor
+  ccds setup
   ccds loop init
 
 LAYOUT
@@ -251,6 +265,460 @@ function Invoke-VerifyCommand {
 
     & $verifyScript -AgentsPath $agentsPath
     exit $LASTEXITCODE
+}
+
+# ---------------------------------------------------------------------------
+# Shared: authoritative cross-cutting (global) skill list, extracted at RUNTIME
+# from whichever installer source is present -- never a third hardcoded copy
+# that can drift. Dev layout ships Install-Playbook.ps1 at the repo root;
+# installed/packaged layouts ship scripts\ccds-user-setup.sh.
+# Returns $null when neither source parses.
+# ---------------------------------------------------------------------------
+function Get-GlobalSkillList {
+    # Source 1: Install-Playbook.ps1 ($Script:GlobalSkills = @( ... ))
+    $ps1Src = Join-Path $installRoot 'Install-Playbook.ps1'
+    if (Test-Path -LiteralPath $ps1Src) {
+        try {
+            $text = [System.IO.File]::ReadAllText($ps1Src)
+            $m = [regex]::Match($text, '\$Script:GlobalSkills\s*=\s*@\(([^)]*)\)')
+            if ($m.Success) {
+                $names = @($m.Groups[1].Value -split "`n" | ForEach-Object {
+                    ($_ -replace '#.*$', '').Trim().Trim("'").Trim('"')
+                } | Where-Object { $_ -match '^[a-z0-9-]+$' })
+                if ($names.Count -gt 0) {
+                    return @{ Names = $names; Source = 'Install-Playbook.ps1' }
+                }
+            }
+        } catch { }
+    }
+    # Source 2: scripts\ccds-user-setup.sh (GLOBAL_SKILLS=( ... ))
+    $shSrc = Join-Path $installRoot 'scripts\ccds-user-setup.sh'
+    if (Test-Path -LiteralPath $shSrc) {
+        try {
+            $text = [System.IO.File]::ReadAllText($shSrc)
+            $m = [regex]::Match($text, 'GLOBAL_SKILLS=\(([^)]*)\)')
+            if ($m.Success) {
+                $names = @($m.Groups[1].Value -split "`n" | ForEach-Object {
+                    ($_ -replace '#.*$', '').Trim()
+                } | Where-Object { $_ -match '^[a-z0-9-]+$' })
+                if ($names.Count -gt 0) {
+                    return @{ Names = $names; Source = 'scripts\ccds-user-setup.sh' }
+                }
+            }
+        } catch { }
+    }
+    return $null
+}
+
+# ---------------------------------------------------------------------------
+# Command: setup (per-user install: agents + global skills + CLAUDE.md block).
+# PowerShell twin of scripts/ccds-user-setup.sh -- same three steps, same
+# BOM-less UTF-8 writes (ADR-0001).
+# ---------------------------------------------------------------------------
+function Invoke-SetupCommand {
+    param([hashtable]$Opts)
+
+    $claudeHome  = Join-Path $env:USERPROFILE '.claude'
+    $agentsSrc   = Join-Path $installRoot 'agents'
+    $skillsSrc   = Join-Path $installRoot 'skills'
+    $jitSrc      = Join-Path $installRoot 'scripts\jit-claude.md'
+    $agentsDst   = Join-Path $claudeHome 'agents'
+    $skillsDst   = Join-Path $claudeHome 'skills'
+    $claudeMd    = Join-Path $claudeHome 'CLAUDE.md'
+
+    # Step 1 -- always-on agents
+    Write-Host "==> Installing always-on agents to $agentsDst" -ForegroundColor Cyan
+    $srcAgents = @()
+    if (Test-Path -LiteralPath $agentsSrc) {
+        $srcAgents = @(Get-ChildItem -LiteralPath $agentsSrc -Filter *.md -File -ErrorAction SilentlyContinue)
+    }
+    if ($Opts.DryRun) {
+        Write-Host "    DRY RUN -- would copy $($srcAgents.Count) always-on agents to $agentsDst"
+    } else {
+        if (-not (Test-Path -LiteralPath $agentsDst)) {
+            New-Item -ItemType Directory -Path $agentsDst -Force | Out-Null
+        }
+        $copied = 0
+        foreach ($f in $srcAgents) {
+            Copy-Item -LiteralPath $f.FullName -Destination (Join-Path $agentsDst $f.Name) -Force
+            $copied++
+        }
+        Write-Host "OK  Copied $copied always-on agents to $agentsDst" -ForegroundColor Green
+    }
+
+    # Step 2 -- cross-cutting (global) skills
+    Write-Host "==> Installing cross-cutting skills to $skillsDst" -ForegroundColor Cyan
+    $skillList = Get-GlobalSkillList
+    if (-not $skillList) {
+        Write-Error "cannot determine the global skill list (no parsable Install-Playbook.ps1 or scripts\ccds-user-setup.sh under $installRoot)" -ErrorAction Continue
+        exit 2
+    }
+    if ($Opts.DryRun) {
+        Write-Host "    DRY RUN -- would copy $($skillList.Names.Count) cross-cutting skills to $skillsDst (list from $($skillList.Source))"
+    } else {
+        if (-not (Test-Path -LiteralPath $skillsDst)) {
+            New-Item -ItemType Directory -Path $skillsDst -Force | Out-Null
+        }
+        $copied = 0
+        foreach ($name in $skillList.Names) {
+            $src     = Join-Path $skillsSrc $name
+            $skillMd = Join-Path $src 'SKILL.md'
+            if ((Test-Path -LiteralPath $src) -and (Test-Path -LiteralPath $skillMd)) {
+                $dst = Join-Path $skillsDst $name
+                if (Test-Path -LiteralPath $dst) { Remove-Item -LiteralPath $dst -Recurse -Force }
+                Copy-Item -LiteralPath $src -Destination $dst -Recurse -Force
+                $copied++
+            } else {
+                Write-Host "!!  Global skill not found in package: skills\$name\SKILL.md" -ForegroundColor Yellow
+            }
+        }
+        Write-Host "OK  Copied $copied/$($skillList.Names.Count) cross-cutting skills to $skillsDst" -ForegroundColor Green
+    }
+
+    # Step 3 -- ccds pointer block in ~/.claude/CLAUDE.md (idempotent)
+    Write-Host "==> Updating ccds block in $claudeMd" -ForegroundColor Cyan
+    if (-not (Test-Path -LiteralPath $jitSrc)) {
+        Write-Host "!!  jit-claude.md not found at $jitSrc -- skipping CLAUDE.md injection" -ForegroundColor Yellow
+    } elseif ($Opts.DryRun) {
+        Write-Host "    DRY RUN -- would inject/update ccds block in $claudeMd"
+        Write-Host ""
+        Write-Host "DRY RUN -- no changes made." -ForegroundColor Yellow
+        return
+    } else {
+        if (-not (Test-Path -LiteralPath $claudeHome)) {
+            New-Item -ItemType Directory -Path $claudeHome -Force | Out-Null
+        }
+        $existing = ''
+        if (Test-Path -LiteralPath $claudeMd) {
+            $existing = [System.IO.File]::ReadAllText($claudeMd, [System.Text.Encoding]::UTF8)
+            $stamp    = Get-Date -Format 'yyyyMMdd-HHmmss'
+            Copy-Item -LiteralPath $claudeMd -Destination "$claudeMd.ccds-backup-$stamp" -Force
+            Write-Host "    Backed up existing CLAUDE.md to CLAUDE.md.ccds-backup-$stamp"
+        }
+        $blockContent = ([System.IO.File]::ReadAllText($jitSrc, [System.Text.Encoding]::UTF8)).TrimEnd("`r", "`n")
+        $markerStart  = '# >>> ccds >>>'
+        $markerEnd    = '# <<< ccds <<<'
+        # Strip ALL existing ccds blocks (duplicates from prior buggy installs,
+        # trailing whitespace on marker lines) -- same contract as the bash twin.
+        $stripPattern = "(?s)\r?\n?[ \t]*$([regex]::Escape($markerStart))[ \t\r]*\r?\n.*?[ \t]*$([regex]::Escape($markerEnd))[ \t\r]*\r?\n?"
+        $cleaned = ([regex]::Replace($existing, $stripPattern, '')).TrimEnd("`r", "`n")
+        if ($cleaned -match '##\s+Playbook JIT Agent Loading') {
+            Write-Host "!!  Detected legacy 'Playbook JIT Agent Loading' content outside markers -- inspect $claudeMd." -ForegroundColor Yellow
+        }
+        if ($cleaned.Length -gt 0) {
+            $updated = $cleaned + "`n`n" + $blockContent + "`n"
+        } else {
+            $updated = $blockContent + "`n"
+        }
+        [System.IO.File]::WriteAllText($claudeMd, $updated, [System.Text.UTF8Encoding]::new($false))
+        Write-Host "OK  Refreshed ccds block in $claudeMd" -ForegroundColor Green
+    }
+
+    if ($Opts.DryRun) {
+        Write-Host ""
+        Write-Host "DRY RUN -- no changes made." -ForegroundColor Yellow
+    } else {
+        Write-Host ""
+        Write-Host "User setup complete." -ForegroundColor Green
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Command: doctor -- proactive environment health checks.
+# PowerShell twin of bin/ccds.sh cmd_doctor: same 9 checks, same output
+# contract (one 'OK|WARN|FAIL  name: detail' line per check + indented remedy
+# on WARN/FAIL, summary block, exit 0 = no FAIL / 1 = FAIL found).
+#
+# CCDS_DOCTOR_RELEASE_URL is a TEST-ONLY override for the GitHub
+# latest-release endpoint, so tests can force the offline path
+# deterministically. Do not set it in normal use.
+#
+# All error paths are non-terminating (-ErrorAction Continue / try-catch):
+# under $ErrorActionPreference='Stop' a bare cmdlet error would kill the run
+# with exit 1 mid-checks (see #33/#36).
+# ---------------------------------------------------------------------------
+$Script:DocOk = 0; $Script:DocWarn = 0; $Script:DocFail = 0
+
+function Write-DoctorLine {
+    param([string]$Status, [string]$Name, [string]$Detail, [string]$Remedy = '')
+    Write-Host ('{0}  {1}: {2}' -f $Status, $Name, $Detail)
+    switch ($Status) {
+        'OK'   { $Script:DocOk++ }
+        'WARN' { $Script:DocWarn++ }
+        'FAIL' { $Script:DocFail++ }
+        default {
+            Write-Error "Write-DoctorLine: unknown status '$Status'" -ErrorAction Continue
+            exit 2
+        }
+    }
+    if ($Status -ne 'OK' -and $Remedy) {
+        Write-Host "      remedy: $Remedy"
+    }
+}
+
+function Test-DoctorLayout {
+    if ($layoutKind -eq 'dev') {
+        Write-DoctorLine WARN 'layout' `
+            "dev (repo clone at $installRoot); 'ccds setup' expects the packaged shape (<root>\agents, <root>\skills) -- this repo keeps agents in .claude\agents" `
+            "stage a release first (build-release.ps1) or install via Install-Playbook.ps1, then run 'ccds setup' from that tree"
+    } else {
+        Write-DoctorLine OK 'layout' "$layoutKind ($installRoot)"
+    }
+}
+
+function Test-DoctorVersion {
+    $installed = Get-InstalledVersion
+    $url = if ($env:CCDS_DOCTOR_RELEASE_URL) { $env:CCDS_DOCTOR_RELEASE_URL }
+           else { 'https://api.github.com/repos/ggrace519/claude-code-dev-studio/releases/latest' }
+
+    $body = $null
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = `
+            [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        $resp = Invoke-WebRequest -Uri $url -Headers @{ 'User-Agent' = 'ccds-doctor' } `
+                    -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+        $body = $resp.Content
+    } catch {
+        Write-DoctorLine WARN 'version' `
+            "installed $installed; could not check latest release (offline, timeout, or rate-limited)" `
+            'retry with network access, or check https://github.com/ggrace519/claude-code-dev-studio/releases'
+        return
+    }
+
+    $latest = $null
+    try { $latest = (ConvertFrom-Json $body).tag_name } catch { }
+    if (-not $latest) {
+        Write-DoctorLine WARN 'version' `
+            "installed $installed; could not parse latest release tag from $url" `
+            'check https://github.com/ggrace519/claude-code-dev-studio/releases'
+        return
+    }
+
+    $vi = "$installed" -replace '^v', ''
+    $vl = "$latest" -replace '^v', ''
+    if ($installed -eq 'dev') {
+        Write-DoctorLine OK 'version' "dev (repo clone; latest release is $latest)"
+        return
+    }
+    if ($vi -eq $vl) {
+        Write-DoctorLine OK 'version' "$installed (up to date with latest release $latest)"
+        return
+    }
+    # Compare numeric prefixes (0.10.1, 0.11.0-rc1 -> 0.11.0). If either side
+    # refuses to parse, degrade to a WARN rather than guessing an order.
+    $pi = [regex]::Match($vi, '^\d+(\.\d+)+').Value
+    $pl = [regex]::Match($vl, '^\d+(\.\d+)+').Value
+    $parsedI = $null; $parsedL = $null
+    if ($pi -and $pl) {
+        try { $parsedI = [version]$pi; $parsedL = [version]$pl } catch { }
+    }
+    if (-not $parsedI -or -not $parsedL) {
+        Write-DoctorLine WARN 'version' `
+            "installed $installed; could not compare against latest release $latest" `
+            'check https://github.com/ggrace519/claude-code-dev-studio/releases'
+    } elseif ($parsedI -lt $parsedL) {
+        Write-DoctorLine WARN 'version' `
+            "installed $installed is older than latest release $latest" `
+            "run 'ccds update'"
+    } else {
+        Write-DoctorLine OK 'version' "$installed (ahead of latest release $latest)"
+    }
+}
+
+function Test-DoctorAgents {
+    $dir = Join-Path $env:USERPROFILE '.claude\agents'
+    if (Test-Path -LiteralPath (Join-Path $dir 'plan-architect.md')) {
+        $n = @(Get-ChildItem -LiteralPath $dir -Filter *.md -File -ErrorAction SilentlyContinue).Count
+        Write-DoctorLine OK 'agents-installed' "core sentinel plan-architect.md present ($n agent file(s) in $dir)"
+    } else {
+        Write-DoctorLine FAIL 'agents-installed' `
+            "plan-architect.md missing from $dir -- the always-on agents are not installed" `
+            "run 'ccds setup'"
+    }
+}
+
+function Test-DoctorSkills {
+    $skillList = Get-GlobalSkillList
+    if (-not $skillList) {
+        Write-DoctorLine WARN 'skills-installed' `
+            "cannot determine expected skill list (no parsable Install-Playbook.ps1 or scripts\ccds-user-setup.sh under $installRoot)" `
+            "reinstall via 'ccds update' or the installer"
+        return
+    }
+    $skillsDir = Join-Path $env:USERPROFILE '.claude\skills'
+    $missing = @()
+    foreach ($name in $skillList.Names) {
+        if (-not (Test-Path -LiteralPath (Join-Path $skillsDir "$name\SKILL.md"))) {
+            $missing += $name
+        }
+    }
+    if ($missing.Count -eq 0) {
+        Write-DoctorLine OK 'skills-installed' `
+            "all $($skillList.Names.Count) cross-cutting skills present in $skillsDir (expected list from $($skillList.Source))"
+    } else {
+        Write-DoctorLine FAIL 'skills-installed' `
+            "$($missing.Count)/$($skillList.Names.Count) cross-cutting skills missing from ${skillsDir}: $($missing -join ' ')" `
+            "run 'ccds setup'"
+    }
+}
+
+function Test-DoctorBom {
+    $candidates = @()
+    $agentsDir = Join-Path $env:USERPROFILE '.claude\agents'
+    $skillsDir = Join-Path $env:USERPROFILE '.claude\skills'
+    if (Test-Path -LiteralPath $agentsDir) {
+        $candidates += @(Get-ChildItem -LiteralPath $agentsDir -Filter *.md -File -ErrorAction SilentlyContinue)
+    }
+    if (Test-Path -LiteralPath $skillsDir) {
+        $candidates += @(Get-ChildItem -LiteralPath $skillsDir -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object { Get-Item -LiteralPath (Join-Path $_.FullName 'SKILL.md') -ErrorAction SilentlyContinue })
+    }
+    $hits = @()
+    foreach ($f in $candidates) {
+        if (-not $f) { continue }
+        try {
+            $fs = [System.IO.File]::OpenRead($f.FullName)
+            try {
+                $buf = New-Object byte[] 3
+                $n = $fs.Read($buf, 0, 3)
+            } finally {
+                $fs.Dispose()
+            }
+            if ($n -eq 3 -and $buf[0] -eq 0xEF -and $buf[1] -eq 0xBB -and $buf[2] -eq 0xBF) {
+                $hits += $f.FullName
+            }
+        } catch { }
+    }
+    if ($hits.Count -eq 0) {
+        Write-DoctorLine OK 'bom-scan' 'no UTF-8 BOM in installed agents or skills'
+    } else {
+        Write-DoctorLine FAIL 'bom-scan' `
+            "$($hits.Count) installed file(s) start with a UTF-8 BOM, which makes Claude Code silently skip the frontmatter (ADR-0001): $($hits -join ' ')" `
+            "run 'ccds setup' to restore clean copies; re-save any hand-edited file as UTF-8 without BOM"
+    }
+}
+
+function Test-DoctorCrlf {
+    # Scoped to *.sh only (same as the bash twin): CR bytes break bash scripts;
+    # on Windows checkouts with autocrlf this can legitimately fire.
+    $hits = @()
+    try {
+        $shFiles = @(Get-ChildItem -LiteralPath $installRoot -Recurse -Filter '*.sh' -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '[\\/]\.git[\\/]' })
+        foreach ($f in $shFiles) {
+            try {
+                if (([System.IO.File]::ReadAllText($f.FullName)).Contains("`r")) {
+                    $hits += $f.FullName
+                }
+            } catch { }
+        }
+    } catch { }
+    if ($hits.Count -eq 0) {
+        Write-DoctorLine OK 'crlf-scan' "no CR bytes in *.sh under $installRoot"
+    } else {
+        Write-DoctorLine WARN 'crlf-scan' `
+            "$($hits.Count) shell script(s) under $installRoot contain CR (CRLF) bytes: $($hits -join ' ')" `
+            "normalize to LF (e.g. sed -i 's/\r`$//' <file>) or reinstall via 'ccds update'"
+    }
+}
+
+function Test-DoctorClaudeBlock {
+    $md = Join-Path $env:USERPROFILE '.claude\CLAUDE.md'
+    if (-not (Test-Path -LiteralPath $md)) {
+        Write-DoctorLine FAIL 'claude-md-block' "$md not found -- the ccds pointer block is not installed" "run 'ccds setup'"
+        return
+    }
+    $nb = 0; $ne = 0
+    try {
+        $lines = [System.IO.File]::ReadAllLines($md)
+        $nb = @($lines | Where-Object { $_.Contains('# >>> ccds >>>') }).Count
+        $ne = @($lines | Where-Object { $_.Contains('# <<< ccds <<<') }).Count
+    } catch { }
+    if ($nb -eq 1 -and $ne -eq 1) {
+        Write-DoctorLine OK 'claude-md-block' "exactly one ccds marker block in $md"
+    } else {
+        Write-DoctorLine FAIL 'claude-md-block' `
+            "expected exactly one ccds block in $md; found $nb begin / $ne end marker(s)" `
+            "run 'ccds setup' (it strips duplicate/broken blocks and reinjects a single fresh one)"
+    }
+}
+
+function Test-DoctorCatalog {
+    $cat = Join-Path $libraryRoot 'catalog.json'
+    if (-not (Test-Path -LiteralPath $cat)) {
+        Write-DoctorLine FAIL 'catalog' "catalog.json not found at $cat" `
+            "reinstall via 'ccds update' (or regenerate with scripts/build-catalog.py in a repo clone)"
+        return
+    }
+    try {
+        [System.IO.File]::ReadAllText($cat) | ConvertFrom-Json | Out-Null
+        Write-DoctorLine OK 'catalog' "$cat parses as valid JSON"
+    } catch {
+        Write-DoctorLine FAIL 'catalog' "$cat is not valid JSON" `
+            "regenerate with scripts/build-catalog.py or reinstall via 'ccds update'"
+    }
+}
+
+function Test-DoctorPathDuals {
+    $resolvedCmd = Get-Command ccds -ErrorAction SilentlyContinue
+    $resolved = if ($resolvedCmd) { $resolvedCmd.Source } else { '' }
+    # Dual-install: this dispatcher runs from an installed root that is NOT the
+    # default per-user prefix while that prefix also exists (two live copies).
+    # Windows translation of the bash /usr/share/ccds vs ~/.claude/playbook check.
+    $defaultPrefix = Join-Path $env:USERPROFILE '.claude\playbook'
+    $dual = $false
+    if ($layoutKind -eq 'installed' -and (Test-Path -LiteralPath $defaultPrefix)) {
+        try {
+            $a = (Resolve-Path -LiteralPath $installRoot).Path.TrimEnd('\')
+            $b = (Resolve-Path -LiteralPath $defaultPrefix).Path.TrimEnd('\')
+            if ($a -ne $b) { $dual = $true }
+        } catch { }
+    }
+    if ($dual) {
+        $resolvedDetail = if ($resolved) { $resolved } else { '<none -- ccds not on PATH>' }
+        Write-DoctorLine WARN 'path-and-duals' `
+            "both $installRoot and $defaultPrefix (default per-user prefix) are installed; this shell runs: $resolvedDetail" `
+            "keep one install: run 'ccds uninstall' from the copy you want to remove"
+    } elseif (-not $resolved) {
+        Write-DoctorLine WARN 'path-and-duals' `
+            "'ccds' is not resolvable on PATH (this run used $PSCommandPath)" `
+            "add $binDir to PATH (the installer normally does this) or re-run the installer"
+    } else {
+        Write-DoctorLine OK 'path-and-duals' "ccds resolves to $resolved"
+    }
+}
+
+function Invoke-DoctorCommand {
+    # Registry: check-name -> check function. Adding a check = one function
+    # plus one row here (keep in lockstep with bin/ccds.sh cmd_doctor).
+    $checks = @(
+        @{ Name = 'layout'          ; Fn = ${function:Test-DoctorLayout} }
+        @{ Name = 'version'         ; Fn = ${function:Test-DoctorVersion} }
+        @{ Name = 'agents-installed'; Fn = ${function:Test-DoctorAgents} }
+        @{ Name = 'skills-installed'; Fn = ${function:Test-DoctorSkills} }
+        @{ Name = 'bom-scan'        ; Fn = ${function:Test-DoctorBom} }
+        @{ Name = 'crlf-scan'       ; Fn = ${function:Test-DoctorCrlf} }
+        @{ Name = 'claude-md-block' ; Fn = ${function:Test-DoctorClaudeBlock} }
+        @{ Name = 'catalog'         ; Fn = ${function:Test-DoctorCatalog} }
+        @{ Name = 'path-and-duals'  ; Fn = ${function:Test-DoctorPathDuals} }
+    )
+
+    Write-Host "ccds doctor -- environment checks (version $(Get-InstalledVersion), $layoutKind layout)"
+    Write-Host ""
+    foreach ($check in $checks) {
+        & $check.Fn
+    }
+    Write-Host ""
+    Write-Host '=== ccds doctor summary ==='
+    Write-Host ('OK    : {0}' -f $Script:DocOk)
+    Write-Host ('WARN  : {0}' -f $Script:DocWarn)
+    Write-Host ('FAIL  : {0}' -f $Script:DocFail)
+    if ($Script:DocFail -gt 0) {
+        Write-Host 'RESULT: FAIL'
+        exit 1
+    }
+    Write-Host 'RESULT: PASS'
+    exit 0
 }
 
 # ---------------------------------------------------------------------------
@@ -516,8 +984,10 @@ try {
 }
 
 switch ($Command) {
+    'setup'      { Invoke-SetupCommand -Opts $opts }
     'sync'       { Invoke-SyncCommand -Opts $opts }
     'verify'     { Invoke-VerifyCommand -Opts $opts }
+    'doctor'     { Invoke-DoctorCommand }
     'lint'       { Invoke-LintCommand }
     'loop'       { Invoke-LoopCommand -Opts $opts }
     'update'     { Invoke-UpdateCommand -Opts $opts }

--- a/scripts/ccds-completion.ps1
+++ b/scripts/ccds-completion.ps1
@@ -19,7 +19,7 @@ Register-ArgumentCompleter -Native -CommandName ccds -ScriptBlock {
         $prev = if ($tokenCount -ge 1) { $elements[$tokenCount - 1] } else { '' }
     }
 
-    $commands    = @('sync', 'verify', 'loop', 'update', 'uninstall', 'version', 'help')
+    $commands    = @('sync', 'verify', 'doctor', 'loop', 'update', 'uninstall', 'version', 'help')
     $packs       = @('game','saas','mobile','ai','dataplat','ecom','fintech',
                      'devtool','desktop','ext','embed','media','orch','infra','common')
     $modes       = @('copy', 'symlink')
@@ -111,7 +111,7 @@ Register-ArgumentCompleter -Native -CommandName ccds -ScriptBlock {
             }
             return Complete-FromList @('init') $wordToComplete
         }
-        { $_ -in 'verify', 'uninstall', 'version', 'help' } {
+        { $_ -in 'verify', 'doctor', 'uninstall', 'version', 'help' } {
             return Complete-FromList $globalFlags $wordToComplete
         }
     }

--- a/scripts/lint-playbook.py
+++ b/scripts/lint-playbook.py
@@ -28,6 +28,11 @@ This linter checks that what the files SAY is true:
                        exactly one '## Iron law' section, and a
                        '## Rationalizations' table (ADR-0010,
                        docs/skill-authoring.md "Process skills").
+ 10. cli-parity        bin/ccds.sh and bin/ccds.ps1 dispatch the same command
+                       set ("fixes and releases should be for every outlet") —
+                       a command added to one dispatcher must ship in the
+                       other, in the same PR. Skipped when a tree ships
+                       neither dispatcher (test fixtures).
 
 Exit codes: 0 = pass (warnings allowed), 1 = one or more errors, 2 = config error.
 
@@ -213,6 +218,72 @@ def check_process_skills():
             err("process-skill", f"skills/{d}: missing the '## Rationalizations' table")
 
 
+# --- 10: cli-parity ------------------------------------------------------------
+# The two dispatchers must expose the same command surface forever ("fixes and
+# releases should be for every outlet"). Both parsers anchor to the real
+# dispatch structures — the bash `elif [[ "$COMMAND" == "..." ]]` chain and the
+# PowerShell `switch ($Command)` block — and tolerate whitespace/formatting.
+# version/help are handled before either structure and are exempt by design.
+BASH_DISPATCH_RE = re.compile(
+    r'\[\[\s*"\$COMMAND"\s*==\s*"([a-z][a-z0-9-]*)"\s*\]\]\s*;?\s*then')
+PS1_CASE_LABEL_RE = re.compile(r"^\s*'([a-z][a-z0-9-]*)'\s*\{", re.MULTILINE)
+PS1_SWITCH_RE = re.compile(r'switch\s*\(\s*\$Command\s*\)\s*\{')
+
+
+def parse_bash_commands(path):
+    return set(BASH_DISPATCH_RE.findall(read(path)))
+
+
+def parse_ps1_commands(path):
+    src = read(path)
+    m = PS1_SWITCH_RE.search(src)
+    if m is None:
+        return None
+    # Take the balanced-brace region of the switch statement, then collect its
+    # quoted case labels ('default' is unquoted and thus ignored).
+    start = m.end() - 1
+    depth = 0
+    end = len(src)
+    for i in range(start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+    return set(PS1_CASE_LABEL_RE.findall(src[start:end]))
+
+
+def check_cli_parity():
+    bash_path = os.path.join(REPO_ROOT, "bin", "ccds.sh")
+    ps1_path = os.path.join(REPO_ROOT, "bin", "ccds.ps1")
+    if not os.path.isfile(bash_path) and not os.path.isfile(ps1_path):
+        return  # fixture/library-only trees ship no dispatchers
+    if not os.path.isfile(bash_path):
+        err("cli-parity", "bin/ccds.ps1 present but bin/ccds.sh is missing")
+        return
+    if not os.path.isfile(ps1_path):
+        err("cli-parity", "bin/ccds.sh present but bin/ccds.ps1 is missing")
+        return
+    bash_cmds = parse_bash_commands(bash_path)
+    ps1_cmds = parse_ps1_commands(ps1_path)
+    if not bash_cmds:
+        err("cli-parity", 'could not parse any commands from the bin/ccds.sh '
+                          'dispatch chain (elif [[ "$COMMAND" == "..." ]])')
+        return
+    if not ps1_cmds:
+        err("cli-parity", "could not parse any commands from the bin/ccds.ps1 "
+                          "switch ($Command) dispatch block")
+        return
+    for cmd in sorted(bash_cmds - ps1_cmds):
+        err("cli-parity", f"command '{cmd}' is dispatched in bin/ccds.sh but missing "
+                          f"from bin/ccds.ps1 — CLI changes ship in both dispatchers")
+    for cmd in sorted(ps1_cmds - bash_cmds):
+        err("cli-parity", f"command '{cmd}' is dispatched in bin/ccds.ps1 but missing "
+                          f"from bin/ccds.sh — CLI changes ship in both dispatchers")
+
+
 # --- 5 + 6 + 7: descriptions and models --------------------------------------
 def check_descriptions_and_models():
     agent_desc_chars = 0
@@ -254,6 +325,7 @@ def main():
     check_urls()
     check_skill_voice()
     check_process_skills()
+    check_cli_parity()
     check_descriptions_and_models()
 
     for w in warnings:

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -240,6 +240,73 @@ class TestLintPlaybook(FixtureCase):
         self.assertNotIn("process-skill", r.stdout)
 
 
+class TestCliParity(FixtureCase):
+    """Check 10: bin/ccds.sh and bin/ccds.ps1 must dispatch the same command
+    set ("fixes and releases should be for every outlet").
+
+    The fixture writes minimal fake dispatchers carrying only the structures
+    the parser anchors to — the bash `elif [[ "$COMMAND" == "..." ]]` chain
+    and the PowerShell `switch ($Command)` block — with deliberately uneven
+    whitespace to prove the parser tolerates formatting.
+    """
+
+    def write_dispatchers(self, bash_cmds, ps1_cmds):
+        chain = []
+        for i, cmd in enumerate(bash_cmds):
+            kw = "if  " if i == 0 else "elif"
+            pad = " " * (10 - len(cmd))  # ragged alignment like the real file
+            chain.append(f'{kw} [[ "$COMMAND" == "{cmd}"{pad}]]; then cmd_{cmd}')
+        write(os.path.join(self.root, "bin", "ccds.sh"),
+              "#!/usr/bin/env bash\nCOMMAND=\"$1\"\n"
+              + "\n".join(chain)
+              + "\nelse\n    exit 2\nfi\n")
+
+        cases = "\n".join(f"    '{cmd}'  {{ Invoke-Command -Name {cmd} }}"
+                          for cmd in ps1_cmds)
+        write(os.path.join(self.root, "bin", "ccds.ps1"),
+              "param([string]$Command)\n"
+              "switch ($Command) {\n"
+              + cases
+              + "\n    default { exit 2 }\n}\n")
+
+    def test_no_dispatchers_is_exempt(self):
+        # Library-only fixture trees ship no bin/; parity must not fire.
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertNotIn("cli-parity", r.stdout)
+
+    def test_matching_surfaces_pass(self):
+        self.write_dispatchers(["sync", "verify", "doctor"],
+                               ["sync", "verify", "doctor"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertNotIn("cli-parity", r.stdout)
+
+    def test_bash_only_command_fails_naming_it(self):
+        self.write_dispatchers(["sync", "doctor"], ["sync"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("cli-parity", r.stdout)
+        self.assertIn("'doctor'", r.stdout)
+        self.assertIn("missing from bin/ccds.ps1", r.stdout)
+
+    def test_ps1_only_command_fails_naming_it(self):
+        self.write_dispatchers(["sync"], ["sync", "setup"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("cli-parity", r.stdout)
+        self.assertIn("'setup'", r.stdout)
+        self.assertIn("missing from bin/ccds.sh", r.stdout)
+
+    def test_missing_twin_dispatcher_fails(self):
+        self.write_dispatchers(["sync"], ["sync"])
+        os.remove(os.path.join(self.root, "bin", "ccds.ps1"))
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("cli-parity", r.stdout)
+        self.assertIn("bin/ccds.ps1 is missing", r.stdout)
+
+
 @unittest.skipUnless(os.path.isfile(BUILD_MARKETPLACE),
                      "build-marketplace.py not on this branch yet")
 class TestBuildMarketplace(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements the new standing rule — **fixes and releases ship for every outlet** — in both directions: `ccds.ps1` gains native `doctor` and `setup` twins (setup turned out to be missing too, discovered by the new check), and lint check 10 (`cli-parity`) permanently errors on any command dispatched in one shell but not the other.

## What changed and why

- `bin/ccds.ps1`: `doctor` (same 9 checks, same OK/WARN/FAIL + remedy contract, offline-safe version check, skill list extracted at runtime — no drifting copy) and `setup` (agents + global skills + CLAUDE.md marker block, BOM-less UTF-8, `--dry-run`). Error paths use `-ErrorAction Continue` per #33. Completion updated.
- `scripts/lint-playbook.py` check 10 parses both dispatch structures and errors on set differences; repo CLAUDE.md conventions now state the both-shells-per-PR rule.

## Verification

Real Windows PowerShell 5.1 run against the actual Windows profile: 8 OK / 1 WARN / PASS, live GitHub version check hit v0.10.1 (network path proven, plus forced-offline WARN path). Forced-FAIL run (empty profile): graceful FAILs, exit 1. Parity lint: PASS on identical 8-command sets; deleting `doctor` from the ps1 switch → named cli-parity error, exit 1; restored. Suite: 66 passed (+5 parity fixture tests). Caveats in the branch report: pwsh 7 untested (5.1-safe syntax only); `setup` exercised with `--dry-run` only against the real profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)