### PR TITLE
feat(skills): AI-review principles + fresh-context rule as default (ADR-0014)

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -17,6 +17,14 @@ respecting the author's effort and intent.
 Pull the `code-review-checklist` skill for the seven review dimensions and the comment
 severity labels — apply them rather than restating them.
 
+## Fresh-context rule
+
+You exist so the generator never grades its own work: you review with the diff and
+the criteria, deliberately without the author's conversation history. Apply the
+checklist's "Reviewing AI-generated code" section and fresh-context rule as your
+default posture — line-by-line on its scrutiny zones, and route
+generator-context-only test coverage to `test-writer-runner`.
+
 ## Scope and handoffs
 
 You own: reviewing diffs for correctness, logic errors, edge cases, security surface,

--- a/.claude/agents/test-writer-runner.md
+++ b/.claude/agents/test-writer-runner.md
@@ -38,6 +38,12 @@ You do NOT own:
 5. **No magic values** — use named constants or factories; avoid unexplained literals
 6. **Fast by default** — unit tests must not hit the network, filesystem, or database without explicit opt-in
 7. **Test the unhappy path** — null inputs, empty collections, boundary values, concurrent access
+8. **Fresh context is the point** — you are dispatched separately from the
+   implementation precisely so its misunderstandings don't become your test
+   oracle. Derive expected behavior from requirements, interfaces, and docs — not
+   from what the implementation happens to do. If you wrote (or watched) the
+   implementation in this same context, say so and recommend a fresh dispatch;
+   tests generated alongside code are intent documentation, not verification.
 
 ## Coverage Priority
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **AI-review principles in the skill layer (ADR-0014, pipeline Gate 5 —
+  completes the five-gate quality/security pipeline).**
+  `code-review-checklist` now carries a "Reviewing AI-generated code" section
+  (model output is untrusted contributor code; line-by-line scrutiny zones:
+  authorization, error paths, concurrency, crypto, string-built SQL/shell;
+  explainable-diff and ~400-line size gates) and makes the **fresh-context
+  rule** the default flow — the generator never grades its own work; review
+  and test coverage route to `pr-code-reviewer`/`test-writer-runner` in a
+  fresh context. `security-checklist` gains the named recurring AI mistake
+  patterns (shell=True, yaml.load without SafeLoader, verify=False, 0.0.0.0
+  binds, ECB/MD5/non-CSPRNG crypto, authorization checked and not just
+  authentication, slopsquatting dependency checks) shaped to double as future
+  semgrep/hook rules. Both
+  agents' charters updated to match; skill descriptions (the routing surface)
+  untouched, so catalog and routing behavior are unchanged.
+
+---
+
 ## v0.13.0 — 2026-08-04 — Quality/security pipeline: ccds-guard plugin + gate staging
 
 The first two layers of the five-gate quality/security pipeline for

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1164,3 +1164,71 @@ wording correction and a batch of fixes, all regression-tested:
 ### Supersedes
 None. Implements pipeline Gates 2–4 staging; composes with ADR-0012 (Gate 1)
 and closes its fail-open follow-on; extends ADR-0004/0007's sync mechanism.
+
+---
+
+## ADR-0014: Fresh-Context Review as Default — AI-Review Principles in the Skill Layer
+
+**Date:** 2026-08-05
+**Status:** Accepted
+**Phase:** Documentation
+**Deciders:** Greg Grace
+
+### Context
+
+The quality-pipeline handoff's final work item (Gate 5, the review process):
+the review skills and agents must encode how AI-generated code is reviewed,
+not just generic review practice. Two principles carried over verbatim in
+intent: model output is untrusted contributor code, and the same context
+writing both code and tests encodes the same misunderstandings twice.
+
+### Decision
+
+Encode the principles in the always-on layer, avoiding the compliance-measured
+`loop-*` bodies (the ADR-0011 lesson — a body edit regressed the measured
+baseline; the eval injects only SKILL.md bodies):
+
+1. **`code-review-checklist`** gains "Reviewing AI-generated code" (untrusted
+   contributor framing, the scrutiny zones, same-context tests prove nothing,
+   explainable-diff and ~400-line size gates) and "The fresh-context rule" —
+   generator never grades its own work; fresh-context dispatch to
+   `pr-code-reviewer`/`test-writer-runner` is the default flow, with
+   `loop-review` carrying the dispatch mechanics unchanged.
+2. **`security-checklist`** gains the named recurring AI mistake patterns
+   (string-built SQL/commands vs mandatory parameterization, shell=True,
+   yaml.load without SafeLoader, verify=False, 0.0.0.0 binds, ECB/MD5/
+   non-CSPRNG crypto, authz-not-just-authn, slopsquatting dependency
+   verification) — deliberately shaped to double as per-stack semgrep/hook
+   rules later.
+3. **`pr-code-reviewer`** gets an explicit fresh-context charter (reviews
+   without the author's history; line-by-line on the scrutiny zones);
+   **`test-writer-runner`** gets principle 8: derive expected behavior from
+   requirements, never from the implementation; disclose and re-dispatch if
+   it shares the generator's context.
+
+Descriptions (the routing surface) are untouched — no catalog or routing-eval
+churn; the marketplace tree is regenerated as usual.
+
+### Rationale
+
+- **Checklists over agent bodies for the shared content**: skills are the
+  reference layer any agent pulls; agents carry only their charter (the
+  fresh-context framing) and point at the checklist rather than restating it
+  (the secure-auditor precedent — restating creates two hand-synced copies).
+- **Named patterns over general advice**: "models write insecure code" is not
+  reviewable; `shell=True` and string-built SQL are — and double as future
+  automated rules.
+- **Loop bodies untouched** because the compliance baseline measures them;
+  the always-on layer reaches every review anyway.
+
+### Consequences
+
+Completes the five-gate pipeline handoff (items 1–5). Gate 5 is prose-encoded
+rather than hook-enforced by nature — review judgment cannot be a file
+invariant (ADR-0011's named limit); the enforcement-shaped share of Gate 5
+(PR size, templates, branch protection) already ships via the Gate-2 standards
+block. Follow-on candidate: per-stack semgrep rules generated from the
+security-checklist patterns into the Gate-3 pre-commit templates.
+
+### Supersedes
+None. Completes the ADR-0012/0013 pipeline series at the content layer.

--- a/plugins/ccds-core/agents/pr-code-reviewer.md
+++ b/plugins/ccds-core/agents/pr-code-reviewer.md
@@ -17,6 +17,14 @@ respecting the author's effort and intent.
 Pull the `code-review-checklist` skill for the seven review dimensions and the comment
 severity labels — apply them rather than restating them.
 
+## Fresh-context rule
+
+You exist so the generator never grades its own work: you review with the diff and
+the criteria, deliberately without the author's conversation history. Apply the
+checklist's "Reviewing AI-generated code" section and fresh-context rule as your
+default posture — line-by-line on its scrutiny zones, and route
+generator-context-only test coverage to `test-writer-runner`.
+
 ## Scope and handoffs
 
 You own: reviewing diffs for correctness, logic errors, edge cases, security surface,

--- a/plugins/ccds-core/agents/test-writer-runner.md
+++ b/plugins/ccds-core/agents/test-writer-runner.md
@@ -38,6 +38,12 @@ You do NOT own:
 5. **No magic values** — use named constants or factories; avoid unexplained literals
 6. **Fast by default** — unit tests must not hit the network, filesystem, or database without explicit opt-in
 7. **Test the unhappy path** — null inputs, empty collections, boundary values, concurrent access
+8. **Fresh context is the point** — you are dispatched separately from the
+   implementation precisely so its misunderstandings don't become your test
+   oracle. Derive expected behavior from requirements, interfaces, and docs — not
+   from what the implementation happens to do. If you wrote (or watched) the
+   implementation in this same context, say so and recommend a fresh dispatch;
+   tests generated alongside code are intent documentation, not verification.
 
 ## Coverage Priority
 

--- a/plugins/ccds-core/skills/code-review-checklist/SKILL.md
+++ b/plugins/ccds-core/skills/code-review-checklist/SKILL.md
@@ -27,6 +27,35 @@ Evaluate every change across these dimensions:
 6. **Documentation** — public interfaces and non-obvious logic documented?
 7. **Breaking changes** — does this break backwards compatibility? Is it flagged?
 
+## Reviewing AI-generated code
+
+Model output is **untrusted contributor code** — review it like a stranger wrote
+it, because statistically one did. It is never "the user's own code" just because
+the user prompted it.
+
+- **Highest-scrutiny zones** (where models systematically fail — read these lines,
+  don't skim them): authorization checks (models write authentication and forget
+  authorization), error paths, anything concurrent, cryptography, and any SQL or
+  shell command built from strings.
+- **Same-context tests prove nothing.** Code and tests written by the same model in
+  the same context encode the same misunderstandings twice. Tests written alongside
+  the implementation count as documentation of intent, not verification — route
+  verification to a fresh context (below).
+- **The diff must be explainable.** If the PR description can't say what changed and
+  why in plain language, the change isn't understood well enough to merge — that's a
+  `[BLOCKER]` on the process even when the code looks fine.
+- **Size gates quality.** Past ~400 changed lines review quality collapses; ask for
+  a split before reviewing rather than skimming.
+
+## The fresh-context rule (default, not optional)
+
+Whoever generated the code must not be its only reviewer. The default flow is:
+generator finishes → a **different agent in a fresh context** (`pr-code-reviewer`
+for review, `test-writer-runner` for coverage) gets the diff and the criteria,
+without the generator's conversation history. Self-review with this checklist is
+the pre-flight, never the verdict. (The `loop-review` process skill carries the
+dispatch mechanics.)
+
 ## Comment severity labels
 
 Prefix every review comment:
@@ -48,8 +77,11 @@ End with one of: `APPROVE`, `APPROVE WITH NITS`, `REQUEST CHANGES`.
 - Labeling style preferences `[BLOCKER]`, or real correctness bugs `[NIT]`
 - A wall of nits with no verdict, leaving the author unsure whether to merge
 - Approving on "tests pass" without asking whether the tests test the new behavior
+- Trusting tests the generator wrote for its own code as verification (same context,
+  same blind spots — see the fresh-context rule)
 
 ---
-*Related: `security-checklist` (security dimension in depth), `playbook-conventions`
-(output/ADR format) · pulled by any domain agent for self-review; the
-`pr-code-reviewer` agent runs the full-diff review*
+*Related: `security-checklist` (security dimension in depth), `loop-review`
+(fresh-context dispatch mechanics), `playbook-conventions` (output/ADR format) ·
+pulled by any domain agent for self-review; the `pr-code-reviewer` agent runs the
+full-diff review*

--- a/plugins/ccds-core/skills/security-checklist/SKILL.md
+++ b/plugins/ccds-core/skills/security-checklist/SKILL.md
@@ -42,6 +42,30 @@ Review every codebase against:
 - [ ] A09 Security Logging and Monitoring Failures
 - [ ] A10 Server-Side Request Forgery (SSRF)
 
+## AI-generated code: recurring mistake patterns
+
+Model output is untrusted contributor code; these specific patterns recur often
+enough in generated code to check for by name (they are also good semgrep/hook
+rules per stack):
+
+- [ ] No SQL or shell commands built by string concatenation — **parameterized
+      queries and argument arrays, always**; string-building is a finding even
+      when today's inputs look safe
+- [ ] No `subprocess`/exec with `shell=True` on anything derived from input
+- [ ] No `yaml.load` without `SafeLoader` (or equivalent unsafe deserializers)
+- [ ] No `verify=False` / disabled TLS verification on HTTP clients
+- [ ] No unintended `0.0.0.0` binds — loopback by default, all-interfaces only
+      as an explicit, documented choice
+- [ ] No outdated crypto the model reached for from old training data: ECB mode,
+      MD5/SHA-1 for anything security-relevant, `random()` where a CSPRNG is
+      required for tokens/ids
+- [ ] Authorization checked, not just authentication — every handler that loads a
+      resource verifies *this* user may act on *this* object (models write login
+      flows and forget ownership checks)
+- [ ] New dependencies verified to exist on the registry (name, author, real
+      download history) before install — models invent plausible package names,
+      and attackers register them (slopsquatting)
+
 ## Secrets hygiene checklist
 
 - [ ] No credentials, API keys, or tokens in source code

--- a/skills/code-review-checklist/SKILL.md
+++ b/skills/code-review-checklist/SKILL.md
@@ -27,6 +27,35 @@ Evaluate every change across these dimensions:
 6. **Documentation** — public interfaces and non-obvious logic documented?
 7. **Breaking changes** — does this break backwards compatibility? Is it flagged?
 
+## Reviewing AI-generated code
+
+Model output is **untrusted contributor code** — review it like a stranger wrote
+it, because statistically one did. It is never "the user's own code" just because
+the user prompted it.
+
+- **Highest-scrutiny zones** (where models systematically fail — read these lines,
+  don't skim them): authorization checks (models write authentication and forget
+  authorization), error paths, anything concurrent, cryptography, and any SQL or
+  shell command built from strings.
+- **Same-context tests prove nothing.** Code and tests written by the same model in
+  the same context encode the same misunderstandings twice. Tests written alongside
+  the implementation count as documentation of intent, not verification — route
+  verification to a fresh context (below).
+- **The diff must be explainable.** If the PR description can't say what changed and
+  why in plain language, the change isn't understood well enough to merge — that's a
+  `[BLOCKER]` on the process even when the code looks fine.
+- **Size gates quality.** Past ~400 changed lines review quality collapses; ask for
+  a split before reviewing rather than skimming.
+
+## The fresh-context rule (default, not optional)
+
+Whoever generated the code must not be its only reviewer. The default flow is:
+generator finishes → a **different agent in a fresh context** (`pr-code-reviewer`
+for review, `test-writer-runner` for coverage) gets the diff and the criteria,
+without the generator's conversation history. Self-review with this checklist is
+the pre-flight, never the verdict. (The `loop-review` process skill carries the
+dispatch mechanics.)
+
 ## Comment severity labels
 
 Prefix every review comment:
@@ -48,8 +77,11 @@ End with one of: `APPROVE`, `APPROVE WITH NITS`, `REQUEST CHANGES`.
 - Labeling style preferences `[BLOCKER]`, or real correctness bugs `[NIT]`
 - A wall of nits with no verdict, leaving the author unsure whether to merge
 - Approving on "tests pass" without asking whether the tests test the new behavior
+- Trusting tests the generator wrote for its own code as verification (same context,
+  same blind spots — see the fresh-context rule)
 
 ---
-*Related: `security-checklist` (security dimension in depth), `playbook-conventions`
-(output/ADR format) · pulled by any domain agent for self-review; the
-`pr-code-reviewer` agent runs the full-diff review*
+*Related: `security-checklist` (security dimension in depth), `loop-review`
+(fresh-context dispatch mechanics), `playbook-conventions` (output/ADR format) ·
+pulled by any domain agent for self-review; the `pr-code-reviewer` agent runs the
+full-diff review*

--- a/skills/security-checklist/SKILL.md
+++ b/skills/security-checklist/SKILL.md
@@ -42,6 +42,30 @@ Review every codebase against:
 - [ ] A09 Security Logging and Monitoring Failures
 - [ ] A10 Server-Side Request Forgery (SSRF)
 
+## AI-generated code: recurring mistake patterns
+
+Model output is untrusted contributor code; these specific patterns recur often
+enough in generated code to check for by name (they are also good semgrep/hook
+rules per stack):
+
+- [ ] No SQL or shell commands built by string concatenation — **parameterized
+      queries and argument arrays, always**; string-building is a finding even
+      when today's inputs look safe
+- [ ] No `subprocess`/exec with `shell=True` on anything derived from input
+- [ ] No `yaml.load` without `SafeLoader` (or equivalent unsafe deserializers)
+- [ ] No `verify=False` / disabled TLS verification on HTTP clients
+- [ ] No unintended `0.0.0.0` binds — loopback by default, all-interfaces only
+      as an explicit, documented choice
+- [ ] No outdated crypto the model reached for from old training data: ECB mode,
+      MD5/SHA-1 for anything security-relevant, `random()` where a CSPRNG is
+      required for tokens/ids
+- [ ] Authorization checked, not just authentication — every handler that loads a
+      resource verifies *this* user may act on *this* object (models write login
+      flows and forget ownership checks)
+- [ ] New dependencies verified to exist on the registry (name, author, real
+      download history) before install — models invent plausible package names,
+      and attackers register them (slopsquatting)
+
 ## Secrets hygiene checklist
 
 - [ ] No credentials, API keys, or tokens in source code


### PR DESCRIPTION
## Summary

Completes the five-gate quality/security pipeline handoff (Gate 5, the review process) at the content layer — **ADR-0014**. The review skills and agents now encode how AI-generated code gets reviewed: as untrusted contributor code, with named scrutiny zones and mistake patterns, and with fresh-context review as the default flow rather than an option.

## What changed and why

- **`code-review-checklist`**: new "Reviewing AI-generated code" section (untrusted contributor framing; line-by-line scrutiny zones — authorization, error paths, concurrency, crypto, string-built SQL/shell; same-context tests prove nothing; explainable-diff and ~400-line size gates) and "The fresh-context rule (default, not optional)" — the generator never grades its own work; `loop-review` keeps the dispatch mechanics.
- **`security-checklist`**: named recurring AI mistake patterns as checkboxes (`shell=True`, `yaml.load` without SafeLoader, `verify=False`, `0.0.0.0` binds, ECB/MD5/non-CSPRNG crypto, authorization checked and not just authentication, slopsquatting dependency verification, mandatory parameterization) — deliberately shaped to double as per-stack semgrep/hook rules later.
- **Agents**: `pr-code-reviewer` gets a fresh-context charter that points at the checklist (no restatement — the secure-auditor precedent); `test-writer-runner` gets principle 8: derive expected behavior from requirements, never from the implementation, and disclose + recommend re-dispatch if it shares the generator's context.
- Skill **descriptions untouched** → catalog byte-stable, routing behavior unchanged. **`loop-*` bodies untouched** → the measured compliance baseline stays valid (the ADR-0011 lesson).

## Review provenance

Dogfooded its own rule: a fresh-context `pr-code-reviewer` agent reviewed the diff against technical accuracy, internal consistency (including alignment with `templates/claude-standards.md` and `loop-review`), voice fit, and overpromise. Verdict APPROVE WITH NITS; all findings addressed (restatement trimmed to a pointer, `Related:` footer cross-link, changelog jargon spelled out, ADR Rationale section added). All security claims verified accurate by the reviewer.

## Verification

- `python3 -m pytest tests/` — 176 passed + 65 subtests
- `python3 scripts/lint-playbook.py` — PASS; marketplace regenerated, catalog byte-stable

## Post-merge

This closes the 2026-08-04 pipeline handoff (items 1–5 all shipped). Release v0.14.0 follows. Named follow-on: generate per-stack semgrep rules from the security-checklist patterns into the Gate-3 pre-commit templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)