### PR TITLE
docs: retitle changelog [Unreleased] as v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## [Unreleased]
+## v0.16.1 — 2026-08-07 — The guard stops walling off your own config
+
+A same-day follow-up to v0.15.0: the new unattended hard deny on
+safety-config writes was applied too broadly on the Bash path, so an
+unattended session could not so much as list its own plugin directory.
+Update if you run unattended loops.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Cuts v0.16.1 for the ADR-0015 amendment (#59).

Patch rather than minor: it restores read-only behavior that v0.15.0 removed, rather than adding anything. The heading names who should care — anyone running unattended loops, where the over-broad deny actually bites.

## Verification

- `python3 -m pytest tests/ -q` → **237 passed, 158 subtests passed**
- Docs-only change.

## Post-merge

Tag `v0.16.1` → `release.yml` builds and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)