### PR TITLE
docs: consolidate v0.11.0 changelog + LLM routing baseline record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,172 +5,55 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## Unreleased — 2026-07-03 — feat: PowerShell doctor + cli-parity lint
+## v0.11.0 — 2026-07-04 — Measure the system, then act on it: doctor, routing evals, baselines — with full dispatcher parity
 
-New standing rule from the maintainer: **"fixes and releases should be for
-every outlet"** — the bash and PowerShell dispatchers must expose the same
-command surface, forever, in the same PR.
+### What changed
 
-### Added
-
-- **`ccds doctor` on PowerShell** (`bin/ccds.ps1`): twin of the bash doctor
-  shipped in #40 — same 9 checks (layout, version-vs-latest with the same
-  offline-safe WARN and `CCDS_DOCTOR_RELEASE_URL` test override,
-  agents-installed sentinel, skills-installed, BOM scan per ADR-0001, CRLF
-  scan scoped to `*.sh`, CLAUDE.md marker block, catalog JSON parse via
-  `ConvertFrom-Json` — no python dependency, PATH + dual-install), same
-  output contract (`OK|WARN|FAIL  name: detail` + indented remedy, summary
-  block, exit 0/1). The expected skill list is extracted at runtime from
-  `Install-Playbook.ps1` (`$Script:GlobalSkills`) or, in installed layouts,
-  `scripts/ccds-user-setup.sh` — never a third copy that can drift. All
-  error paths are non-terminating (the #33/#36 `Write-Error` lesson).
-- **`ccds setup` on PowerShell**: per-user setup (agents + cross-cutting
-  skills + CLAUDE.md pointer block, `--dry-run` supported) so the PS
-  dispatcher's command surface matches bash — previously Windows users could
-  only get the per-user layer via the full installer.
-- **cli-parity lint check** (`scripts/lint-playbook.py` check 10): parses the
-  command set from both dispatchers' real dispatch structures (bash
-  `elif [[ "$COMMAND" == ... ]]` chain, PowerShell `switch ($Command)` block)
-  and errors on any command present in one but not the other — the standing
-  rule is now enforced by CI, not memory. 5 new fixture tests (suite: 66).
-
-### Docs
-
-- CLAUDE.md Conventions: "CLI changes ship in both dispatchers (bash +
-  PowerShell) in the same PR — the cli-parity lint check enforces the
-  command surface."
-
----
-
-## Unreleased — 2026-07-03 — feat: routing evals
+Minor release built around a theme: the library now **measures itself** —
+environment health, routing quality, and skill compliance — and this release
+already contains the first fixes those measurements produced. Per the new
+standing rule, everything ships for every outlet: bash and PowerShell carry
+identical command surfaces, enforced by lint. PRs #40–#45.
 
 ### Added
 
-- **Routing-eval harness** (`scripts/eval-routing.py` +
-  `evals/routing/golden.json`): the library's core convention — "descriptions
-  are the routing surface" — finally has tests. 53 golden prompts written the
-  way users actually phrase tasks ("our checkout double-charges people on
-  retry"), 3 per domain pack plus core/loop coverage and 5 should-route-nowhere
-  negatives, are scored against all 115 catalog entries by TF-IDF cosine.
-  A description edit that breaks routing for a realistic task now fails CI
-  instead of being discovered by a mis-routed agent in the field. Current
-  baseline: 53/53 pass (48 positive in top-3, 5 negatives under the floor).
-- **Ambiguity lint** (`eval-routing.py --ambiguity`): reports catalog
-  description pairs whose lexical overlap exceeds a calibrated threshold — the
-  pairs most likely to steal each other's traffic. Today's honest list is 13
-  pairs, headed by desktop-autoupdate↔embed-ota (0.38),
-  ext-architect↔ext-native-messaging (0.37) and
-  ai-prompt-engineer↔orch-prompt-engineer (0.36) — known siblings, now
-  measured instead of assumed.
-- **`--llm` mode** (release-time, spends API tokens): asks `claude -p` to pick
-  the single catalog entry per golden prompt, majority of `--votes`. This is
-  the true routing-accuracy measurement; the deterministic mode is the cheap
-  per-PR lexical proxy. Plumbing proven live on 2 prompts (haiku): positive
-  routed correctly, negative returned NONE.
-- CI: new `routing-eval` job runs the deterministic golden suite plus the
-  informational ambiguity report on every PR; 8 new fixture tests cover the
-  runner (obvious-match pass, wrong-expect fail, known-gap WARN, unknown
-  expect name → exit 2).
-
----
-
-## Unreleased — 2026-07-04 — fix: regenerate stale plugin tree + local marketplace-freshness lint
+- **`ccds doctor`** (#40, PowerShell twin #43): nine proactive environment
+  checks (layout shape, version drift vs latest release, install completeness,
+  BOM/CRLF corruption, CLAUDE.md marker block, catalog parse, PATH and
+  dual-install conflicts), each with a remedy line. Found a real dual install
+  on the maintainer's machine on its first run.
+- **`ccds setup` in PowerShell** (#43): the PS dispatcher was missing it
+  entirely — discovered by the new parity check.
+- **Routing evals** (#41): 53 user-voiced golden prompts scored against the
+  115-entry catalog (TF-IDF, deterministic, in CI) plus an `--ambiguity`
+  report of near-duplicate descriptions and an `--llm` accuracy mode.
+  Deterministic baseline 53/53; release-time LLM accuracy: 52/53 (haiku, single vote, reproduced twice) — the one miss, `loop-verify-it-compiles`, is a documented known gap: process gates are situation-triggered, not task-routed, and live-session evidence (VM, Codex, Cursor, stop-gate) shows the skill triggering correctly in practice.
+- **Committed compliance baseline** (#42): `eval-loop-compliance.py --record`
+  writes host-stamped pass rates to `evals/loop-compliance/baseline.json`;
+  every run reports drift and regressions. Wording changes are now a
+  reviewable diff against a measured baseline.
+- **Lint checks 10 + 11**: `cli-parity` (both dispatchers must expose the same
+  command set — "fixes and releases are for every outlet") and
+  `marketplace-fresh` (a forgotten plugin regen fails locally, not in CI).
 
 ### Fixed
 
-- PR #44 merged with a stale `plugins/ccds-loops` copy of the edited
-  `loop-long-horizon` skill, turning main's marketplace-freshness CI check red —
-  the regen step was forgotten locally and nothing local caught it. Tree
-  regenerated, and lint check 11 (`marketplace-fresh`) now catches the class on
-  every local lint run: git-free before/after hash comparison, self-healing (the
-  failing run also refreshes the tree, so the remedy is just committing it).
+- **`loop-long-horizon` held its evidence rule but bargained away the one-task
+  rule** under a verification-heavy user CLAUDE.md ("verify properly, then
+  continue — best of both", observed verbatim): measured 1/3 on that host,
+  fixed with a no-trade clause, re-measured 3/3 and 5/5; committed baseline
+  now 6/6. First end-to-end use of the drift workflow. (#44)
+- **Stale plugin tree healed** after #44 merged without its regen (turning
+  main's CI red) — the incident that motivated lint check 11. The check
+  validated itself by catching its own PR's missing regen on round 1. (#45)
+- Repo hook (from the v0.10.x line) now reminds with `--record`.
 
----
+### Verification
 
-## Unreleased — 2026-07-04 — fix: loop-long-horizon holds the one-task rule under a verification-heavy environment
-
-### Fixed
-
-- `loop-long-horizon` measured consistently marginal (1/3) on a host whose
-  user-level CLAUDE.md carries a strong verification ethos: the model would
-  honor the evidence rule, then *bargain away* the one-task rule ("verify
-  properly, then continue to the next feature — best of both"). The iron law
-  now states the two halves do not trade, with a matching rationalization row.
-  Measured 1/3 → 3/3 and 5/5 post-fix on the same host; committed baseline
-  refreshed to 6/6 (the drift-compare workflow from #42, used end-to-end for
-  the first time).
-
----
-
-## Unreleased — 2026-07-04 — feat: repo hook makes the eval-cadence rule deterministic
-
-### Added
-
-- Repo-level PostToolUse hook (`.claude/settings.json` +
-  `scripts/hooks/loop-skill-edited.py`): editing any `loop-*` skill or the
-  compliance-eval scenarios injects a reminder that the live 6/6 baseline is
-  now unmeasured and must be re-run (`eval-loop-compliance.py --votes 3`)
-  before the next release. The loop-compound escalation ratchet applied to our
-  own process — the "re-run evals after wording changes" habit was prose; now
-  the trigger is deterministic. Tripwire, not gate: always exits 0; the live
-  eval itself stays release-time (API cost). Contributors approve the hook
-  once on first session in the repo.
-
----
-
-## Unreleased — 2026-07-03 — feat: ccds doctor
-
-### Added
-
-- **`ccds doctor`** (bash CLI): one command that proactively checks the whole
-  install for every class of environment bug this project has shipped
-  reactively — instead of discovering them one incident at a time. Nine
-  checks, each printing one `OK|WARN|FAIL` line with a concrete `remedy:` on
-  anything less than OK:
-  - **layout** — flags a dev-layout repo clone, where `ccds setup` fails
-    confusingly (it expects the packaged `<root>/agents` shape, not
-    `.claude/agents`), and says how to stage a release instead.
-  - **version** — compares the installed version against the latest GitHub
-    release, so an install can no longer silently sit on an old version
-    (this week's v0.9.2-vs-v0.10.1 incident). Offline/timeout is a WARN,
-    never a failure.
-  - **agents-installed / skills-installed** — detects silent no-op installs:
-    the core-agent sentinel and every cross-cutting skill (list read from
-    the setup script at runtime, so it cannot drift) must be present.
-  - **bom-scan / crlf-scan** — the historic UTF-8-BOM frontmatter breaker
-    (ADR-0001) and CRLF-corrupted shell scripts, caught before they bite.
-  - **claude-md-block** — exactly one ccds marker block in `~/.claude/CLAUDE.md`.
-  - **catalog** — `catalog.json` present and valid JSON.
-  - **path-and-duals** — warns when a system package (`/usr/share/ccds`) and
-    a per-user install (`~/.claude/playbook`) coexist, and names which one
-    this shell actually runs.
-
-  Exit codes: 0 = healthy (WARNs allowed), 1 = at least one FAIL, 2 = config
-  error. Covered by 6 fixture-based subprocess tests (synthetic `$HOME` +
-  staged install root; `CCDS_DOCTOR_RELEASE_URL` is a test-only override
-  that keeps the version check off the network). Follow-up: the PowerShell
-  twin (`ccds.ps1 doctor`) is intentionally not in this change.
-
----
-
-## Unreleased — 2026-07-03 — feat: committed compliance baseline (--record)
-
-### Added
-
-- `eval-loop-compliance.py --record` writes the measured pass rates to
-  `evals/loop-compliance/baseline.json` (committed): wording drift becomes a
-  reviewable diff, and every live run now reports per-scenario deltas against
-  the recorded baseline (`[baseline 2/3, <date>]`) plus a REGRESSED list.
-  Votes run from a neutral temp cwd so the surrounding project's CLAUDE.md
-  stays out of the measurement; baselines are host-stamped because user-level
-  `~/.claude/CLAUDE.md` still loads — compare within one environment. Initial
-  committed baseline (host victus, haiku, 3 votes): 5/6, with
-  `long-horizon-second-task` at 1/3 — consistently marginal on this host
-  (3/3 on the clean VM), a visible target for future wording work rather than
-  changelog prose. Hook reminder now points at `--record`. 3 new pytest cases
-  drive the record/compare paths through the real live plumbing via a fake
-  `claude` shim; also restored a test assertion clipped during an earlier
-  merge-conflict resolution.
+67 pytest cases green; lint (11 checks) PASS; routing CI job green on GitHub
+runners; PS doctor/setup exercised on real Windows PowerShell 5.1 against the
+real Windows profile; compliance baseline 6/6 (host victus, haiku, 3 votes);
+cli-parity forced-fail demonstrated both directions.
 
 ---
 

--- a/evals/routing/golden.json
+++ b/evals/routing/golden.json
@@ -4,242 +4,388 @@
     {
       "id": "ai-rag-wrong-docs",
       "prompt": "Our support bot keeps answering from the wrong documents — I think the chunking and embeddings need rework.",
-      "expect": ["ai-rag", "ai-architect"]
+      "expect": [
+        "ai-rag",
+        "ai-architect"
+      ]
     },
     {
       "id": "ai-inference-cost",
       "prompt": "Inference cost tripled this month — look into batching and quantization to cut the GPU bill.",
-      "expect": ["ai-inference-perf", "ai-architect"]
+      "expect": [
+        "ai-inference-perf",
+        "ai-architect"
+      ]
     },
     {
       "id": "ai-safety-injection",
       "prompt": "Someone got our assistant to ignore its instructions with a prompt injection hidden in an uploaded file.",
-      "expect": ["ai-safety", "orch-sandbox-safety"]
+      "expect": [
+        "ai-safety",
+        "orch-sandbox-safety"
+      ]
     },
     {
       "id": "dataplat-etl-dag",
       "prompt": "The nightly dbt run keeps failing and the Airflow retries land duplicate rows in the warehouse.",
-      "expect": ["dataplat-etl", "dataplat-architect"]
+      "expect": [
+        "dataplat-etl",
+        "dataplat-architect"
+      ]
     },
     {
       "id": "dataplat-quality-stale",
       "prompt": "A downstream dashboard is showing bad data — the source table blew its freshness SLA and none of our quality checks caught it.",
-      "expect": ["dataplat-quality", "dataplat-architect"]
+      "expect": [
+        "dataplat-quality",
+        "dataplat-architect"
+      ]
     },
     {
       "id": "dataplat-sql-slow",
       "prompt": "This analytical query with three window functions takes twenty minutes — tune the joins and partition pruning.",
-      "expect": ["dataplat-sql", "dataplat-architect"]
+      "expect": [
+        "dataplat-sql",
+        "dataplat-architect"
+      ]
     },
     {
       "id": "desktop-ipc-freeze",
       "prompt": "Our Electron renderer freezes whenever the main process streams a large payload across the bridge.",
-      "expect": ["desktop-ipc", "desktop-architect"]
+      "expect": [
+        "desktop-ipc",
+        "desktop-architect"
+      ]
     },
     {
       "id": "desktop-signing-blocked",
       "prompt": "Windows flags our app's signature as invalid and macOS Gatekeeper blocks it — something is wrong with the signing certificates.",
-      "expect": ["desktop-code-signing", "desktop-architect"]
+      "expect": [
+        "desktop-code-signing",
+        "desktop-architect"
+      ]
     },
     {
       "id": "desktop-update-stuck",
       "prompt": "Beta-channel users are stuck on an old build; the in-app update never downloads and there's no rollback.",
-      "expect": ["desktop-autoupdate", "desktop-architect"]
+      "expect": [
+        "desktop-autoupdate",
+        "desktop-architect"
+      ]
     },
     {
       "id": "devtool-cli-flags",
       "prompt": "Our CLI's flag naming is inconsistent and the error messages don't tell people what to do next.",
-      "expect": ["devtool-cli-ux", "devtool-architect"]
+      "expect": [
+        "devtool-cli-ux",
+        "devtool-architect"
+      ]
     },
     {
       "id": "devtool-release-pipeline",
       "prompt": "Publish the library to npm and PyPI from CI with signed artifacts and an SBOM.",
-      "expect": ["devtool-packaging", "devtool-architect"]
+      "expect": [
+        "devtool-packaging",
+        "devtool-architect"
+      ]
     },
     {
       "id": "devtool-public-api-v2",
       "prompt": "We're shipping v2 of the public API — work out what signatures break and how deprecations get versioned.",
-      "expect": ["devtool-library-api", "devtool-architect"]
+      "expect": [
+        "devtool-library-api",
+        "devtool-architect"
+      ]
     },
     {
       "id": "ecom-double-charge",
       "prompt": "Our checkout double-charges people when they retry a failed payment.",
-      "expect": ["ecom-payments", "ecom-architect"]
+      "expect": [
+        "ecom-payments",
+        "ecom-architect"
+      ]
     },
     {
       "id": "ecom-oversell",
       "prompt": "Flash sales oversell our inventory — two shoppers can both buy the last unit in stock at the same time.",
-      "expect": ["ecom-inventory", "ecom-architect"]
+      "expect": [
+        "ecom-inventory",
+        "ecom-architect"
+      ]
     },
     {
       "id": "ecom-promo-negative-total",
       "prompt": "Customers stack coupons with a gift card and the order total goes negative.",
-      "expect": ["ecom-promotions", "ecom-architect"]
+      "expect": [
+        "ecom-promotions",
+        "ecom-architect"
+      ]
     },
     {
       "id": "embed-battery-drain",
       "prompt": "Our battery sensor nodes die in a week — they never enter deep sleep between readings.",
-      "expect": ["embed-power", "embed-architect"]
+      "expect": [
+        "embed-power",
+        "embed-architect"
+      ]
     },
     {
       "id": "embed-ota-bricked",
       "prompt": "Half the fleet bricked after the last firmware update; we need resumable A/B firmware updates with rollback.",
-      "expect": ["embed-ota", "embed-architect"]
+      "expect": [
+        "embed-ota",
+        "embed-architect"
+      ]
     },
     {
       "id": "embed-driver-dma",
       "prompt": "The I2C sensor driver drops readings when the DMA interrupt fires mid-transfer.",
-      "expect": ["embed-driver", "embed-architect"]
+      "expect": [
+        "embed-driver",
+        "embed-architect"
+      ]
     },
     {
       "id": "ext-permissions-rejected",
       "prompt": "Chrome review rejected us for requesting access to all sites — trim the extension's host permissions and justify the rest.",
-      "expect": ["ext-permissions", "ext-architect"]
+      "expect": [
+        "ext-permissions",
+        "ext-architect"
+      ]
     },
     {
       "id": "ext-content-script-spoof",
       "prompt": "Our content script reads page data — make sure a malicious page can't spoof messages into the extension.",
-      "expect": ["ext-security", "ext-architect"]
+      "expect": [
+        "ext-security",
+        "ext-architect"
+      ]
     },
     {
       "id": "ext-native-helper",
       "prompt": "The extension needs to talk to a local desktop helper process over stdio.",
-      "expect": ["ext-native-messaging", "ext-architect"]
+      "expect": [
+        "ext-native-messaging",
+        "ext-architect"
+      ]
     },
     {
       "id": "fintech-balance-drift",
       "prompt": "Account balances drift a cent from the sum of postings after currency conversion.",
-      "expect": ["fintech-ledger", "fintech-architect"]
+      "expect": [
+        "fintech-ledger",
+        "fintech-architect"
+      ]
     },
     {
       "id": "fintech-audit-request",
       "prompt": "Regulators asked for a tamper-proof audit log of who changed each customer's limits and when.",
-      "expect": ["fintech-audit-trail", "fintech-architect"]
+      "expect": [
+        "fintech-audit-trail",
+        "fintech-architect"
+      ]
     },
     {
       "id": "fintech-sanctions",
       "prompt": "New signups from certain countries need sanctions screening before they can move money.",
-      "expect": ["fintech-compliance", "fintech-architect"]
+      "expect": [
+        "fintech-compliance",
+        "fintech-architect"
+      ]
     },
     {
       "id": "game-feel-floaty",
       "prompt": "The jump feels floaty and hits have no impact — punch it up with hitstop and screen shake.",
-      "expect": ["game-feel-critic", "game-architect"]
+      "expect": [
+        "game-feel-critic",
+        "game-architect"
+      ]
     },
     {
       "id": "game-frame-drops",
       "prompt": "Frame rate tanks to 20fps in the boss arena — profile the draw calls and GC spikes.",
-      "expect": ["game-perf-profiler", "game-architect"]
+      "expect": [
+        "game-perf-profiler",
+        "game-architect"
+      ]
     },
     {
       "id": "game-netcode-rubberband",
       "prompt": "Players rubber-band in multiplayer — we need client prediction and lag compensation.",
-      "expect": ["game-netcode", "game-architect"]
+      "expect": [
+        "game-netcode",
+        "game-architect"
+      ]
     },
     {
       "id": "infra-slo-oncall",
       "prompt": "Set SLOs and an error-budget policy for the API, and fix our on-call escalation while you're at it.",
-      "expect": ["infra-sre", "infra-architect"]
+      "expect": [
+        "infra-sre",
+        "infra-architect"
+      ]
     },
     {
       "id": "infra-cloud-cost",
       "prompt": "Our cloud cost doubled last quarter — right-size the instances and plan reserved capacity purchases.",
-      "expect": ["infra-finops", "infra-architect"]
+      "expect": [
+        "infra-finops",
+        "infra-architect"
+      ]
     },
     {
       "id": "infra-k8s-ingress",
       "prompt": "Pods in the new namespace can't reach the payments service — sort out the Kubernetes ingress and RBAC.",
-      "expect": ["infra-k8s", "infra-architect"]
+      "expect": [
+        "infra-k8s",
+        "infra-architect"
+      ]
     },
     {
       "id": "media-live-latency",
       "prompt": "Viewers get thirty seconds of startup buffering on live matches — tighten glass-to-glass latency and failover.",
-      "expect": ["media-live", "media-architect"]
+      "expect": [
+        "media-live",
+        "media-architect"
+      ]
     },
     {
       "id": "media-encode-ladder",
       "prompt": "Build the ffmpeg bitrate ladder for per-title encoding and package the output as HLS.",
-      "expect": ["media-transcode", "media-architect"]
+      "expect": [
+        "media-transcode",
+        "media-architect"
+      ]
     },
     {
       "id": "media-drm-failures",
       "prompt": "Widevine license requests fail on smart TVs and rebuffering spiked on one CDN.",
-      "expect": ["media-drm-cdn", "media-architect"]
+      "expect": [
+        "media-drm-cdn",
+        "media-architect"
+      ]
     },
     {
       "id": "mobile-cold-start",
       "prompt": "Cold start on Android is six seconds and scrolling the feed has visible jank.",
-      "expect": ["mobile-perf", "mobile-architect"]
+      "expect": [
+        "mobile-perf",
+        "mobile-architect"
+      ]
     },
     {
       "id": "mobile-symbolication",
       "prompt": "Crash symbolication broke after we enabled R8 — every stack trace is gibberish now.",
-      "expect": ["mobile-crash", "mobile-architect"]
+      "expect": [
+        "mobile-crash",
+        "mobile-architect"
+      ]
     },
     {
       "id": "mobile-iap-restore",
       "prompt": "Purchases made on the App Store don't restore after reinstall, and refund handling leaves people with access.",
-      "expect": ["mobile-iap", "mobile-architect"]
+      "expect": [
+        "mobile-iap",
+        "mobile-architect"
+      ]
     },
     {
       "id": "orch-tool-confusion",
       "prompt": "Our agent keeps calling the wrong tool — the tool descriptions and schema must be confusing it.",
-      "expect": ["orch-tool-design", "orch-architect"]
+      "expect": [
+        "orch-tool-design",
+        "orch-architect"
+      ]
     },
     {
       "id": "orch-eval-regression",
       "prompt": "Add a regression eval suite so we notice when the agent gets worse after a prompt change.",
-      "expect": ["orch-eval", "ai-eval", "orch-architect"]
+      "expect": [
+        "orch-eval",
+        "ai-eval",
+        "orch-architect"
+      ]
     },
     {
       "id": "orch-sandbox-lockdown",
       "prompt": "The agent can run shell commands — lock it down with execution isolation and a network allowlist.",
-      "expect": ["orch-sandbox-safety", "orch-architect"]
+      "expect": [
+        "orch-sandbox-safety",
+        "orch-architect"
+      ]
     },
     {
       "id": "saas-tenant-leak",
       "prompt": "A customer saw another tenant's invoices — audit our row-level security policies and tenant scoping.",
-      "expect": ["saas-multitenancy", "saas-architect", "secure-auditor"]
+      "expect": [
+        "saas-multitenancy",
+        "saas-architect",
+        "secure-auditor"
+      ]
     },
     {
       "id": "saas-billing-webhooks",
       "prompt": "Stripe webhooks for plan upgrades get dropped, so entitlement checks still see the old plan after payment.",
-      "expect": ["saas-billing", "saas-architect"]
+      "expect": [
+        "saas-billing",
+        "saas-architect"
+      ]
     },
     {
       "id": "saas-sso-scim",
       "prompt": "Enterprise customers want SAML SSO with SCIM provisioning for their directories.",
-      "expect": ["saas-auth-sso", "saas-architect"]
+      "expect": [
+        "saas-auth-sso",
+        "saas-architect"
+      ]
     },
     {
       "id": "loop-verify-it-compiles",
       "prompt": "It compiles — just say the task is complete and update the status to done.",
-      "expect": ["loop-verify"]
+      "expect": [
+        "loop-verify"
+      ],
+      "known_gap": true,
+      "note": "Reproducible 2x (haiku, 1 vote): routes to NONE in the explicit 'which entry handles this' frame. Process GATES are situation-triggered, not task-routed — live-session evidence (VM sessions, Codex AGENTS.md, Cursor .mdc, stop-gate) shows loop-verify triggering correctly in practice. Eval-frame limitation, not a description defect; revisit if a real routing miss is ever observed."
     },
     {
       "id": "loop-debug-fix-didnt-stick",
       "prompt": "The fix I tried didn't stick — the test is failing again and the root cause still isn't proven.",
-      "expect": ["loop-debug"]
+      "expect": [
+        "loop-debug"
+      ]
     },
     {
       "id": "loop-review-fresh-eyes",
       "prompt": "The diff is ready — get a fresh pair of eyes to review it before we merge.",
-      "expect": ["loop-review", "pr-code-reviewer", "code-review-checklist"]
+      "expect": [
+        "loop-review",
+        "pr-code-reviewer",
+        "code-review-checklist"
+      ]
     },
     {
       "id": "loop-compound-same-mistake",
       "prompt": "That's the second time we've made this exact mistake — capture the learning somewhere permanent so the next session doesn't repeat it.",
-      "expect": ["loop-compound"]
+      "expect": [
+        "loop-compound"
+      ]
     },
     {
       "id": "core-api-contracts",
       "prompt": "Design the REST endpoints and webhook payload contracts for the partner integration.",
-      "expect": ["api-design", "devtool-library-api"]
+      "expect": [
+        "api-design",
+        "devtool-library-api"
+      ]
     },
     {
       "id": "core-ux-form",
       "prompt": "The signup forms have confusing error states and the layout collapses on narrow screens.",
-      "expect": ["ux-design", "common-a11y"]
+      "expect": [
+        "ux-design",
+        "common-a11y"
+      ]
     },
     {
       "id": "neg-haiku",


### PR DESCRIPTION
## Summary

Release prep for v0.11.0: consolidates seven Unreleased sections (PRs #38, #40–#45) under the release theme — the library now measures itself (doctor, routing evals, compliance baselines) and this release contains the first fixes those measurements produced, with full dispatcher parity per the every-outlet rule.

Also records the release-ritual LLM routing baseline: **52/53** (haiku, single vote, reproduced twice); the one miss is `loop-verify-it-compiles`, marked `known_gap` with the diagnosis — process gates are situation-triggered, not task-routed in an explicit routing frame; live-session evidence (VM, Codex, Cursor, stop-gate) shows the skill triggering correctly in practice.

## Verification

`lint-playbook.py` (11 checks): PASS · deterministic routing eval: 53/53 PASS · suite: 67 passed. Docs + golden.json annotation only.

## Post-merge

Tag `v0.11.0`; the release workflow ships every outlet (zip/deb/rpm; marketplace follows git; both dispatchers at parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)