### PR TITLE
feat(doctor): detect the two conditions that failed silently (ADRs 0015, 0016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`ccds doctor` now checks the two things that failed silently this week.**
+  Both v0.15.0 and v0.16.0 shipped bugs whose whole character was that nothing
+  told you they were happening; these are the backstops.
+  - **`claude-cli`** — WARNs when Claude Code is older than v2.1.169, the
+    release that added `--safe-mode`. Below that floor, ccds-guard's
+    unattended adjudicator cannot isolate its judge, so every unattended
+    ask-gate hit denies instead of being judged (ADR-0015). WARN, not FAIL:
+    the environment is constrained, the install is not defective. Also WARNs
+    when the CLI is absent or its `--version` is unrecognizable.
+  - **`plugins-installed`** — **FAILs** when `ccds-guard` or `ccds-loops` is
+    missing *or installed-but-disabled*. Hooks ship only via plugins, so
+    either state means the install has no security layer — the exact condition
+    ADR-0016 fixed, now detectable instead of invisible. Plugins from any
+    marketplace count, and the remedy line names the command to fix it. With
+    no `claude` CLI on PATH the state is unknowable, so it WARNs rather than
+    failing.
+
+---
+
 ## v0.16.1 — 2026-08-07 — The guard stops walling off your own config
 
 A same-day follow-up to v0.15.0: the new unattended hard deny on

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1395,9 +1395,9 @@ prompt:
   papered over with a retry that drops `--safe-mode`: silently downgrading a
   security boundary to keep a loop moving is the wrong default. The child's
   stderr now surfaces in the deny message, so the cause is visible rather than
-  mysterious. Recorded in README Requirements and CLAUDE.md; a `ccds doctor`
-  check for the CLI version is the natural follow-up (deferred — it is code in
-  both dispatchers, not documentation).
+  mysterious. Recorded in README Requirements and CLAUDE.md. **Follow-up
+  delivered:** `ccds doctor`'s `claude-cli` check WARNs below the floor, so the
+  degraded state is visible instead of silent.
 - Unattended sessions can no longer edit `.claude/settings.json`, hooks,
   plugins, or `.pre-commit-config.yaml` at all — they get a teaching deny and
   route around it. That work moves to an attended session. Accepted cost:
@@ -1521,10 +1521,10 @@ Root cause is placement, not logic: the step lived in the outermost layer
   was verified by hand — `bash -n`, `--help`, and a real `--dry-run` run —
   not by the suite. Test coverage for the installers is the standing gap this
   ADR did not close.
-- Deferred follow-up, joining ADR-0015's `ccds doctor` CLI-version check: a
-  **doctor check that the two plugins are actually installed**. It is the
-  backstop that would have caught this entire class of bug, and it is a new
-  check in both dispatchers — its own PR.
+- **Follow-up delivered:** `ccds doctor`'s `plugins-installed` check FAILs when
+  either plugin is missing *or installed-but-disabled* — the backstop that
+  would have caught this entire class of bug. A disabled guard protects
+  nothing, so it is treated exactly like a missing one.
 
 ### Supersedes
 None. Completes ADR-0012's distribution decision, which was only

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -114,7 +114,9 @@ COMMANDS
   doctor               Run proactive environment health checks: layout shape,
                        version drift vs the latest release, install
                        completeness (agents, skills, CLAUDE.md block, catalog),
-                       BOM/CRLF corruption, PATH and dual-install conflicts.
+                       BOM/CRLF corruption, PATH and dual-install conflicts,
+                       Claude Code version floor, and whether the ccds-guard /
+                       ccds-loops enforcement plugins are installed + enabled.
                        Exit 0 = healthy (WARNs allowed), 1 = failures found.
 
   setup                Install the always-on agents + cross-cutting skills into
@@ -513,7 +515,7 @@ function Invoke-SetupCommand {
 
 # ---------------------------------------------------------------------------
 # Command: doctor -- proactive environment health checks.
-# PowerShell twin of bin/ccds.sh cmd_doctor: same 9 checks, same output
+# PowerShell twin of bin/ccds.sh cmd_doctor: same 11 checks, same output
 # contract (one 'OK|WARN|FAIL  name: detail' line per check + indented remedy
 # on WARN/FAIL, summary block, exit 0 = no FAIL / 1 = FAIL found).
 #
@@ -776,6 +778,89 @@ function Test-DoctorPathDuals {
     }
 }
 
+# Twins of bin/ccds.sh doc_check_claude_cli / doc_check_plugins.
+# Minimum Claude Code for ccds-guard's unattended adjudicator: v2.1.169 added
+# --safe-mode, without which the judge is not isolated (ADR-0015).
+$Script:MinClaudeVersion = [version]'2.1.169'
+
+function Get-ClaudeCommand {
+    if ($env:CCDS_CLAUDE_CMD) { return $env:CCDS_CLAUDE_CMD }
+    return 'claude'
+}
+
+function Test-DoctorClaudeCli {
+    # WARN, not FAIL: an older CLI does not break ccds -- the guard's deny and
+    # ask tiers work unchanged. It silently costs the unattended adjudicator.
+    $claudeCmd = Get-ClaudeCommand
+    if (-not (Get-Command $claudeCmd -ErrorAction SilentlyContinue)) {
+        Write-DoctorLine 'WARN' 'claude-cli' `
+            "claude CLI not on PATH; ccds's agents/skills still load, but the guard plugin and 'ccds setup' plugin install cannot run" `
+            "install Claude Code, then run 'ccds setup'"
+        return
+    }
+    $raw = ''
+    try { $raw = (& $claudeCmd --version 2>$null | Select-Object -First 1) } catch { }
+    $m = [regex]::Match([string]$raw, '\d+\.\d+\.\d+')
+    if (-not $m.Success) {
+        Write-DoctorLine 'WARN' 'claude-cli' `
+            "could not parse a version from '$claudeCmd --version' (got: $(if ($raw) { $raw } else { 'empty' }))" `
+            "check that '$claudeCmd --version' prints a x.y.z version"
+        return
+    }
+    $ver = [version]$m.Value
+    if ($ver -lt $Script:MinClaudeVersion) {
+        Write-DoctorLine 'WARN' 'claude-cli' `
+            "Claude Code $ver is older than $($Script:MinClaudeVersion); ccds-guard's unattended adjudicator needs --safe-mode to isolate its judge, so every unattended ask-gate hit denies instead of being judged (ADR-0015)" `
+            "upgrade Claude Code to $($Script:MinClaudeVersion) or newer"
+        return
+    }
+    Write-DoctorLine 'OK' 'claude-cli' "Claude Code $ver (>= $($Script:MinClaudeVersion))"
+}
+
+function Test-DoctorPlugins {
+    # FAIL, not WARN: hooks ship ONLY via plugins (ADR-0012), so a missing or
+    # disabled ccds-guard means this install has no security layer at all --
+    # an incomplete install, same class as a missing core agent.
+    $claudeCmd = Get-ClaudeCommand
+    if (-not (Get-Command $claudeCmd -ErrorAction SilentlyContinue)) {
+        Write-DoctorLine 'WARN' 'plugins-installed' `
+            'cannot check: claude CLI not on PATH' `
+            "install Claude Code, then run 'ccds setup'"
+        return
+    }
+    $plugins = $null
+    try {
+        $raw = & $claudeCmd plugin list --json 2>$null
+        $plugins = @($raw | ConvertFrom-Json)
+    } catch { }
+    if ($null -eq $plugins) {
+        Write-DoctorLine 'WARN' 'plugins-installed' `
+            "could not read 'claude plugin list --json'" `
+            "run 'claude plugin list' and check the CLI is healthy"
+        return
+    }
+    $missing = @(); $disabled = @()
+    foreach ($name in @('ccds-guard', 'ccds-loops')) {
+        # Match the plugin id from any marketplace: "<name>@<marketplace>".
+        $hit = @($plugins | Where-Object { $_.id -like "$name@*" })
+        if ($hit.Count -eq 0) { $missing += $name }
+        elseif (@($hit | Where-Object { $_.enabled }).Count -eq 0) { $disabled += $name }
+    }
+    if ($missing.Count -gt 0) {
+        Write-DoctorLine 'FAIL' 'plugins-installed' `
+            "not installed: $($missing -join ' ') -- hooks ship only via plugins, so this install is missing that protection" `
+            "run 'ccds setup' (or: claude plugin install $($missing[0])@ccds --scope user)"
+        return
+    }
+    if ($disabled.Count -gt 0) {
+        Write-DoctorLine 'FAIL' 'plugins-installed' `
+            "installed but DISABLED: $($disabled -join ' ') -- a disabled guard protects nothing" `
+            "claude plugin enable $($disabled[0])"
+        return
+    }
+    Write-DoctorLine 'OK' 'plugins-installed' 'ccds-guard ccds-loops installed and enabled'
+}
+
 function Invoke-DoctorCommand {
     # Registry: check-name -> check function. Adding a check = one function
     # plus one row here (keep in lockstep with bin/ccds.sh cmd_doctor).
@@ -789,6 +874,8 @@ function Invoke-DoctorCommand {
         @{ Name = 'claude-md-block' ; Fn = ${function:Test-DoctorClaudeBlock} }
         @{ Name = 'catalog'         ; Fn = ${function:Test-DoctorCatalog} }
         @{ Name = 'path-and-duals'  ; Fn = ${function:Test-DoctorPathDuals} }
+        @{ Name = 'claude-cli'      ; Fn = ${function:Test-DoctorClaudeCli} }
+        @{ Name = 'plugins-installed'; Fn = ${function:Test-DoctorPlugins} }
     )
 
     Write-Host "ccds doctor -- environment checks (version $(Get-InstalledVersion), $layoutKind layout)"

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -86,7 +86,9 @@ COMMANDS
   doctor               Run proactive environment health checks: layout shape,
                        version drift vs the latest release, install
                        completeness (agents, skills, CLAUDE.md block, catalog),
-                       BOM/CRLF corruption, PATH and dual-install conflicts.
+                       BOM/CRLF corruption, PATH and dual-install conflicts,
+                       Claude Code version floor, and whether the ccds-guard /
+                       ccds-loops enforcement plugins are installed + enabled.
                        Exit 0 = healthy (WARNs allowed), 1 = failures found.
 
   lint                 Lint the playbook library's semantic invariants
@@ -254,6 +256,100 @@ doc_line() {  # doc_line STATUS NAME DETAIL [REMEDY]
     if [[ "$status" != "OK" && -n "$remedy" ]]; then
         printf '      remedy: %s\n' "$remedy"
     fi
+}
+
+# Minimum Claude Code for ccds-guard's unattended adjudicator: v2.1.169 added
+# --safe-mode, without which the judge is not isolated (ADR-0015).
+MIN_CLAUDE_VERSION="2.1.169"
+CLAUDE_CMD="${CCDS_CLAUDE_CMD:-claude}"
+ENFORCEMENT_PLUGINS=(ccds-guard ccds-loops)
+
+# Numeric compare of dotted versions without sort -V (absent on some minimal
+# images). Echoes "older", "same" or "newer" for $1 relative to $2.
+version_cmp() {
+    local a b i
+    IFS=. read -r -a a <<< "${1%%[^0-9.]*}"
+    IFS=. read -r -a b <<< "${2%%[^0-9.]*}"
+    for i in 0 1 2; do
+        local x="${a[i]:-0}" y="${b[i]:-0}"
+        (( x > y )) && { echo newer; return; }
+        (( x < y )) && { echo older; return; }
+    done
+    echo same
+}
+
+doc_check_claude_cli() {
+    # An older CLI does not break ccds: the guard's deny and ask tiers work
+    # unchanged. It silently costs the unattended adjudicator, which is why
+    # this is WARN rather than FAIL — the environment is constrained, the
+    # install is not defective.
+    if ! command -v "$CLAUDE_CMD" >/dev/null 2>&1; then
+        doc_line WARN claude-cli \
+            "claude CLI not on PATH; ccds's agents/skills still load, but the guard plugin and 'ccds setup' plugin install cannot run" \
+            "install Claude Code, then run 'ccds setup'"
+        return
+    fi
+    local raw ver
+    # `|| true` on both: under `set -euo pipefail` a non-matching grep (exit 1)
+    # in a command substitution kills the whole doctor run mid-checks, so an
+    # unrecognized --version string would abort instead of warning.
+    raw="$("$CLAUDE_CMD" --version 2>/dev/null | head -n1 || true)"
+    ver="$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)"
+    if [[ -z "$ver" ]]; then
+        doc_line WARN claude-cli \
+            "could not parse a version from '$CLAUDE_CMD --version' (got: ${raw:-empty})" \
+            "check that '$CLAUDE_CMD --version' prints a x.y.z version"
+        return
+    fi
+    if [[ "$(version_cmp "$ver" "$MIN_CLAUDE_VERSION")" == "older" ]]; then
+        doc_line WARN claude-cli \
+            "Claude Code $ver is older than $MIN_CLAUDE_VERSION; ccds-guard's unattended adjudicator needs --safe-mode to isolate its judge, so every unattended ask-gate hit denies instead of being judged (ADR-0015)" \
+            "upgrade Claude Code to $MIN_CLAUDE_VERSION or newer"
+        return
+    fi
+    doc_line OK claude-cli "Claude Code $ver (>= $MIN_CLAUDE_VERSION)"
+}
+
+doc_check_plugins() {
+    # FAIL, not WARN: hooks ship ONLY via plugins (ADR-0012), so a missing or
+    # disabled ccds-guard means this install has no security layer at all --
+    # an incomplete install, the same class as a missing core agent. Shipping
+    # exactly that silently is what ADR-0016 exists to prevent.
+    if ! command -v "$CLAUDE_CMD" >/dev/null 2>&1; then
+        doc_line WARN plugins-installed \
+            "cannot check: claude CLI not on PATH" \
+            "install Claude Code, then run 'ccds setup'"
+        return
+    fi
+    local json missing=() disabled=() p
+    if ! json="$("$CLAUDE_CMD" plugin list --json 2>/dev/null)"; then
+        doc_line WARN plugins-installed \
+            "could not read 'claude plugin list --json'" \
+            "run 'claude plugin list' and check the CLI is healthy"
+        return
+    fi
+    for p in "${ENFORCEMENT_PLUGINS[@]}"; do
+        # Match the plugin id from any marketplace: "<name>@<marketplace>".
+        if ! printf '%s' "$json" | grep -q "\"id\"[[:space:]]*:[[:space:]]*\"${p}@"; then
+            missing+=("$p")
+        elif printf '%s' "$json" \
+            | tr '{' '\n' | grep "\"${p}@" | grep -q '"enabled"[[:space:]]*:[[:space:]]*false'; then
+            disabled+=("$p")
+        fi
+    done
+    if (( ${#missing[@]} > 0 )); then
+        doc_line FAIL plugins-installed \
+            "not installed: ${missing[*]} -- hooks ship only via plugins, so this install is missing that protection" \
+            "run 'ccds setup' (or: claude plugin install ${missing[0]}@ccds --scope user)"
+        return
+    fi
+    if (( ${#disabled[@]} > 0 )); then
+        doc_line FAIL plugins-installed \
+            "installed but DISABLED: ${disabled[*]} -- a disabled guard protects nothing" \
+            "claude plugin enable ${disabled[0]}"
+        return
+    fi
+    doc_line OK plugins-installed "${ENFORCEMENT_PLUGINS[*]} installed and enabled"
 }
 
 doc_check_layout() {
@@ -452,6 +548,8 @@ cmd_doctor() {
         "claude-md-block:doc_check_claude_block"
         "catalog:doc_check_catalog"
         "path-and-duals:doc_check_path_duals"
+        "claude-cli:doc_check_claude_cli"
+        "plugins-installed:doc_check_plugins"
     )
 
     echo "ccds doctor -- environment checks (version $(installed_version), $LAYOUT_KIND layout)"

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -13,6 +13,7 @@ Run: python3 -m unittest discover -s tests -v
 import ast
 import getpass
 import json
+import shlex
 import os
 import re
 import shutil
@@ -1389,11 +1390,28 @@ class TestCcdsDoctor(unittest.TestCase):
         return [ln.strip() for ln in block.splitlines()
                 if ln.strip() and not ln.strip().startswith("#")]
 
-    def doctor(self):
+    def stub_claude(self, version="2.1.224 (Claude Code)", plugins=None):
+        """Pin the `claude` the doctor sees. Without this the checks would ask
+        the developer's real CLI, so `test_healthy_home_passes` would depend on
+        whether that machine happens to have the ccds plugins installed."""
+        if plugins is None:
+            plugins = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True}]
+        path = os.path.join(self.root, "claude-stub")
+        write(path, "#!/usr/bin/env bash\ncase \"$1\" in\n"
+                    "  --version) printf '%%s\\n' %s ;;\n"
+                    "  plugin)    printf '%%s\\n' %s ;;\n"
+                    "esac\n" % (shlex.quote(version),
+                                shlex.quote(json.dumps(plugins))))
+        os.chmod(path, 0o755)
+        return path
+
+    def doctor(self, claude=None):
         env = {**os.environ,
                "HOME": self.home,
                # unreachable (discard-port) URL: forces the offline WARN path
-               "CCDS_DOCTOR_RELEASE_URL": "http://127.0.0.1:9/releases/latest"}
+               "CCDS_DOCTOR_RELEASE_URL": "http://127.0.0.1:9/releases/latest",
+               "CCDS_CLAUDE_CMD": claude if claude else self.stub_claude()}
         return subprocess.run(
             [BASH, os.path.join(self.inst, "bin", "ccds.sh"), "doctor"],
             capture_output=True, text=True, env=env)
@@ -1403,6 +1421,67 @@ class TestCcdsDoctor(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertIn("RESULT: PASS", r.stdout)
         self.assertIn("FAIL  : 0", r.stdout)
+
+    def test_claude_cli_below_the_version_floor_warns(self):
+        """ADR-0015 set the floor at 2.1.169 (--safe-mode). Older is a WARN,
+        not a FAIL: nothing breaks, the unattended adjudicator just degrades
+        to denying every ask-gate hit — the silent failure this check exists
+        to make loud."""
+        for version, expect_ok in (("2.1.224 (Claude Code)", True),
+                                   ("2.1.169 (Claude Code)", True),
+                                   ("2.1.168 (Claude Code)", False),
+                                   ("1.9.999 (Claude Code)", False)):
+            with self.subTest(version):
+                r = self.doctor(claude=self.stub_claude(version=version))
+                self.assertEqual(r.returncode, 0, "version drift never FAILs")
+                if expect_ok:
+                    self.assertIn("OK  claude-cli", r.stdout)
+                else:
+                    self.assertIn("WARN  claude-cli", r.stdout)
+                    self.assertIn("2.1.169", r.stdout)
+
+    def test_unparsable_claude_version_warns(self):
+        r = self.doctor(claude=self.stub_claude(version="not a version"))
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("WARN  claude-cli", r.stdout)
+        self.assertIn("could not parse", r.stdout)
+
+    def test_missing_enforcement_plugin_fails(self):
+        """FAIL, not WARN: hooks ship only via plugins, so a missing
+        ccds-guard means no security layer at all. Shipping exactly that
+        silently is the bug ADR-0016 fixed — this is the backstop."""
+        r = self.doctor(claude=self.stub_claude(
+            plugins=[{"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("FAIL  plugins-installed", r.stdout)
+        self.assertIn("ccds-guard", r.stdout)
+        self.assertIn("remedy: run 'ccds setup'", r.stdout)
+
+    def test_disabled_enforcement_plugin_fails(self):
+        r = self.doctor(claude=self.stub_claude(
+            plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                     {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("FAIL  plugins-installed", r.stdout)
+        self.assertIn("DISABLED", r.stdout)
+        self.assertIn("claude plugin enable ccds-guard", r.stdout)
+
+    def test_plugins_from_any_marketplace_count(self):
+        # A local or renamed marketplace is still a real install.
+        r = self.doctor(claude=self.stub_claude(
+            plugins=[{"id": "ccds-guard@local-mp", "enabled": True},
+                     {"id": "ccds-loops@local-mp", "enabled": True}]))
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("OK  plugins-installed", r.stdout)
+
+    def test_absent_claude_cli_warns_but_does_not_fail(self):
+        """No CLI means the checks are unknowable, not failed — doctor must
+        stay usable on a box where Claude Code is not installed yet."""
+        r = self.doctor(claude=os.path.join(self.root, "no-such-claude"))
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertIn("WARN  claude-cli", r.stdout)
+        self.assertIn("WARN  plugins-installed", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
 
     def test_missing_core_agent_fails(self):
         os.remove(os.path.join(self.home, ".claude", "agents", "plan-architect.md"))


### PR DESCRIPTION
## Summary

Both bugs that shipped this week had the same character: **a safety mechanism stopped working and nothing told you.** These are the backstops, closing the follow-ups ADR-0015 and ADR-0016 each deferred.

### `claude-cli` — WARN

Claude Code older than **v2.1.169**, the release that added `--safe-mode`. Below that floor ccds-guard's unattended adjudicator cannot isolate its judge, so every unattended ask-gate hit denies instead of being judged.

WARN rather than FAIL: the environment is constrained, the install is not defective. Also covers an absent CLI and an unparsable `--version`.

### `plugins-installed` — FAIL

`ccds-guard` or `ccds-loops` missing, **or installed but DISABLED**. Hooks ship only via plugins, so either state means the install has no security layer — an incomplete install, the same class as a missing core agent, and exactly the condition ADR-0016 fixed.

A disabled guard protects nothing, so it is treated like a missing one. Plugins from any marketplace count. With no `claude` CLI the state is unknowable, so it WARNs rather than failing.

Detection uses `claude plugin list --json` (structured `id`/`enabled`), not filesystem archaeology.

## Two things worth calling out

**Writing the test caught a bug the manual probe missed.** Under `set -euo pipefail`, a non-matching `grep` inside a command substitution killed the whole doctor run — so an unrecognized `--version` aborted mid-checks instead of warning. My probe only fed it parseable versions; the test fed it garbage. Fixed with `|| true` on both substitutions.

**`TestCcdsDoctor` now pins `CCDS_CLAUDE_CMD` to a stub.** Without it these checks would query the developer's real CLI, making `test_healthy_home_passes` depend on whether that machine happens to have the ccds plugins installed. Same class of hazard as the postinst harness in #57.

## Verification

Drove the real dispatcher through every branch, exit codes included:

| Scenario | Result |
|---|---|
| Current CLI (2.1.224), both plugins enabled | OK / OK, exit 0 |
| CLI 2.1.168 | WARN claude-cli, exit 0 |
| CLI exactly 2.1.169 (boundary) | **OK**, exit 0 |
| CLI 1.9.999 | WARN claude-cli, exit 0 |
| `--version` unparsable | WARN, exit 0 (was: aborted the run) |
| `claude` absent | WARN both, RESULT: PASS |
| ccds-guard missing | **FAIL**, exit 1, remedy names the fix |
| ccds-guard installed but disabled | **FAIL**, exit 1, `claude plugin enable` remedy |
| Plugins from a non-default marketplace | OK |

**6 new tests; suite 243 passed** (was 237). `lint-playbook.py` → RESULT: PASS.

PowerShell twin ships in the same commit. cli-parity compares command *names* only, so the real coverage here is the shared registry shape plus the tests; PSScriptAnalyzer and the Windows job validate the PS side.

## Docs

ADR-0015 and ADR-0016 deferral notes both flipped to **follow-up delivered**; changelog entry under `[Unreleased]`; help text updated in both dispatchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)