### PR TITLE
fix(install): every outlet installs the enforcement plugins (ADR-0016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Every install outlet now installs the enforcement plugins (ADR-0016).**
+  What was wrong: `ccds-guard` (the whole Gate 1 security layer) and
+  `ccds-loops` (process enforcement) were only ever installed by the two
+  script installers. If you installed the `.deb`/`.rpm`, ran `ccds setup`, or
+  let `ccds sync` do its first-run setup, you got the 19 agents and the
+  cross-cutting skills and **neither hook layer** — no secret-file guard, no
+  dangerous-command blocks, no install ask-gate — with nothing in the output
+  saying so. The product looked complete and was not. ADR-0012 had already
+  decided every outlet should converge on the plugin install; only the
+  installers implemented it.
+
+  The step now lives in per-user setup, the one path every outlet runs, so
+  deb/rpm, `ccds setup`, `ccds sync`'s lazy first-run setup, and the
+  installers all share one implementation. Opt out with `--skip-plugins` /
+  `-SkipPlugins`. It stays best-effort and never fails an install: with no
+  `claude` CLI on `PATH` it warns, names what you are missing, and prints the
+  exact commands for later. Manual extraction of the release ZIP still wires
+  nothing — the ZIP carries no plugin tree; use an installer or the plugin
+  marketplace.
+
+### Changed
+
+- **PowerShell `ccds sync` now performs first-run per-user setup**, matching
+  bash. Previously a Windows user who only ever ran `ccds sync` never got
+  agents, skills, or the `CLAUDE.md` block installed at all unless they
+  thought to run `ccds setup` — and after the fix above, would have been the
+  one outlet still missing the plugins.
+- `ccds-user-setup.sh` accepts `--dry-run` and `--skip-plugins` in any order,
+  and now **rejects an unknown flag** instead of ignoring it. The old
+  positional parsing treated anything that wasn't exactly `--dry-run` in the
+  second slot as absent, so a typo'd `--dry-run` silently made real changes.
+
+---
+
 ## v0.15.0 — 2026-08-07 — Unattended loops stop stalling on the guard's ask-gates
 
 **Heads-up: this release raises the minimum Claude Code version to v2.1.169**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ composable expertise any agent (or the main loop) pulls in place. Authoring rule
 thumb: isolated multi-step work → agent; reference/checklist others must reach → skill.
 
 A third layer, **hooks**, ships only via plugins (never via the installer writing user
-settings — ADR-0012): `ccds-loops` carries the process-enforcement hooks (ADR-0011) and
+settings — ADR-0012), and **every outlet installs them from per-user setup** —
+`scripts/ccds-user-setup.sh` step 4 and its `bin/ccds.ps1` twin, which the deb/rpm
+postinst, `ccds setup`, `ccds sync`'s first run, and the installers all funnel through
+(ADR-0016). Put outlet-wide install behavior there, never in an installer.
+`ccds-loops` carries the process-enforcement hooks (ADR-0011) and
 `ccds-guard` the zero-config security guard (secret-path denies, dangerous-command
 blocks, install ask-gate, config tamper watch; rules in `hooks/guard-rules.txt`, kill
 switch `CCDS_GUARD_DISABLE=1`; in unattended/auto-accept sessions ask-gates are decided

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1403,3 +1403,106 @@ prompt:
 ### Supersedes
 None. Amends the ADR-0012 charter's ask-tier behavior for unattended
 sessions.
+
+---
+
+## ADR-0016: Enforcement Plugins Install From Per-User Setup, Not the Installers
+
+**Date:** 2026-08-07
+**Status:** Accepted
+**Phase:** Architecture
+**Deciders:** Greg Grace
+
+### Context
+
+ADR-0012 decided that plugins are the only hook-shipping mechanism and that
+every outlet converges on it: "the classic installer … registers the repo as a
+marketplace and runs `claude plugin install ccds-guard@ccds` (and
+`ccds-loops@ccds`) by default, with a `--skip-plugins` flag to opt out."
+
+Only the two *script* installers ever implemented it. Traced outlet by outlet
+against the shipped v0.15.0 tree:
+
+| Outlet | Plugins wired? |
+|---|---|
+| `install-playbook.sh` / `Install-Playbook.ps1` | yes |
+| `ccds update` (re-invokes the installer) | yes |
+| `/plugin marketplace add` (documented "recommended" path) | yes — plugins *are* the artifact |
+| **`.deb` / `.rpm`** → `packaging/postinst` → `ccds-user-setup.sh` | **no** |
+| **`ccds setup`** (bash and PowerShell) | **no** |
+| **`ccds sync` first-run lazy setup** (bash) | **no** |
+| **Manual ZIP extraction** | **no** — and the ZIP contains no `plugins/` at all |
+
+A `.deb` user therefore got the 19 agents and the cross-cutting skills and
+**no `ccds-guard` and no `ccds-loops`** — the entire Gate 1 security layer and
+the process-enforcement layer, absent, with nothing in the output saying so.
+The product looked complete and was not.
+
+Root cause is placement, not logic: the step lived in the outermost layer
+(the installers) instead of the innermost one every outlet shares.
+
+### Decision
+
+1. **Per-user setup owns the plugin step.** `scripts/ccds-user-setup.sh` gains
+   Step 4 (`install_plugins`) and its own `Plugins :` status line; the bash
+   installer deletes its copy and forwards `--skip-plugins`. Every outlet that
+   runs per-user setup — deb/rpm postinst, `ccds setup`, `ccds sync`'s lazy
+   first-run setup, and the installer itself — now converges on one
+   implementation. Flags parse in any order and an **unknown flag is an error**
+   (the old positional `[[ "$2" == --dry-run ]]` silently ignored a typo and
+   made real changes).
+2. **Source and CLI are seams.** `CCDS_MARKETPLACE_SOURCE` (default
+   `ggrace519/claude-code-dev-studio`) and `CCDS_CLAUDE_CMD` (default `claude`)
+   follow the data-not-logic pattern of the guard's rule table. They exist so
+   tests can never reach a real marketplace or a real CLI — see Consequences.
+3. **`bin/ccds.ps1` gains the twin**, plus `Test-NeedsUserSetup` /
+   `Invoke-UserSetupIfNeeded` so PowerShell `ccds sync` performs first-run
+   setup like its bash counterpart. Without that, fixing `ccds setup` would
+   have left a *new* asymmetry: a Windows user who only ever runs `ccds sync`
+   would still get nothing.
+4. **`Install-Playbook.ps1` keeps its own copy.** It is a curl-piped
+   standalone script that cannot depend on an installed `ccds-user-setup.sh`
+   or `bin/ccds.ps1`. Named duplication, not an oversight.
+
+### Rationale
+
+- The fix belongs at the narrowest waist every outlet passes through. Adding
+  the step to each outlet instead would have re-created the same bug the next
+  time an outlet is added.
+- Best-effort, never fatal: a missing `claude` CLI warns, **names what is
+  missing** ("no security guard and no loop enforcement"), prints the exact
+  commands, and setup still succeeds. A security layer that fails an install
+  gets uninstalled; one that explains itself gets fixed.
+- GitHub stays the marketplace source (Greg's call), matching what the
+  installers and the README already do. Bundling `plugins/` into the packages
+  would make offline installs work and lock plugin versions to the package —
+  rejected for now as a second mechanism to maintain.
+
+### Consequences
+
+- deb/rpm and `ccds setup` users gain both hook layers. This is new
+  user-visible behavior on those outlets, hence a minor release, not a patch.
+- **Test hazard, fixed first in its own commit:** `TestDebPostinst._run`
+  appends the real `PATH` (postinst needs `getent`/`chmod`/`su`), so once
+  setup shelled out to `claude`, a plain `pytest` run would have hit the
+  developer's real CLI and mutated their actual marketplace registration —
+  `marketplace add`, then `update` on the already-exists path. The harness now
+  stubs `claude`, records argv for assertions, and pins `CCDS_CLAUDE_CMD` by
+  absolute path.
+- Still not covered, and stated rather than hidden: **manual ZIP extraction**
+  with no installer run wires nothing, because the ZIP ships no `plugins/`
+  tree and no `.claude-plugin/marketplace.json`. The README documents the
+  installer and the marketplace as the supported paths.
+- `install-playbook.sh` and `Install-Playbook.ps1` have **no test coverage at
+  all** (confirmed while tracing this). Deleting the bash installer's block
+  was verified by hand — `bash -n`, `--help`, and a real `--dry-run` run —
+  not by the suite. Test coverage for the installers is the standing gap this
+  ADR did not close.
+- Deferred follow-up, joining ADR-0015's `ccds doctor` CLI-version check: a
+  **doctor check that the two plugins are actually installed**. It is the
+  backstop that would have caught this entire class of bug, and it is a new
+  check in both dispatchers — its own PR.
+
+### Supersedes
+None. Completes ADR-0012's distribution decision, which was only
+half-implemented.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ staging via `ccds sync`.
 
 ## Install
 
-The installer downloads a GitHub Release ZIP, verifies its SHA256 against the sidecar, stages to `<prefix>.new`, snapshots the existing install to `<prefix>.previous`, and atomically promotes. It copies the 19 agents to `~/.claude/agents/`, the cross-cutting skills to `~/.claude/skills/`, injects the ccds block into `~/.claude/CLAUDE.md`, and updates `PATH` so `ccds` resolves in new shells. It also registers the ccds marketplace and installs the `ccds-guard` + `ccds-loops` enforcement plugins via the `claude` CLI (plugins are the only hook-shipping mechanism, ADR-0012) — skip with `--skip-plugins` / `-SkipPlugins`.
+The installer downloads a GitHub Release ZIP, verifies its SHA256 against the sidecar, stages to `<prefix>.new`, snapshots the existing install to `<prefix>.previous`, and atomically promotes. It copies the 19 agents to `~/.claude/agents/`, the cross-cutting skills to `~/.claude/skills/`, injects the ccds block into `~/.claude/CLAUDE.md`, and updates `PATH` so `ccds` resolves in new shells.
+
+**Every outlet installs the enforcement plugins** (ADR-0016). Per-user setup — which the script installers, the `.deb`/`.rpm` packages, and `ccds setup` all run — registers the ccds marketplace and installs `ccds-guard` + `ccds-loops` via the `claude` CLI, because plugins are the only hook-shipping mechanism (ADR-0012). Opt out with `--skip-plugins` / `-SkipPlugins`. It is best-effort and never fails the install: if the `claude` CLI is not on `PATH`, setup warns — naming what you are missing — and prints the exact commands to run later. Requires Claude Code on `PATH` and network access to reach the marketplace.
 
 **Windows (PowerShell 5.1 or 7+):**
 
@@ -141,7 +143,7 @@ sudo apt install ./ccds_<version>_all.deb     # Debian/Ubuntu
 sudo dnf install ./ccds-<version>-1.noarch.rpm # RHEL/Fedora
 ```
 
-The package installs the shared library to `/usr/share/ccds` and the `ccds` launcher to `/usr/bin/ccds`. Because the agents/skills/`CLAUDE.md` block are **per-user** (they live under `~/.claude/`), per-user setup runs for the installing user automatically when the package can identify them (`sudo`, polkit/GUI installers, or a login terminal).
+The package installs the shared library to `/usr/share/ccds` and the `ccds` launcher to `/usr/bin/ccds`. Because the agents/skills/`CLAUDE.md` block and the plugins are **per-user** (they live under `~/.claude/`), per-user setup — including the enforcement-plugin install above — runs for the installing user automatically when the package can identify them (`sudo`, polkit/GUI installers, or a login terminal). Other users on the box run `ccds setup` once.
 
 If you install from a bare root shell or a headless/CI/Docker context, the package cannot tell which user to set up — run setup yourself once per user:
 

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -118,8 +118,11 @@ COMMANDS
                        Exit 0 = healthy (WARNs allowed), 1 = failures found.
 
   setup                Install the always-on agents + cross-cutting skills into
-                       %USERPROFILE%\.claude\, inject the CLAUDE.md block
+                       %USERPROFILE%\.claude\, inject the CLAUDE.md block, and
+                       install the ccds-guard + ccds-loops enforcement plugins
+                       (ADR-0016)
       --dry-run             Preview without writing
+      --skip-plugins        Skip the enforcement-plugin install
 
   lint                 Lint the playbook library's semantic invariants
                        (skill cross-refs, catalog freshness, URL/description
@@ -173,6 +176,7 @@ function ConvertTo-Hashtable {
         WriteAdr          = $false
         Clean             = $false
         NoGates           = $false
+        SkipPlugins       = $false
         Target            = $null
         Rollback          = $false
         IncludePrerelease = $false
@@ -186,6 +190,7 @@ function ConvertTo-Hashtable {
             '^--write-adr$'           { $result.WriteAdr = $true; $i++; continue }
             '^--clean$'               { $result.Clean = $true; $i++; continue }
             '^--no-gates$'            { $result.NoGates = $true; $i++; continue }
+            '^--skip-plugins$'        { $result.SkipPlugins = $true; $i++; continue }
             '^--rollback$'            { $result.Rollback = $true; $i++; continue }
             '^--include-prerelease$'  { $result.IncludePrerelease = $true; $i++; continue }
             '^--target$' {
@@ -211,8 +216,32 @@ function ConvertTo-Hashtable {
 # ---------------------------------------------------------------------------
 # Command: sync
 # ---------------------------------------------------------------------------
+# Twin of bin/ccds.sh needs_user_setup / run_user_setup_if_needed. Without
+# this, a Windows user who only ever ran `ccds sync` never got per-user setup
+# at all -- and after ADR-0016 that also means never got the enforcement
+# plugins, while the bash user did. Same outlet, same result.
+function Test-NeedsUserSetup {
+    $claudeHome = Join-Path $env:USERPROFILE '.claude'
+    if (-not (Test-Path -LiteralPath (Join-Path $claudeHome 'agents\plan-architect.md'))) { return $true }
+    $claudeMd = Join-Path $claudeHome 'CLAUDE.md'
+    if (-not (Test-Path -LiteralPath $claudeMd)) { return $true }
+    if (-not (Select-String -LiteralPath $claudeMd -SimpleMatch '# >>> ccds >>>' -Quiet)) { return $true }
+    return $false
+}
+
+function Invoke-UserSetupIfNeeded {
+    param([hashtable]$Opts)
+    if (Test-NeedsUserSetup) {
+        Write-Host "==> First run: performing per-user setup..." -ForegroundColor Cyan
+        Invoke-SetupCommand -Opts $Opts
+        Write-Host ""
+    }
+}
+
 function Invoke-SyncCommand {
     param([hashtable]$Opts)
+
+    Invoke-UserSetupIfNeeded -Opts $Opts
 
     $target = if ($Opts.Target) { $Opts.Target } else { (Get-Location).Path }
 
@@ -388,10 +417,9 @@ function Invoke-SetupCommand {
     if (-not (Test-Path -LiteralPath $jitSrc)) {
         Write-Host "!!  jit-claude.md not found at $jitSrc -- skipping CLAUDE.md injection" -ForegroundColor Yellow
     } elseif ($Opts.DryRun) {
+        # No early return: Step 4 must still report what it *would* do, and the
+        # single "DRY RUN -- no changes made." line is printed at the end.
         Write-Host "    DRY RUN -- would inject/update ccds block in $claudeMd"
-        Write-Host ""
-        Write-Host "DRY RUN -- no changes made." -ForegroundColor Yellow
-        return
     } else {
         if (-not (Test-Path -LiteralPath $claudeHome)) {
             New-Item -ItemType Directory -Path $claudeHome -Force | Out-Null
@@ -422,12 +450,64 @@ function Invoke-SetupCommand {
         Write-Host "OK  Refreshed ccds block in $claudeMd" -ForegroundColor Green
     }
 
+    # Step 4 -- enforcement plugins (ADR-0016). Twin of ccds-user-setup.sh
+    # install_plugins: plugins are the only hook-shipping mechanism, so every
+    # outlet installs them. Best-effort; never fails setup.
+    $pluginStatus = 'skipped (-SkipPlugins)'
+    if (-not $Opts.SkipPlugins) {
+        $marketplace = if ($env:CCDS_MARKETPLACE_SOURCE) { $env:CCDS_MARKETPLACE_SOURCE }
+                       else { 'ggrace519/claude-code-dev-studio' }
+        $claudeCmd   = if ($env:CCDS_CLAUDE_CMD) { $env:CCDS_CLAUDE_CMD } else { 'claude' }
+        $plugins     = @('ccds-guard', 'ccds-loops')
+        Write-Host "==> Installing enforcement plugins ($($plugins -join ', '))" -ForegroundColor Cyan
+        if ($Opts.DryRun) {
+            $pluginStatus = 'dry run'
+            Write-Host "    DRY RUN -- would run:"
+            Write-Host "      $claudeCmd plugin marketplace add $marketplace"
+            foreach ($p in $plugins) {
+                Write-Host "      $claudeCmd plugin install $p@ccds --scope user"
+            }
+        } elseif (-not (Get-Command $claudeCmd -ErrorAction SilentlyContinue)) {
+            $pluginStatus = 'skipped (claude CLI not on PATH)'
+            Write-Host "!!  claude CLI not found -- skipping plugin install." -ForegroundColor Yellow
+            Write-Host "!!  Without these, this install has no security guard and no loop" -ForegroundColor Yellow
+            Write-Host "!!  enforcement. After installing Claude Code, run:" -ForegroundColor Yellow
+            Write-Host "!!    claude plugin marketplace add $marketplace" -ForegroundColor Yellow
+            foreach ($p in $plugins) {
+                Write-Host "!!    claude plugin install $p@ccds --scope user" -ForegroundColor Yellow
+            }
+        } else {
+            # `marketplace add` fails when already registered, and that
+            # registration may predate a plugin -- refresh instead of assuming.
+            & $claudeCmd plugin marketplace add $marketplace 2>$null | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "    marketplace 'ccds' already registered; refreshing catalog"
+                & $claudeCmd plugin marketplace update ccds 2>$null | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "!!  could not refresh marketplace 'ccds'; plugin installs may see a stale catalog" -ForegroundColor Yellow
+                }
+            }
+            $pluginStatus = "installed ($($plugins -join ', '))"
+            foreach ($p in $plugins) {
+                & $claudeCmd plugin install "$p@ccds" --scope user 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "OK  $p plugin installed (user scope)" -ForegroundColor Green
+                } else {
+                    $pluginStatus = 'partial -- see warnings'
+                    Write-Host "!!  Could not install $p automatically. Run:" -ForegroundColor Yellow
+                    Write-Host "!!    claude plugin install $p@ccds --scope user" -ForegroundColor Yellow
+                }
+            }
+        }
+    }
+
     if ($Opts.DryRun) {
         Write-Host ""
         Write-Host "DRY RUN -- no changes made." -ForegroundColor Yellow
     } else {
         Write-Host ""
         Write-Host "User setup complete." -ForegroundColor Green
+        Write-Host "Plugins     : $pluginStatus"
     }
 }
 

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -93,8 +93,11 @@ COMMANDS
                        (skill cross-refs, catalog freshness, URL/description
                        conventions). Requires a repo clone (dev layout).
 
-  setup                Install the 19 agents + cross-cutting skills, inject CLAUDE.md block
+  setup                Install the 19 agents + cross-cutting skills, inject the
+                       CLAUDE.md block, and install the ccds-guard + ccds-loops
+                       enforcement plugins (ADR-0016)
       --dry-run             Preview without writing
+      --skip-plugins        Skip the enforcement-plugin install
 
   loop init            Scaffold the long-horizon loop state-file kit into ./.loop/
                        (feature_list.json, progress.md, PROMPT.md, init.sh — see the
@@ -139,6 +142,7 @@ DRY_RUN=0
 WRITE_ADR=0
 CLEAN=0
 NO_GATES=0
+SKIP_PLUGINS=0
 TARGET=""
 ROLLBACK=0
 INCLUDE_PRERELEASE=0
@@ -162,6 +166,7 @@ while (( $# > 0 )); do
         --write-adr)          WRITE_ADR=1; shift ;;
         --clean)              CLEAN=1; shift ;;
         --no-gates)           NO_GATES=1; shift ;;
+        --skip-plugins)       SKIP_PLUGINS=1; shift ;;
         --rollback)           ROLLBACK=1; shift ;;
         --include-prerelease) INCLUDE_PRERELEASE=1; shift ;;
         --target)
@@ -181,9 +186,10 @@ cmd_setup() {
         echo "ERROR: ccds-user-setup.sh not found at $SETUP_SCRIPT" >&2
         exit 2
     }
-    local dry=""
-    (( DRY_RUN )) && dry="--dry-run"
-    bash "$SETUP_SCRIPT" "$INSTALL_ROOT" $dry
+    local flags=()
+    (( DRY_RUN )) && flags+=(--dry-run)
+    (( SKIP_PLUGINS )) && flags+=(--skip-plugins)
+    bash "$SETUP_SCRIPT" "$INSTALL_ROOT" ${flags[@]+"${flags[@]}"}
 }
 
 cmd_sync() {

--- a/install-playbook.sh
+++ b/install-playbook.sh
@@ -554,50 +554,18 @@ if [[ -f "$PREFIX/version.txt" ]]; then
     INSTALLED_VERSION="$(tr -d '[:space:]' < "$PREFIX/version.txt")"
 fi
 
-# Per-user setup: generalist agents + CLAUDE.md JIT block
-dry_flag=""
-(( DRY_RUN )) && dry_flag="--dry-run"
-bash "$PREFIX/scripts/ccds-user-setup.sh" "$PREFIX" $dry_flag
+# Per-user setup: generalist agents + CLAUDE.md JIT block + enforcement plugins.
+# The plugin step lives in ccds-user-setup.sh, not here (ADR-0016) — it is the
+# one path every outlet shares, so deb/rpm and `ccds setup` get it too.
+setup_flags=()
+(( DRY_RUN )) && setup_flags+=(--dry-run)
+(( SKIP_PLUGINS )) && setup_flags+=(--skip-plugins)
+# ${a[@]+"${a[@]}"} — an empty array under `set -u` is an unbound-variable
+# error before bash 4.4, and README claims bash 4+.
+bash "$PREFIX/scripts/ccds-user-setup.sh" "$PREFIX" ${setup_flags[@]+"${setup_flags[@]}"}
 
 if (( NO_PATH == 0 )); then
     add_to_path_rc "$PREFIX/bin"
-fi
-
-# ---------------------------------------------------------------------------
-# Enforcement plugins (ADR-0012): plugins are the ONLY hook-shipping mechanism,
-# so every outlet installs them by default. Best-effort — a failure here warns
-# with the exact manual commands and never fails the main install.
-# ---------------------------------------------------------------------------
-PLUGINS_STATUS="skipped (--skip-plugins)"
-if (( SKIP_PLUGINS == 0 )); then
-    log_step "Installing enforcement plugins (ccds-guard, ccds-loops)"
-    if ! command -v claude >/dev/null 2>&1; then
-        PLUGINS_STATUS="skipped (claude CLI not on PATH)"
-        log_warn "claude CLI not found -- skipping plugin install."
-        log_warn "After installing Claude Code, run:"
-        log_warn "  claude plugin marketplace add ${OWNER}/${REPO}"
-        log_warn "  claude plugin install ccds-guard@ccds --scope user"
-        log_warn "  claude plugin install ccds-loops@ccds --scope user"
-    else
-        # Marketplace add is idempotent-ish: tolerate "already exists", but
-        # then refresh — a stale pre-guard registration would not know the
-        # ccds-guard plugin exists (round-2 review finding).
-        if ! claude plugin marketplace add "${OWNER}/${REPO}" </dev/null >/dev/null 2>&1; then
-            log_info "marketplace 'ccds' already registered; refreshing catalog"
-            claude plugin marketplace update ccds </dev/null >/dev/null 2>&1 \
-                || log_warn "could not refresh marketplace 'ccds'; plugin installs may see a stale catalog"
-        fi
-        PLUGINS_STATUS="installed (ccds-guard, ccds-loops)"
-        for plugin in ccds-guard ccds-loops; do
-            if claude plugin install "${plugin}@ccds" --scope user </dev/null >/dev/null 2>&1; then
-                log_ok "${plugin} plugin installed (user scope)"
-            else
-                PLUGINS_STATUS="partial -- see warnings"
-                log_warn "Could not install ${plugin} automatically. Run:"
-                log_warn "  claude plugin install ${plugin}@ccds --scope user"
-            fi
-        done
-    fi
 fi
 
 printf '\n'
@@ -607,7 +575,7 @@ printf 'Version : %s\n' "$INSTALLED_VERSION"
 printf 'Agents  : 19 always-on → ~/.claude/agents (14 domain + 5 core)\n'
 printf 'Skills  : %s/skills (domain skills, JIT per project; cross-cutting → ~/.claude/skills)\n' "$PREFIX"
 printf 'CLAUDE  : %s/.claude/CLAUDE.md (ccds pointer block injected)\n' "$HOME"
-printf 'Plugins : %s\n' "$PLUGINS_STATUS"
+printf 'Plugins : ccds-guard + ccds-loops — see the setup step above for status\n'
 if (( NO_PATH == 0 )); then
     printf 'PATH    : %s (added to shell rc files)\n' "$PREFIX/bin"
     printf '\n'

--- a/scripts/ccds-user-setup.sh
+++ b/scripts/ccds-user-setup.sh
@@ -5,12 +5,19 @@
 #   1. Copies all 19 always-on agents to ~/.claude/agents/
 #   2. Copies the cross-cutting (global) skills to ~/.claude/skills/
 #   3. Injects / updates the ccds pointer block in ~/.claude/CLAUDE.md
+#   4. Installs the enforcement plugins (ccds-guard, ccds-loops)
 #
 # Called by:
 #   - install-playbook.sh  (after promoting the install tree)
 #   - ccds setup           (dispatcher, package installs and manual re-runs)
+#   - packaging/postinst   (deb/rpm, via ccds setup's script)
 #
-# Usage: ccds-user-setup.sh <install_root> [--dry-run]
+# Step 4 lives HERE, not in the installers, because this script is the one
+# thing every outlet funnels through (ADR-0016). It used to live only in
+# install-playbook.sh / Install-Playbook.ps1, so .deb/.rpm and `ccds setup`
+# users silently ran with no ccds-guard and no ccds-loops at all.
+#
+# Usage: ccds-user-setup.sh <install_root> [--dry-run] [--skip-plugins]
 #
 # <install_root> must contain:
 #   agents/<name>.md           for each always-on agent
@@ -22,11 +29,26 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Args
 # ---------------------------------------------------------------------------
-INSTALL_ROOT="${1:-}"
-DRY_RUN=0
-[[ "${2:-}" == "--dry-run" ]] && DRY_RUN=1
+usage() {
+    echo "usage: ccds-user-setup.sh <install_root> [--dry-run] [--skip-plugins]" >&2
+}
 
-[[ -n "$INSTALL_ROOT" ]] || { echo "ERROR: usage: ccds-user-setup.sh <install_root> [--dry-run]" >&2; exit 2; }
+INSTALL_ROOT="${1:-}"
+shift || true
+DRY_RUN=0
+SKIP_PLUGINS=0
+# Flags in any order. An unknown flag is an error, not a silent no-op: the old
+# positional form ([[ "$2" == --dry-run ]]) would have ignored a misspelled
+# --dry-run and made real changes.
+while (( $# )); do
+    case "$1" in
+        --dry-run)      DRY_RUN=1; shift ;;
+        --skip-plugins) SKIP_PLUGINS=1; shift ;;
+        *) echo "ERROR: unknown argument: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+[[ -n "$INSTALL_ROOT" ]] || { echo "ERROR: install_root is required" >&2; usage; exit 2; }
 [[ -d "$INSTALL_ROOT" ]] || { echo "ERROR: install_root does not exist: $INSTALL_ROOT" >&2; exit 2; }
 
 # ---------------------------------------------------------------------------
@@ -64,6 +86,15 @@ GLOBAL_SKILLS=(
     loop-long-horizon
     loop-compound
 )
+
+# ---------------------------------------------------------------------------
+# Enforcement plugins (ADR-0012): plugins are the ONLY hook-shipping mechanism.
+# Source is the GitHub repo, the same one the marketplace docs name — both are
+# overridable so tests never touch a real marketplace or a real CLI.
+# ---------------------------------------------------------------------------
+MARKETPLACE_SOURCE="${CCDS_MARKETPLACE_SOURCE:-ggrace519/claude-code-dev-studio}"
+CLAUDE_CMD="${CCDS_CLAUDE_CMD:-claude}"
+ENFORCEMENT_PLUGINS=(ccds-guard ccds-loops)
 
 # ---------------------------------------------------------------------------
 # Step 1 — Copy all always-on agents to ~/.claude/agents/
@@ -191,6 +222,60 @@ set_claude_playbook_block() {
 }
 
 # ---------------------------------------------------------------------------
+# Step 4 — Install the enforcement plugins (ccds-guard, ccds-loops)
+#
+# Best-effort by contract: a failure here warns with the exact manual commands
+# and never fails setup. Half a playbook beats a failed install — but a silent
+# half is what ADR-0016 exists to prevent, so every outcome is reported.
+# ---------------------------------------------------------------------------
+PLUGINS_STATUS="skipped (--skip-plugins)"
+
+install_plugins() {
+    if (( SKIP_PLUGINS )); then
+        log_info "Skipping enforcement plugins (--skip-plugins)"
+        return
+    fi
+    if (( DRY_RUN )); then
+        PLUGINS_STATUS="dry run"
+        log_info "DRY RUN -- would run:"
+        log_info "  $CLAUDE_CMD plugin marketplace add $MARKETPLACE_SOURCE"
+        for plugin in "${ENFORCEMENT_PLUGINS[@]}"; do
+            log_info "  $CLAUDE_CMD plugin install ${plugin}@ccds --scope user"
+        done
+        return
+    fi
+    if ! command -v "$CLAUDE_CMD" >/dev/null 2>&1; then
+        PLUGINS_STATUS="skipped (claude CLI not on PATH)"
+        log_warn "claude CLI not found -- skipping plugin install."
+        log_warn "Without these, this install has no security guard and no loop"
+        log_warn "enforcement. After installing Claude Code, run:"
+        log_warn "  claude plugin marketplace add $MARKETPLACE_SOURCE"
+        for plugin in "${ENFORCEMENT_PLUGINS[@]}"; do
+            log_warn "  claude plugin install ${plugin}@ccds --scope user"
+        done
+        return
+    fi
+    # `marketplace add` fails when the marketplace is already registered. That
+    # registration may predate a plugin (ccds-guard did not always exist), so
+    # refresh rather than assume the catalog knows about both.
+    if ! "$CLAUDE_CMD" plugin marketplace add "$MARKETPLACE_SOURCE" </dev/null >/dev/null 2>&1; then
+        log_info "marketplace 'ccds' already registered; refreshing catalog"
+        "$CLAUDE_CMD" plugin marketplace update ccds </dev/null >/dev/null 2>&1 \
+            || log_warn "could not refresh marketplace 'ccds'; plugin installs may see a stale catalog"
+    fi
+    PLUGINS_STATUS="installed (${ENFORCEMENT_PLUGINS[*]})"
+    for plugin in "${ENFORCEMENT_PLUGINS[@]}"; do
+        if "$CLAUDE_CMD" plugin install "${plugin}@ccds" --scope user </dev/null >/dev/null 2>&1; then
+            log_ok "${plugin} plugin installed (user scope)"
+        else
+            PLUGINS_STATUS="partial -- see warnings"
+            log_warn "Could not install ${plugin} automatically. Run:"
+            log_warn "  claude plugin install ${plugin}@ccds --scope user"
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
 log_step "Installing always-on agents to $HOME/.claude/agents"
@@ -202,6 +287,9 @@ install_global_skills
 log_step "Updating ccds block in $HOME/.claude/CLAUDE.md"
 set_claude_playbook_block
 
+log_step "Installing enforcement plugins (${ENFORCEMENT_PLUGINS[*]})"
+install_plugins
+
 if (( DRY_RUN )); then
     printf '\n%sDRY RUN -- no changes made.%s\n' "$C_YELLOW" "$C_RESET"
 else
@@ -209,4 +297,5 @@ else
     printf 'Agents      : %s/.claude/agents/ (19 always-on)\n' "$HOME"
     printf 'Skills      : %s/.claude/skills/ (%d cross-cutting)\n' "$HOME" "${#GLOBAL_SKILLS[@]}"
     printf 'ccds block  : %s/.claude/CLAUDE.md\n' "$HOME"
+    printf 'Plugins     : %s\n' "$PLUGINS_STATUS"
 fi

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -1490,6 +1490,8 @@ class TestDebPostinst(unittest.TestCase):
         os.makedirs(self.home)
         self.stubbin = os.path.join(self.root, "stubbin")
         os.makedirs(self.stubbin)
+        self.claude_log = os.path.join(self.root, "claude-argv.log")
+        self._stub_claude()
 
     def _stub(self, name, body):
         path = os.path.join(self.stubbin, name)
@@ -1497,8 +1499,28 @@ class TestDebPostinst(unittest.TestCase):
             f.write("#!/bin/bash\n" + body + "\n")
         os.chmod(path, 0o755)
 
+    def _stub_claude(self, exit_code=0):
+        """Record every `claude` invocation instead of running the real CLI.
+
+        Load-bearing safety, not convenience: per-user setup shells out to
+        `claude plugin marketplace add/update` and `claude plugin install`.
+        `_run` keeps the real PATH appended (postinst needs getent/chmod/su),
+        so without this stub a test run would reach the developer's actual
+        `claude` and mutate their real marketplace registration."""
+        self._stub("claude", 'printf "%%s\\n" "$*" >> "%s"\nexit %d'
+                             % (self.claude_log, exit_code))
+
+    def claude_calls(self):
+        if not os.path.isfile(self.claude_log):
+            return []
+        return [l for l in read(self.claude_log).splitlines() if l.strip()]
+
     def _run(self, env_overrides):
-        env = {"HOME": self.home, "PATH": self.stubbin + os.pathsep + os.environ["PATH"]}
+        env = {"HOME": self.home, "PATH": self.stubbin + os.pathsep + os.environ["PATH"],
+               # Belt and braces with the PATH stub: the seam pins the command
+               # by absolute path, so no code path can reach a real `claude`.
+               "CCDS_CLAUDE_CMD": os.path.join(self.stubbin, "claude"),
+               "CCDS_MARKETPLACE_SOURCE": "test-owner/test-repo"}
         env.update(env_overrides)
         return subprocess.run([BASH, self.postinst],
                               capture_output=True, text=True, env=env)

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -1552,6 +1552,19 @@ class TestDebPostinst(unittest.TestCase):
         self.assertIn("# >>> ccds >>>", claude_md)
         self.assertIn("# <<< ccds <<<", claude_md)
 
+    def test_package_install_wires_the_enforcement_plugins(self):
+        """ADR-0016: the .deb/.rpm outlet used to install agents and skills and
+        then stop, leaving the user with no ccds-guard and no ccds-loops —
+        a product that looks complete and has no security layer."""
+        self._stub("runuser", 'shift 3\nexec "$@"')
+        r = self._run({"SUDO_USER": getpass.getuser()})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertEqual(self.claude_calls(), [
+            "plugin marketplace add test-owner/test-repo",
+            "plugin install ccds-guard@ccds --scope user",
+            "plugin install ccds-loops@ccds --scope user",
+        ], r.stdout + r.stderr)
+
     def test_headless_root_prints_instructions_and_no_op(self):
         # No identifiable user: SUDO_USER/PKEXEC_UID unset, logname fails.
         self._stub("logname", "exit 1")
@@ -1561,6 +1574,149 @@ class TestDebPostinst(unittest.TestCase):
         # The bug under test: nothing must be silently half-installed, but also
         # the install must not error out — ~/.claude stays untouched here.
         self.assertFalse(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
+
+
+@unittest.skipUnless(BASH and sys.platform != "win32",
+                     "ccds-user-setup.sh is a bash script (POSIX shells only)")
+class TestUserSetupPlugins(unittest.TestCase):
+    """ADR-0016: the enforcement plugins install from per-user setup, the one
+    path EVERY outlet funnels through — not from the installers, where the
+    step used to live and which .deb/.rpm and `ccds setup` never run.
+
+    The `claude` CLI is pinned by absolute path via CCDS_CLAUDE_CMD and the
+    marketplace by CCDS_MARKETPLACE_SOURCE, so no test can reach a real CLI
+    or a real marketplace."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="ccds-setup-plugins-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.home = os.path.join(self.root, "home")
+        self.log = os.path.join(self.root, "calls.log")
+        os.makedirs(self.home)
+
+        # Minimal package layout: setup only needs agents/, skills/, jit-claude.
+        self.pkg = os.path.join(self.root, "pkg")
+        os.makedirs(os.path.join(self.pkg, "agents"))
+        os.makedirs(os.path.join(self.pkg, "scripts"))
+        for md in os.listdir(os.path.join(REPO_ROOT, ".claude", "agents")):
+            if md.endswith(".md"):
+                shutil.copy(os.path.join(REPO_ROOT, ".claude", "agents", md),
+                            os.path.join(self.pkg, "agents", md))
+        shutil.copytree(os.path.join(REPO_ROOT, "skills"),
+                        os.path.join(self.pkg, "skills"))
+        shutil.copy(os.path.join(SCRIPTS, "jit-claude.md"),
+                    os.path.join(self.pkg, "scripts", "jit-claude.md"))
+        self.claude = self.stub_claude()
+
+    def stub_claude(self, body='exit 0'):
+        """Records argv, then runs `body` (which may branch on "$*")."""
+        path = os.path.join(self.root, "claude-stub")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write('#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "%s"\n%s\n'
+                    % (self.log, body))
+        os.chmod(path, 0o755)
+        return path
+
+    def setup(self, *flags, claude=None):
+        env = {**os.environ, "HOME": self.home,
+               "CCDS_CLAUDE_CMD": self.claude if claude is None else claude,
+               "CCDS_MARKETPLACE_SOURCE": "test-owner/test-repo"}
+        return subprocess.run([BASH, USER_SETUP, self.pkg, *flags],
+                              capture_output=True, text=True, env=env)
+
+    def calls(self):
+        if not os.path.isfile(self.log):
+            return []
+        return [l for l in read(self.log).splitlines() if l.strip()]
+
+    def test_installs_both_plugins_from_the_shared_setup(self):
+        r = self.setup()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertEqual(self.calls(), [
+            "plugin marketplace add test-owner/test-repo",
+            "plugin install ccds-guard@ccds --scope user",
+            "plugin install ccds-loops@ccds --scope user",
+        ])
+        self.assertIn("Plugins     : installed", r.stdout)
+
+    def test_skip_plugins_suppresses_every_call(self):
+        r = self.setup("--skip-plugins")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertEqual(self.calls(), [])
+        # The rest of setup still ran.
+        self.assertTrue(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
+
+    def test_dry_run_makes_no_calls_and_no_changes(self):
+        r = self.setup("--dry-run")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertEqual(self.calls(), [])
+        self.assertIn("would run", r.stdout)
+        self.assertFalse(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
+
+    def test_flags_work_in_either_order(self):
+        for flags in (("--dry-run", "--skip-plugins"),
+                      ("--skip-plugins", "--dry-run")):
+            with self.subTest(flags):
+                self.assertEqual(self.setup(*flags).returncode, 0)
+
+    def test_unknown_flag_is_an_error_not_a_silent_noop(self):
+        # The old positional parsing ignored anything that wasn't exactly
+        # "--dry-run" in $2 — a typo'd --dry-run made real changes.
+        r = self.setup("--drr-run")
+        self.assertEqual(r.returncode, 2, r.stdout + r.stderr)
+        self.assertIn("unknown argument", r.stderr)
+        self.assertFalse(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
+
+    def test_missing_claude_cli_warns_but_setup_still_succeeds(self):
+        r = self.setup(claude=os.path.join(self.root, "nonexistent-claude"))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertEqual(self.calls(), [])
+        self.assertIn("no security guard", r.stderr)
+        # Best-effort contract: the rest of the playbook is still installed.
+        self.assertTrue(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
+
+    def test_existing_marketplace_is_refreshed_not_assumed_current(self):
+        # A registration predating ccds-guard would not know that plugin
+        # exists, so an "already exists" failure must trigger an update.
+        self.claude = self.stub_claude(
+            'case "$*" in "plugin marketplace add"*) exit 1 ;; esac\nexit 0')
+        r = self.setup()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("plugin marketplace update ccds", self.calls())
+        self.assertIn("already registered", r.stdout)
+
+    def test_one_failing_plugin_reports_partial_and_still_tries_the_other(self):
+        self.claude = self.stub_claude(
+            'case "$*" in *ccds-guard*) exit 1 ;; esac\nexit 0')
+        r = self.setup()
+        self.assertEqual(r.returncode, 0, "a plugin failure must not fail setup")
+        self.assertIn("plugin install ccds-loops@ccds --scope user", self.calls())
+        self.assertIn("Plugins     : partial", r.stdout)
+        self.assertIn("claude plugin install ccds-guard@ccds", r.stderr)
+
+    def test_ccds_setup_dispatcher_reaches_the_plugin_step(self):
+        """`ccds setup` is the outlet a package user actually runs."""
+        # ccds.sh preflights the installed layout, so stage what it looks for
+        # (build-release.sh:59-74) — a thinner stage fails before setup runs.
+        os.makedirs(os.path.join(self.pkg, "bin"), exist_ok=True)
+        shutil.copy(USER_SETUP, os.path.join(self.pkg, "scripts",
+                                             "ccds-user-setup.sh"))
+        for src, dst in (("bin/ccds.sh", "bin/ccds.sh"),
+                         ("Sync-AgentPacks.sh", "scripts/Sync-AgentPacks.sh"),
+                         ("verify-agents.sh", "scripts/verify-agents.sh"),
+                         ("scripts/stage-gates.py", "scripts/stage-gates.py"),
+                         ("catalog.json", "catalog.json")):
+            shutil.copy(os.path.join(REPO_ROOT, src),
+                        os.path.join(self.pkg, dst))
+        with open(os.path.join(self.pkg, "version.txt"), "w") as f:
+            f.write("v0.0.0-test\n")
+        r = subprocess.run([BASH, os.path.join(self.pkg, "bin", "ccds.sh"), "setup"],
+                           capture_output=True, text=True,
+                           env={**os.environ, "HOME": self.home,
+                                "CCDS_CLAUDE_CMD": self.claude,
+                                "CCDS_MARKETPLACE_SOURCE": "test-owner/test-repo"})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("plugin install ccds-guard@ccds --scope user", self.calls())
 
 
 STAGE_GATES = os.path.join(REPO_ROOT, "scripts", "stage-gates.py")


### PR DESCRIPTION
## Summary

ADR-0012 decided that plugins are the only hook-shipping mechanism and that **every outlet converges on installing them**. Only the two script installers ever implemented it.

Traced outlet by outlet against the shipped v0.15.0 tree:

| Outlet | Plugins wired? |
|---|---|
| `install-playbook.sh` / `Install-Playbook.ps1` | ✅ |
| `ccds update` (re-invokes the installer) | ✅ |
| `/plugin marketplace add` (the documented "recommended" path) | ✅ — plugins *are* the artifact |
| **`.deb` / `.rpm`** → `packaging/postinst` → `ccds-user-setup.sh` | ❌ |
| **`ccds setup`** (bash and PowerShell) | ❌ |
| **`ccds sync`** first-run lazy setup (bash) | ❌ |
| **Manual ZIP extraction** | ❌ |

So a `.deb` user got the 19 agents and the cross-cutting skills and **no `ccds-guard` and no `ccds-loops`** — the whole Gate 1 security layer (secret-file denies, dangerous-command blocks, install ask-gate) and the process-enforcement layer, absent, with nothing in the output saying so. The product looked complete and was not.

Root cause is **placement, not logic**: the step sat in the outermost layer (the installers) instead of the innermost one every outlet shares.

## What changed

- **`scripts/ccds-user-setup.sh` owns the plugin step** (new step 4 + a `Plugins :` status line). The bash installer deletes its copy and forwards `--skip-plugins`. deb/rpm, `ccds setup`, `ccds sync`'s lazy setup, and the installer now share one implementation.
- **`bin/ccds.ps1` gains the twin**, plus `Test-NeedsUserSetup` / `Invoke-UserSetupIfNeeded` so PowerShell `ccds sync` performs first-run setup like bash. Without this, fixing `ccds setup` would have left a *new* asymmetry: a Windows user who only ever runs `ccds sync` would still get nothing.
- **Both dispatchers accept `setup --skip-plugins`**; help text updated in both.
- **Unknown flags now error.** The old positional parsing (`[[ "$2" == --dry-run ]]`) silently ignored a typo'd `--dry-run` and made real changes.
- **`CCDS_MARKETPLACE_SOURCE` / `CCDS_CLAUDE_CMD` seams** — data-not-logic, same pattern as the guard's rule table — so no test can reach a real marketplace or a real CLI.
- **`Install-Playbook.ps1` keeps its own copy.** It is curl-piped and standalone, so it cannot depend on installed files. Named duplication in the ADR, not an oversight.

## A hazard fixed first, in its own commit (`00a0856`)

`TestDebPostinst._run` appends the real `PATH` — postinst needs `getent`/`chmod`/`su`. Once setup shells out to `claude`, a plain `pytest` run would have reached the **developer's real CLI and mutated their actual marketplace registration** (`marketplace add`, then `update` on the already-exists path). That commit lands before the feature exists: the harness stubs `claude`, records argv for assertions, and pins `CCDS_CLAUDE_CMD` by absolute path.

## Verification

Driven for real, not only asserted:

| Check | Result |
|---|---|
| deb postinst path records | `marketplace add` + `install ccds-guard` + `install ccds-loops` |
| `ccds setup` (bash dispatcher) | same three calls |
| `ccds setup --skip-plugins` | 0 calls, rest of setup still runs |
| `--dry-run` | 0 calls, no `~/.claude` changes, prints "would run" |
| Missing `claude` CLI | warns naming what's missing, **exit 0**, agents still installed |
| Pre-existing marketplace | falls through to `marketplace update ccds` |
| One plugin failing | `partial` status, still installs the other, exit 0 |
| `install-playbook.sh --dry-run` | still short-circuits before setup (unchanged) |
| Both `GLOBAL_SKILLS` parsers (`ccds.ps1` regex + the test's split) | still yield 18 skills; new arrays not captured |

**10 new tests; suite 236 passed** (was 226). `lint-playbook.py` → `RESULT: PASS`, including cli-parity.

## Known gaps — stated in ADR-0016 rather than hidden

- **Manual ZIP extraction still wires nothing** — the ZIP ships no `plugins/` tree and no `.claude-plugin/marketplace.json`. The README documents the installer and the marketplace as the supported paths. Bundling the plugin tree (offline installs, version-locked) was considered and rejected as a second mechanism to maintain.
- **`install-playbook.sh` / `Install-Playbook.ps1` have no test coverage at all.** Removing the bash installer's block was verified by hand (`bash -n`, `--help`, a real `--dry-run`), not by the suite.
- **`bin/ccds.ps1` could not be parse-checked locally** — no `pwsh` on this machine. Relying on CI's PSScriptAnalyzer and the Windows job.
- **Deferred, joining ADR-0015's CLI-version check:** a `ccds doctor` check that the two plugins are actually installed. It is the backstop that would have caught this entire class of bug, and it is a new check in both dispatchers — its own PR.

Ships as **v0.16.0**: deb/rpm and `ccds setup` users gaining two hook layers is new user-visible behavior, not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
