### PR TITLE
docs: retitle changelog [Unreleased] as v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## [Unreleased]
+## v0.16.0 — 2026-08-07 — The security layer actually reaches every install
+
+If you installed ccds any way other than the two script installers — the
+`.deb`/`.rpm`, `ccds setup`, or letting `ccds sync` set itself up — you have
+been running with **no security guard and no loop enforcement**, and nothing
+said so. This release fixes that for every outlet. After updating, run
+`ccds setup` once (or reinstall the package) to pick up the plugins.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Cuts the v0.16.0 release for ADR-0016 (#57).

The heading leads with the user-facing consequence rather than the mechanism: anyone who installed via `.deb`/`.rpm`, `ccds setup`, or `ccds sync` has been running with **no security guard and no loop enforcement** — and needs to run `ccds setup` once after updating to pick the plugins up. That upgrade note is the part most likely to be missed, so it sits at the top of the entry rather than in a footnote.

Minor rather than patch: two hook layers appearing on outlets that never had them is new user-visible behavior.

## Verification

- `python3 -m pytest tests/ -q` → **236 passed, 159 subtests passed**
- Docs-only change.

## Post-merge

Tag `v0.16.0` → `release.yml` builds the ZIP/deb/rpm and publishes the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
