### PR TITLE
docs: retitle changelog [Unreleased] as v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## [Unreleased]
+## v0.17.0 — 2026-08-07 — Making the silent failures loud
+
+Three bugs shipped this week and every one had the same character: a safety
+mechanism stopped working and nothing told you. This release is the response —
+`ccds doctor` now detects both conditions that went undetected, and the
+primary install path finally has tests. Run `ccds doctor` after updating; a
+`plugins-installed` FAIL means the install has no security layer, and the
+remedy line names the fix.
 
 ### Infrastructure
 


### PR DESCRIPTION
## Summary

Cuts v0.17.0 for the doctor checks (#61) and the first `install-playbook.sh` coverage (#63).

The heading names the through-line rather than the features: three bugs shipped this week, all of them safety mechanisms that stopped working silently. This is the release that makes two of those conditions detectable and the primary install path testable.

The upgrade note leads with the action that matters — run `ccds doctor`, and treat a `plugins-installed` FAIL as "this install has no security layer".

## Verification

- `python3 -m pytest tests/ -q` → **252 passed, 162 subtests passed**
- Docs-only change.

## Post-merge

Tag `v0.17.0` → `release.yml` builds and publishes the ZIP/deb/rpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)