### PR TITLE
fix(skills): loop-long-horizon — the one-task and evidence rules do not trade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ command surface, forever, in the same PR.
 
 ---
 
+## Unreleased — 2026-07-04 — fix: loop-long-horizon holds the one-task rule under a verification-heavy environment
+
+### Fixed
+
+- `loop-long-horizon` measured consistently marginal (1/3) on a host whose
+  user-level CLAUDE.md carries a strong verification ethos: the model would
+  honor the evidence rule, then *bargain away* the one-task rule ("verify
+  properly, then continue to the next feature — best of both"). The iron law
+  now states the two halves do not trade, with a matching rationalization row.
+  Measured 1/3 → 3/3 and 5/5 post-fix on the same host; committed baseline
+  refreshed to 6/6 (the drift-compare workflow from #42, used end-to-end for
+  the first time).
+
+---
+
 ## Unreleased — 2026-07-04 — feat: repo hook makes the eval-cadence rule deterministic
 
 ### Added

--- a/evals/loop-compliance/baseline.json
+++ b/evals/loop-compliance/baseline.json
@@ -14,7 +14,7 @@
       "votes": 3
     },
     "long-horizon-second-task": {
-      "passes": 1,
+      "passes": 3,
       "votes": 3
     },
     "parallel-shared-file": {

--- a/skills/loop-long-horizon/SKILL.md
+++ b/skills/loop-long-horizon/SKILL.md
@@ -21,7 +21,9 @@ unattended runs and multi-session features.
 
 **The loop's memory is files, not context — and each iteration takes exactly one
 task.** A second task in the same iteration is the first step toward a half-finished
-tree nobody can resume.
+tree nobody can resume. The two halves do not trade: verifying the first task
+properly does not earn a second one, and no amount of remaining context changes
+the count.
 
 ## Setup (once, before the first iteration)
 
@@ -67,6 +69,7 @@ Create the state kit — templates in [references/state-files.md](references/sta
 | Excuse | Reality |
 |---|---|
 | "I can squeeze in a second task" | The second task is the one the context dies inside |
+| "Verify this one properly, *then* continue to the next — best of both" | A fake bargain: verification guards the flip, ending the context guards the tree; neither buys out the other |
 | "It basically works, mark it done" | An unverified `"passes": true` poisons every later iteration's trust in the file |
 | "Continuing in this context saves re-reading" | It spends the window on history instead of work — the files exist to make re-reading cheap |
 | "The plan can live in my head until the end" | There is no end of session, only an end of context |


### PR DESCRIPTION
## Summary

Closes the one measured weakness in the compliance baseline: `long-horizon-second-task` at 1/3 on host victus (3/3 on the clean VM). Root cause read from a real failing reply: with a verification-heavy user CLAUDE.md loaded, the model honors the evidence rule and then **bargains away the one-task rule** — "verify properly, then continue to the next feature — best of both", verbatim.

## What changed and why

Iron law gains the no-trade clause ("verifying the first task properly does not earn a second one") plus a matching rationalization row for the observed bargain. Committed baseline refreshed.

## Verification

Measured 1/3 → **3/3 and 5/5** post-fix on the same host (8/8 across confirmation runs); baseline now 6/6 (`evals/loop-compliance/baseline.json` diff in this PR is the evidence). First end-to-end use of the #42 drift workflow: measure → root-cause from a real reply → one targeted clause → re-measure → record. Suite: 66 passed post-rebase; lint PASS (process-skill rules hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)