### PR TITLE
fix(guard): scope the config-write hard deny to tools that prove a write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **ccds-guard no longer blocks read-only inspection of your own config
+  (ADR-0015, amended).** What was wrong: v0.15.0 made writes to session-safety
+  configuration a hard deny in unattended sessions — correct for the file
+  tools, where the tool proves a write, but it was also applied to Bash
+  commands that merely *named* such a path. In a command line the guard cannot
+  tell `ls ~/.claude/plugins/…`, `cat .claude/settings.json` or `git log` from
+  `echo {} > .claude/settings.json`; they match the same patterns. So an
+  unattended session could no longer look at its own configuration at all.
+  Caught live within minutes of v0.15.0 shipping, when the guard blocked a
+  plain `ls` of the plugin cache.
+
+  Bash hits now go to the adjudicator again, whose prompt already treats
+  safety-config writes as an unconditional DENY — verified after the fix that
+  every write form still denies (`>`, `cp`, `sed -i`) while reads proceed. The
+  deterministic hard deny is unchanged for Write/Edit/NotebookEdit, where the
+  write is unambiguous.
+
+---
+
 ## v0.16.0 — 2026-08-07 — The security layer actually reaches every install
 
 If you installed ccds any way other than the two script installers — the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1333,7 +1333,9 @@ prompt:
    — an unbounded value raised `OverflowError` straight out of
    `subprocess.run`.
 4. **Scope — two tiers never reach the judge.** Deny-tier rules, and
-   **`ask-write-path` hits: writes to session-safety configuration
+   **`ask-write-path` hits *from the file tools* (Write/Edit/NotebookEdit),
+   where the tool itself proves a write: writes to session-safety
+   configuration
    (`.claude/settings.json`, `.claude/hooks/`, `.claude/plugins/`,
    `.pre-commit-config.yaml`) deny outright in an unattended session.** The
    first cut asked the judge to allow them "if the flagged input itself proves
@@ -1345,6 +1347,27 @@ prompt:
    and bounds a successful injection to "one package install proceeds".
    Attended modes (`default`, `plan`, absent/unknown) keep the ask path
    byte-identical.
+
+   **Amended 2026-08-07, hours after v0.15.0 shipped** — the first cut also
+   hard-denied `ask-write-path` hits found in **Bash** command text, which was
+   wrong: there the guard only knows a safety path was *named*, never that it
+   is being written. `ls ~/.claude/plugins/…`, `cat .claude/settings.json`,
+   `git log` and `grep` match the same patterns as
+   `echo {} > .claude/settings.json`. The result was that read-only inspection
+   of one's own config became impossible in an unattended session — caught
+   live within minutes of the release, when the guard blocked a plain `ls` of
+   the plugin cache. Bash hits now go to the adjudicator, whose prompt already
+   says safety-config writes are always DENY unattended: verified after the
+   fix, all three write forms (`>`, `cp`, `sed -i`) still deny while reads
+   proceed. Rejected alternative: shell write-shape detection (redirections,
+   `cp`/`mv`/`tee`/`sed -i`). ADR-0012's threat model explicitly declines the
+   shell-quoting arms race, and a heuristic that is wrong in the other
+   direction would silently pass real writes.
+
+   Residual, measured not assumed: the judge is deny-biased, so some
+   legitimate reads under `.claude/plugins/…/hooks/` still get denied. That is
+   a judgment which can go either way rather than an unconditional wall, and
+   it is the same bar the ask tier always had.
 
 ### Rationale
 

--- a/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
@@ -309,7 +309,12 @@ def _ask(reasons, payload, tool, detail, tamper=False):
     establish that a settings/hooks/plugins/pre-commit change was wanted, and
     the only evidence a judge could weigh is text the judged model wrote
     itself. Package-install asks keep their adjudication (registry
-    plausibility is a judgment an LLM can actually make)."""
+    plausibility is a judgment an LLM can actually make).
+
+    Callers set `tamper` only when the WRITE is unambiguous — the file-tool
+    path, where the tool is Write/Edit/NotebookEdit. The Bash path does not:
+    matching a safety path in a command line proves the path was named, not
+    that it is being written."""
     if not _unattended(payload):
         sys.stdout.write(json.dumps({
             "hookSpecificOutput": {
@@ -533,7 +538,18 @@ def _guard_bash(cmd, payload, rules):
             "this command touches session-safety configuration (settings, "
             "hooks, or guard rules) - confirm you asked for this change")
     if reasons:
-        return _ask(reasons, payload, "Bash", cmd.strip(), tamper=tamper_hit)
+        # NOT tamper=tamper_hit. In a Bash command the guard only knows that a
+        # safety path was NAMED, never that it is being written — `ls`,
+        # `cat`, `grep` and `git log` match the same patterns as
+        # `echo {} > .claude/settings.json`. Hard-denying that whole set made
+        # read-only inspection impossible in an unattended session (found
+        # live within minutes of v0.15.0 shipping: `ls ~/.claude/plugins/...`
+        # denied). The hard deny stays where the write is unambiguous — the
+        # file-tool path below, where the TOOL proves the write. Here the
+        # adjudicator decides, and its prompt already says safety-config
+        # writes are always DENY unattended, so an actual write still denies
+        # while a read proceeds.
+        return _ask(reasons, payload, "Bash", cmd.strip())
     return 0
 
 

--- a/plugins/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugins/ccds-guard/hooks/pretooluse-guard.py
@@ -309,7 +309,12 @@ def _ask(reasons, payload, tool, detail, tamper=False):
     establish that a settings/hooks/plugins/pre-commit change was wanted, and
     the only evidence a judge could weigh is text the judged model wrote
     itself. Package-install asks keep their adjudication (registry
-    plausibility is a judgment an LLM can actually make)."""
+    plausibility is a judgment an LLM can actually make).
+
+    Callers set `tamper` only when the WRITE is unambiguous — the file-tool
+    path, where the tool is Write/Edit/NotebookEdit. The Bash path does not:
+    matching a safety path in a command line proves the path was named, not
+    that it is being written."""
     if not _unattended(payload):
         sys.stdout.write(json.dumps({
             "hookSpecificOutput": {
@@ -533,7 +538,18 @@ def _guard_bash(cmd, payload, rules):
             "this command touches session-safety configuration (settings, "
             "hooks, or guard rules) - confirm you asked for this change")
     if reasons:
-        return _ask(reasons, payload, "Bash", cmd.strip(), tamper=tamper_hit)
+        # NOT tamper=tamper_hit. In a Bash command the guard only knows that a
+        # safety path was NAMED, never that it is being written — `ls`,
+        # `cat`, `grep` and `git log` match the same patterns as
+        # `echo {} > .claude/settings.json`. Hard-denying that whole set made
+        # read-only inspection impossible in an unattended session (found
+        # live within minutes of v0.15.0 shipping: `ls ~/.claude/plugins/...`
+        # denied). The hard deny stays where the write is unambiguous — the
+        # file-tool path below, where the TOOL proves the write. Here the
+        # adjudicator decides, and its prompt already says safety-config
+        # writes are always DENY unattended, so an actual write still denies
+        # while a read proceeds.
+        return _ask(reasons, payload, "Bash", cmd.strip())
     return 0
 
 

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -2615,19 +2615,30 @@ class TestGuardUnattended(TestGuardHooks):
                 ("Edit settings.json", self.EDIT_SETTINGS),
                 ("Write a hook", {"tool_name": "Write", "tool_input": {
                     "file_path": "/proj/.claude/hooks/x.py"}}),
-                ("Bash touches settings", {"tool_name": "Bash", "tool_input": {
-                    "command": "echo {} > .claude/settings.json"}}),
-                # One command can raise both an install ask and a tamper hit;
-                # the tamper hit must still win over adjudication.
-                ("Bash install + settings", {
-                    "tool_name": "Bash", "tool_input": {
-                        "command": "pip install foo && "
-                                   "echo {} > .claude/settings.json"}})):
+                ("NotebookEdit a plugin file", {
+                    "tool_name": "NotebookEdit", "tool_input": {
+                        "notebook_path": "/proj/.claude/plugins/x.ipynb"}})):
             with self.subTest(label):
                 r = self.unattended(payload, spawn_proof)
                 self.assert_deny(r, "never auto-approved")
                 self.assertFalse(os.path.exists(marker),
                                  "the flagged text must never reach a judge")
+
+    def test_bash_naming_a_safety_path_is_judged_not_hard_denied(self):
+        """The hard deny is scoped to tools that PROVE a write. A Bash command
+        only proves the path was named — `ls`, `cat`, `grep` and `git log`
+        match the same patterns as `echo {} > .claude/settings.json`. Hard
+        denying that whole set made read-only inspection impossible in an
+        unattended session (found live minutes after v0.15.0 shipped). The
+        judge decides here; its prompt still says config writes always DENY."""
+        read_only = {"tool_name": "Bash", "tool_input": {
+            "command": "ls -1 ~/.claude/plugins/cache/ccds"}}
+        r = self.unattended(read_only, "print('ALLOW: read-only inspection')")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("adjudicated ALLOW", r.stderr)
+        # And a judge that declines still blocks it.
+        self.assert_deny(self.unattended(read_only, "print('DENY: no')"),
+                         "unattended adjudication")
         # Attended, the same writes still merely ask.
         self.assert_ask(self.unattended(self.EDIT_SETTINGS,
                                         "print('ALLOW: x')", mode="default"),


### PR DESCRIPTION
## Summary

v0.15.0 made writes to session-safety configuration an unconditional deny in unattended sessions. That is correct for `Write`/`Edit`/`NotebookEdit`, where the **tool itself proves a write**. It was also applied to `Bash` — where the guard only knows a safety path was *named*.

In a command line, `ls`, `cat`, `grep`, `diff` and `git log` naming one of those paths match exactly the same rule patterns as a redirect that overwrites it. So an unattended session lost the ability to read its own configuration at all.

**Found live, minutes after v0.15.0 shipped.** A routine post-release check — listing the plugin cache to confirm the marketplace update had landed — was blocked. So were the follow-up diagnostics, and then the commit of this fix (its message named the paths). Before v0.15.0 these were adjudicated and a judge would allow a read; the hard deny turned a tolerable false positive into a wall with no recourse, in precisely the mode that has no human to ask.

## The fix

`Bash` ask-write-path hits go back to the adjudicator. Its prompt already states that safety-config writes are **always DENY** unattended, so the security property survives on that path. The deterministic hard deny is untouched for the file tools, where the write is unambiguous.

The principle, now written into the code and the ADR: **hard-deny only where the caller proves a write.**

## Verification

Driven against the real guard, before and after:

| Command | v0.16.0 | after |
|---|---|---|
| `ls -1 ~/.claude/plugins/cache/ccds` | DENY | allowed |
| `cat .claude/settings.json` | DENY | allowed |
| `diff .claude/settings.json /tmp/other.json` | DENY | allowed |
| `echo {} > .claude/settings.json` | DENY | **DENY** |
| `cp /tmp/evil.json .claude/settings.json` | DENY | **DENY** |
| `sed -i s/a/b/ .pre-commit-config.yaml` | DENY | **DENY** |

Every write form still denies; reads proceed. New regression test pins the read-only case both ways (judge allows → proceeds; judge declines → still blocked), and the hard-deny test now covers all three file tools instead of leaning on Bash cases that were testing the wrong contract.

**Suite 237 passed; `lint-playbook.py` → RESULT: PASS.**

## Rejected alternative

Shell write-shape detection — redirections, `cp`/`mv`/`tee`/`sed -i`. ADR-0012's threat model explicitly declines the shell-quoting arms race, and a heuristic wrong in the *other* direction would silently pass real writes. Deferring to the judge fails toward deny; a bad parser fails toward allow.

## Residual — measured, not assumed

The adjudicator is deny-biased, so some legitimate reads under a hooks directory still get denied. That is a judgment which can go either way rather than an unconditional wall — the same bar the ask tier always had. Recorded in the ADR-0015 amendment rather than glossed.

Ships as **v0.16.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
