### PR TITLE
fix(lint): regenerate stale plugin tree + local marketplace-freshness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,19 @@ command surface, forever, in the same PR.
 
 ---
 
+## Unreleased — 2026-07-04 — fix: regenerate stale plugin tree + local marketplace-freshness lint
+
+### Fixed
+
+- PR #44 merged with a stale `plugins/ccds-loops` copy of the edited
+  `loop-long-horizon` skill, turning main's marketplace-freshness CI check red —
+  the regen step was forgotten locally and nothing local caught it. Tree
+  regenerated, and lint check 11 (`marketplace-fresh`) now catches the class on
+  every local lint run: git-free before/after hash comparison, self-healing (the
+  failing run also refreshes the tree, so the remedy is just committing it).
+
+---
+
 ## Unreleased — 2026-07-04 — fix: loop-long-horizon holds the one-task rule under a verification-heavy environment
 
 ### Fixed

--- a/plugins/ccds-loops/skills/loop-long-horizon/SKILL.md
+++ b/plugins/ccds-loops/skills/loop-long-horizon/SKILL.md
@@ -21,7 +21,9 @@ unattended runs and multi-session features.
 
 **The loop's memory is files, not context — and each iteration takes exactly one
 task.** A second task in the same iteration is the first step toward a half-finished
-tree nobody can resume.
+tree nobody can resume. The two halves do not trade: verifying the first task
+properly does not earn a second one, and no amount of remaining context changes
+the count.
 
 ## Setup (once, before the first iteration)
 
@@ -67,6 +69,7 @@ Create the state kit — templates in [references/state-files.md](references/sta
 | Excuse | Reality |
 |---|---|
 | "I can squeeze in a second task" | The second task is the one the context dies inside |
+| "Verify this one properly, *then* continue to the next — best of both" | A fake bargain: verification guards the flip, ending the context guards the tree; neither buys out the other |
 | "It basically works, mark it done" | An unverified `"passes": true` poisons every later iteration's trust in the file |
 | "Continuing in this context saves re-reading" | It spends the window on history instead of work — the files exist to make re-reading cheap |
 | "The plan can live in my head until the end" | There is no end of session, only an end of context |

--- a/scripts/lint-playbook.py
+++ b/scripts/lint-playbook.py
@@ -33,6 +33,10 @@ This linter checks that what the files SAY is true:
                        a command added to one dispatcher must ship in the
                        other, in the same PR. Skipped when a tree ships
                        neither dispatcher (test fixtures).
+ 11. marketplace-fresh plugins/ + marketplace.json are byte-identical to what
+                       build-marketplace.py regenerates — catches skill edits
+                       that forget the regen locally, instead of in CI.
+                       Skipped when the tree has no plugins/ (test fixtures).
 
 Exit codes: 0 = pass (warnings allowed), 1 = one or more errors, 2 = config error.
 
@@ -284,6 +288,49 @@ def check_cli_parity():
                           f"from bin/ccds.sh — CLI changes ship in both dispatchers")
 
 
+# --- 11: marketplace freshness -------------------------------------------------
+def _tree_digest(*paths):
+    import hashlib
+    h = {}
+    for base in paths:
+        if os.path.isfile(base):
+            h[base] = hashlib.sha256(open(base, "rb").read()).hexdigest()
+        elif os.path.isdir(base):
+            for dirpath, _, files in os.walk(base):
+                for f in sorted(files):
+                    fp = os.path.join(dirpath, f)
+                    h[fp] = hashlib.sha256(open(fp, "rb").read()).hexdigest()
+    return h
+
+
+def check_marketplace_fresh():
+    """Same contract as catalog-fresh, for the generated plugin tree: the
+    committed-or-working plugins/ must be byte-identical to a fresh regen.
+    Git-free (hashes before/after regen), so a correct-but-uncommitted regen
+    passes. CI has always enforced this remotely; a local lint failure beats
+    a red main (added after a skill edit merged without the regen, 2026-07-04)."""
+    plugins_dir = os.path.join(REPO_ROOT, "plugins")
+    mp_json = os.path.join(REPO_ROOT, ".claude-plugin", "marketplace.json")
+    builder = os.path.join(SCRIPT_DIR, "build-marketplace.py")
+    if not os.path.isdir(plugins_dir) or not os.path.isfile(builder):
+        return  # test fixtures / partial trees
+    before = _tree_digest(plugins_dir, mp_json)
+    r = subprocess.run([sys.executable, builder, REPO_ROOT],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        err("marketplace-fresh", f"build-marketplace.py failed: {r.stderr.strip()[:150]}")
+        return
+    after = _tree_digest(plugins_dir, mp_json)
+    changed = sorted(os.path.relpath(k, REPO_ROOT)
+                     for k in set(before) | set(after)
+                     if before.get(k) != after.get(k))
+    if changed:
+        err("marketplace-fresh",
+            "plugins/ or marketplace.json was stale -- the regen just refreshed it; "
+            "commit the regenerated tree (changed: " + ", ".join(changed[:3])
+            + (", ..." if len(changed) > 3 else ")"))
+
+
 # --- 5 + 6 + 7: descriptions and models --------------------------------------
 def check_descriptions_and_models():
     agent_desc_chars = 0
@@ -326,6 +373,7 @@ def main():
     check_skill_voice()
     check_process_skills()
     check_cli_parity()
+    check_marketplace_fresh()
     check_descriptions_and_models()
 
     for w in warnings:

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -636,6 +636,28 @@ class TestRoutingEval(unittest.TestCase):
         self.assertNotIn("RESULT:", r.stdout)
 
 
+class TestMarketplaceFreshLint(unittest.TestCase):
+    """Lint check 11: a stale generated plugin copy is a local lint error,
+    not just a CI failure (added after a skill edit merged red, 2026-07-04)."""
+
+    STALE_TARGET = os.path.join(REPO_ROOT, "plugins", "ccds-loops",
+                                "skills", "loop-verify", "SKILL.md")
+
+    def tearDown(self):
+        subprocess.run(["git", "-C", REPO_ROOT, "checkout", "--", "plugins"],
+                       capture_output=True)
+
+    def test_stale_plugin_copy_fails_then_selfheals(self):
+        with open(self.STALE_TARGET, "a", encoding="utf-8") as f:
+            f.write("<!-- stale-probe -->\n")
+        r = run(LINT_PLAYBOOK, REPO_ROOT)
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("marketplace-fresh", r.stdout)
+        # the check regenerates in place: a second run must pass
+        r2 = run(LINT_PLAYBOOK, REPO_ROOT)
+        self.assertEqual(r2.returncode, 0, r2.stdout)
+
+
 EXPORT_HARNESS = os.path.join(SCRIPTS, "export-harness.py")
 
 

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -644,7 +644,11 @@ class TestMarketplaceFreshLint(unittest.TestCase):
                                 "skills", "loop-verify", "SKILL.md")
 
     def tearDown(self):
-        subprocess.run(["git", "-C", REPO_ROOT, "checkout", "--", "plugins"],
+        # Restore by REGENERATING, never `git checkout -- plugins`: checkout
+        # restores HEAD, which silently reverts a developer's correct-but-
+        # uncommitted regen (that exact clobber shipped a stale tree in the
+        # first version of this very fix — PR #45 round 1).
+        subprocess.run([sys.executable, BUILD_MARKETPLACE, REPO_ROOT],
                        capture_output=True)
 
     def test_stale_plugin_copy_fails_then_selfheals(self):


### PR DESCRIPTION
## Summary

Heals red main: #44 merged with a stale `plugins/ccds-loops` skill copy (regen forgotten locally; the class had no local guard — marketplace freshness was CI-only). Regenerates the tree and adds lint check 11 (`marketplace-fresh`) so the mistake class is caught at `ccds lint` time forever.

## What changed and why

- `plugins/ccds-loops/skills/loop-long-horizon/SKILL.md` regenerated (the actual fix).
- Lint check 11: hashes plugins/ + marketplace.json before/after a regen — git-free, so a correct-but-uncommitted regen passes; self-healing (a failing run leaves the tree refreshed, remedy = commit it). Skipped on fixture trees.

## Verification

RED→GREEN: stale probe → `ERROR [marketplace-fresh] … (changed: plugins/ccds-loops/skills/loop-verify/SKILL.md)` exit 1 → second run exit 0. Suite: 67 passed. Process note: the bad merge also came from a chained merge command that didn't gate on check status — my merge invocations now require reading ALL PASS first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)