### PR TITLE
fix(release): payload parity as a linted contract, and bash finally gets completion (ADR-0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **bash users now get shell completion — they never had it (ADR-0017).** The
+  PowerShell installer has loaded `ccds` and `claude` completions into the PS
+  profile since it shipped; `install-playbook.sh` and the `.deb`/`.rpm` had no
+  completion handling at all, and the packages did not even ship the file. Now
+  the script installer adds a marked `# >>> ccds-completion >>>` block to your
+  shell rc (removed again by `--uninstall`), and the packages install
+  `ccds-completion.bash` to `/usr/share/bash-completion/completions/ccds` — the
+  distro-native path, so it loads for every user with no dotfile edits.
+- **The `.deb`/`.rpm` no longer ship a `bin/ccds.ps1` that cannot run.** It was
+  staged without `scripts/Sync-AgentPacks.ps1`, which it requires to resolve
+  its layout, so invoking it could only ever print "Cannot locate
+  Sync-AgentPacks.ps1". Linux packages ship Linux tools; Windows users take the
+  ZIP or the PowerShell installer.
+- `build-release.sh`'s preflight now covers `scripts/stage-gates.py` and
+  `templates`, which it copies. A missing one used to fail with a raw `cp`
+  error instead of the script's own clear message.
+
+### Changed
+
+- **`--no-path` now means "leave my shell rc files alone"** — it skips the
+  completion block as well as the PATH block. Both write to the same files, so
+  one flag governs both rather than adding a near-identical second flag.
+
+### Infrastructure
+
+- **New `release-parity` lint check (#12).** The two release builders staged
+  the payload from independent hand-maintained lists with no cross-check, and
+  had drifted six files apart. The contract is now stated and enforced —
+  ZIP payload == package payload plus a declared Windows-only set — failing in
+  all three drift directions with the offending file named. Same shape as the
+  `cli-parity` check that keeps the two dispatchers honest.
+
+---
+
 ## v0.17.0 — 2026-08-07 — Making the silent failures loud
 
 Three bugs shipped this week and every one had the same character: a safety

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1533,3 +1533,102 @@ Root cause is placement, not logic: the step lived in the outermost layer
 ### Supersedes
 None. Completes ADR-0012's distribution decision, which was only
 half-implemented.
+
+---
+
+## ADR-0017: Per-Outlet Payloads Are a Linted Contract, and bash Gets Its Completion
+
+**Date:** 2026-08-07
+**Status:** Accepted
+**Phase:** Architecture
+**Deciders:** Greg Grace
+
+### Context
+
+`build-release.sh` (deb/rpm) and `build-release.ps1` (ZIP) stage the release
+payload from **independent, hand-maintained lists with no cross-check**. They
+had drifted six files apart:
+
+```
+in ZIP, not in deb:
+  scripts/Sync-AgentPacks.ps1      scripts/ccds-completion.ps1
+  scripts/Verify-Agents.ps1        scripts/claude-completion.ps1
+  scripts/ccds-completion.bash     scripts/claude-completion.bash
+```
+
+Two defects fell out of it:
+
+1. The packages staged `bin/ccds.ps1` **without** `scripts/Sync-AgentPacks.ps1`.
+   `bin/ccds.ps1:63-79` resolves its layout by locating that file and otherwise
+   exits with "Cannot locate Sync-AgentPacks.ps1" — the packages shipped a
+   dispatcher that could never run.
+2. The packages shipped **no bash completion**. Worse, tracing that showed the
+   bash side never had completion *at all*: `Install-Playbook.ps1:466-516` has
+   loaded both completions into the PowerShell profile since it shipped, while
+   `install-playbook.sh` and `packaging/postinst` had no completion handling.
+   Windows users had completion; bash users never did, on any outlet.
+
+Latent alongside: `build-release.sh`'s `REQUIRED_SOURCES` preflight omitted
+`scripts/stage-gates.py` and `templates`, both of which the stage block copies.
+
+### Decision
+
+1. **Linux packages ship Linux tools.** `bin/ccds.ps1` is dropped from the
+   deb/rpm rather than completed by adding the PowerShell helpers. Windows
+   users take the ZIP or the PowerShell installer.
+2. **The payload contract is `ZIP == deb ∪ WINDOWS_ONLY`,** enforced by a new
+   `release-parity` check in `scripts/lint-playbook.py` (check 12), modeled on
+   the existing `cli-parity` check. It parses the destination paths out of both
+   builders and fails in all three drift directions, with `WINDOWS_ONLY_PAYLOAD`
+   as the single declared exception list. Adding a cross-platform file to one
+   builder now fails; adding a Windows-only file must be declared.
+3. **Completion is activated per outlet, in the way each outlet should.**
+   - Script installer: a marked `# >>> ccds-completion >>>` block appended to
+     the same shell rc files the PATH block targets, sourcing both completion
+     scripts from the install prefix. Removed by `--uninstall`.
+   - deb/rpm: `ccds-completion.bash` is staged to
+     `usr/share/bash-completion/completions/ccds`, the distro-native path that
+     loads for every user with **no rc-file edits**. A package may not edit a
+     user's dotfiles; an explicitly-invoked installer script may.
+4. **`claude-completion.bash` completes a third-party binary,** so the packages
+   ship it under `/usr/share/ccds/scripts/` for a user to source deliberately
+   rather than installing it system-wide. The script installer, being an
+   explicit per-user action, wires both.
+5. **`--no-path` governs all shell-rc mutation,** not just PATH. Completion
+   writes to the same files, and that flag is how an operator says "leave my
+   startup files alone" — widening it beats adding a second near-identical
+   flag. Documented in help, README and the changelog.
+
+The PATH and completion blocks now share one `write_rc_block` /
+`remove_rc_block` implementation, so idempotency is fixed in one place. A
+refresh strips and re-appends rather than editing in place, which keeps a
+multi-line body simple; the block therefore moves to the end of the rc file.
+
+### Rationale
+
+- Two hand-maintained lists with no cross-check is the same class of defect as
+  the two dispatchers before `cli-parity`, and the same remedy applies. The
+  lint states the intended relationship instead of hoping reviewers diff two
+  files in different languages.
+- Shipping `ccds-completion.bash` without activating it would have made the
+  payloads consistent and left the feature just as broken — the drift fix and
+  the activation are one change, not two.
+
+### Consequences
+
+- deb/rpm users lose a `bin/ccds.ps1` that never worked, and gain working
+  `ccds` tab-completion with no action required.
+- Script-installer users gain completion on install; `--no-path` opts out of
+  both rc blocks; `--uninstall` removes both.
+- Test surface: `TestReleaseParity` (7 cases, synthesized builders — the real
+  scripts are never mutated) plus two `TestInstallPlaybook` cases. The
+  completion test **sources the rc file in a real shell and asserts
+  `complete -p ccds` resolves**, rather than asserting the text was written —
+  which is what caught that the test ZIP fixture lacked the completion files,
+  a gap a text assertion would have passed straight through.
+- Every check above was mutation-verified: three drift directions for the lint,
+  three broken behaviors for the completion, each caught by the intended test.
+
+### Supersedes
+None. Extends ADR-0012's every-outlet principle from hooks to the release
+payload itself.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Default prefix: `%USERPROFILE%\.claude\playbook`. Override with `-Prefix`, pin a
 curl -fsSL https://raw.githubusercontent.com/ggrace519/claude-code-dev-studio/main/install-playbook.sh | bash
 ```
 
-Default prefix: `$HOME/.claude/playbook`. Override with `--prefix`, pin a version with `--version v0.5.0`, include prereleases with `--include-prerelease`, skip PATH with `--no-path`.
+Default prefix: `$HOME/.claude/playbook`. Override with `--prefix`, pin a version with `--version v0.5.0`, include prereleases with `--include-prerelease`. `--no-path` leaves your shell rc files untouched — it skips both the PATH block and the `ccds` tab-completion block (ADR-0017); `--uninstall` removes both.
 
 Both installers accept `--dry-run` / `-DryRun`, `--local-zip <path>` / `-LocalZip <path>` (install from a locally built ZIP), and `--token` / `-Token` (GitHub token for rate-limited or private-repo environments).
 
@@ -143,7 +143,7 @@ sudo apt install ./ccds_<version>_all.deb     # Debian/Ubuntu
 sudo dnf install ./ccds-<version>-1.noarch.rpm # RHEL/Fedora
 ```
 
-The package installs the shared library to `/usr/share/ccds` and the `ccds` launcher to `/usr/bin/ccds`. Because the agents/skills/`CLAUDE.md` block and the plugins are **per-user** (they live under `~/.claude/`), per-user setup — including the enforcement-plugin install above — runs for the installing user automatically when the package can identify them (`sudo`, polkit/GUI installers, or a login terminal). Other users on the box run `ccds setup` once.
+The package installs the shared library to `/usr/share/ccds`, the `ccds` launcher to `/usr/bin/ccds`, and `ccds` tab-completion to `/usr/share/bash-completion/completions/ccds` — the distro-native path, so it loads for every user without touching anyone's dotfiles. Linux packages carry Linux tools only: the PowerShell dispatcher and helpers ship in the release ZIP and via `Install-Playbook.ps1` (ADR-0017). Because the agents/skills/`CLAUDE.md` block and the plugins are **per-user** (they live under `~/.claude/`), per-user setup — including the enforcement-plugin install above — runs for the installing user automatically when the package can identify them (`sudo`, polkit/GUI installers, or a login terminal). Other users on the box run `ccds setup` once.
 
 If you install from a bare root shell or a headless/CI/Docker context, the package cannot tell which user to set up — run setup yourself once per user:
 

--- a/build-release.sh
+++ b/build-release.sh
@@ -34,9 +34,15 @@ if (( SKIP_RPM == 0 )); then
     }
 fi
 
+# Every path the stage block below reads. Keep the two in lockstep: a file
+# copied but not listed here fails with a raw `cp` error instead of this
+# script's own clear message (stage-gates.py and templates were both in that
+# state).
 REQUIRED_SOURCES=( ".claude/agents" "skills" "catalog.json" "scripts/jit-claude.md"
     "scripts/ccds-user-setup.sh" "Sync-AgentPacks.sh" "verify-agents.sh"
-    "bin/ccds.sh" "bin/ccds.ps1" "README.md" "packaging/postinst" "packaging/prerm" )
+    "scripts/stage-gates.py" "templates" "scripts/ccds-completion.bash"
+    "claude_auto_completion/Linux/claude-completion.bash"
+    "bin/ccds.sh" "README.md" "packaging/postinst" "packaging/prerm" )
 missing=()
 for src in "${REQUIRED_SOURCES[@]}"; do [[ -e "$REPO_ROOT/$src" ]] || missing+=("$src"); done
 (( ${#missing[@]} == 0 )) || { echo "ERROR: Missing: ${missing[*]}" >&2; exit 1; }
@@ -63,15 +69,30 @@ cp "$REPO_ROOT/scripts/ccds-user-setup.sh" "$PKG_ROOT/scripts/"
 cp "$REPO_ROOT/Sync-AgentPacks.sh"         "$PKG_ROOT/scripts/Sync-AgentPacks.sh"
 cp "$REPO_ROOT/verify-agents.sh"           "$PKG_ROOT/scripts/verify-agents.sh"
 cp "$REPO_ROOT/scripts/stage-gates.py"     "$PKG_ROOT/scripts/stage-gates.py"
+cp "$REPO_ROOT/scripts/ccds-completion.bash" "$PKG_ROOT/scripts/ccds-completion.bash"
+cp "$REPO_ROOT/claude_auto_completion/Linux/claude-completion.bash" "$PKG_ROOT/scripts/claude-completion.bash"
 cp -r "$REPO_ROOT/templates"               "$PKG_ROOT/templates"
 chmod 755 "$PKG_ROOT/scripts/"*.sh
+# No bin/ccds.ps1: a Linux package ships Linux tools. It used to be staged
+# without scripts/Sync-AgentPacks.ps1, which bin/ccds.ps1 requires to resolve
+# its layout — so the packages shipped a dispatcher that could only ever print
+# "Cannot locate Sync-AgentPacks.ps1". Windows users take the ZIP or the
+# PowerShell installer. See the release-parity lint check.
 cp "$REPO_ROOT/bin/ccds.sh"  "$PKG_ROOT/bin/"
-cp "$REPO_ROOT/bin/ccds.ps1" "$PKG_ROOT/bin/"
 chmod 755 "$PKG_ROOT/bin/ccds.sh"
 cp "$REPO_ROOT/catalog.json" "$PKG_ROOT/"
 cp "$REPO_ROOT/README.md"    "$PKG_ROOT/"
 printf '%s\n' "$VERSION" > "$PKG_ROOT/version.txt"
 ln -sf "../share/ccds/bin/ccds.sh" "$BIN_ROOT/ccds"
+
+# Shell completion, the distro-native way: a file in the system completions
+# directory loads for every user with no rc-file edits, which is what a
+# package may do and an installer script may not. Only ccds' own completion
+# goes here — claude-completion.bash completes a THIRD-PARTY binary, so it
+# ships under scripts/ for a user to source deliberately.
+COMPLETION_ROOT="$STAGE_DIR/usr/share/bash-completion/completions"
+mkdir -p "$COMPLETION_ROOT"
+cp "$REPO_ROOT/scripts/ccds-completion.bash" "$COMPLETION_ROOT/ccds"
 
 # Normalize line endings: strip \r so scripts edited on Windows work on Linux.
 echo "==> Normalizing line endings (LF)"

--- a/install-playbook.sh
+++ b/install-playbook.sh
@@ -31,7 +31,8 @@
 #   --prefix <path>           Install root (default: $HOME/.claude/playbook)
 #   --local-zip <file>        Install from a locally built ZIP instead of downloading
 #   --token <pat>             GitHub PAT for private-repo downloads (or $GITHUB_TOKEN)
-#   --no-path                 Skip shell-rc PATH update
+#   --no-path                 Leave shell rc files alone (skips both the PATH
+#                             block and the completion block)
 #   --skip-plugins            Skip installing the ccds-guard/ccds-loops plugins
 #   --include-prerelease      When resolving 'latest', include prereleases
 #   --dry-run                 Show actions without changing the filesystem
@@ -258,6 +259,8 @@ verify_sha256() {
 # ---------------------------------------------------------------------------
 PATH_MARKER_BEGIN="# >>> ccds PATH >>>"
 PATH_MARKER_END="# <<< ccds PATH <<<"
+COMPLETION_MARKER_BEGIN="# >>> ccds-completion >>>"
+COMPLETION_MARKER_END="# <<< ccds-completion <<<"
 
 rc_targets() {
     # Emit one rc file per line. Only existing OR sensible-to-create files.
@@ -277,38 +280,66 @@ rc_targets() {
     done
 }
 
-add_to_path_rc() {
-    local bin_dir="$1"
-    local block
-    block=$'\n'"$PATH_MARKER_BEGIN"$'\n'"export PATH=\"$bin_dir:\$PATH\""$'\n'"$PATH_MARKER_END"$'\n'
+# Marker-block primitives, shared by the PATH block and the completion block.
+# One implementation so a fix to the idempotency logic lands for both; a
+# refresh strips the old block and re-appends, which keeps a multi-line body
+# simple (and moves the block to the end of the file, where PATH edits belong).
+RC_BLOCKS_UPDATED=0
 
-    local rc updated=0
+write_rc_block() {  # write_rc_block LABEL BEGIN END BODY
+    local label="$1" begin="$2" end="$3" body="$4"
+    local block rc tmp
+    block=$'\n'"$begin"$'\n'"$body"$'\n'"$end"$'\n'
+    RC_BLOCKS_UPDATED=0
     while IFS= read -r rc; do
         [[ -z "$rc" ]] && continue
-        if [[ ! -e "$rc" ]]; then
-            touch "$rc"
-        fi
-        if grep -qF "$PATH_MARKER_BEGIN" "$rc"; then
-            # Replace existing block in place via temp file (portable sed).
-            local tmp
+        [[ -e "$rc" ]] || touch "$rc"
+        if grep -qF "$begin" "$rc"; then
             tmp="$(mktemp)"
-            awk -v b="$PATH_MARKER_BEGIN" -v e="$PATH_MARKER_END" -v bin="$bin_dir" '
+            awk -v b="$begin" -v e="$end" '
                 BEGIN { in_block=0 }
-                $0 == b { in_block=1; print; print "export PATH=\"" bin ":$PATH\""; next }
-                $0 == e { in_block=0; print; next }
+                $0 == b { in_block=1; next }
+                $0 == e { in_block=0; next }
                 in_block == 1 { next }
                 { print }
             ' "$rc" > "$tmp"
             mv "$tmp" "$rc"
-            log_info "Refreshed ccds PATH block in $rc"
+            printf '%s' "$block" >> "$rc"
+            log_info "Refreshed ccds $label block in $rc"
         else
             printf '%s' "$block" >> "$rc"
-            log_ok "Added ccds PATH block to $rc"
+            log_ok "Added ccds $label block to $rc"
         fi
-        updated=1
+        RC_BLOCKS_UPDATED=1
     done < <(rc_targets)
+}
 
-    if (( updated == 0 )); then
+remove_rc_block() {  # remove_rc_block LABEL BEGIN END
+    local label="$1" begin="$2" end="$3"
+    local rc tmp
+    while IFS= read -r rc; do
+        [[ -z "$rc" || ! -f "$rc" ]] && continue
+        if grep -qF "$begin" "$rc"; then
+            tmp="$(mktemp)"
+            awk -v b="$begin" -v e="$end" '
+                BEGIN { in_block=0 }
+                $0 == b { in_block=1; next }
+                $0 == e { in_block=0; next }
+                in_block == 1 { next }
+                { print }
+            ' "$rc" > "$tmp"
+            mv "$tmp" "$rc"
+            log_ok "Removed ccds $label block from $rc"
+        fi
+    done < <(rc_targets)
+}
+
+add_to_path_rc() {
+    local bin_dir="$1"
+    write_rc_block "PATH" "$PATH_MARKER_BEGIN" "$PATH_MARKER_END" \
+        "export PATH=\"$bin_dir:\$PATH\""
+
+    if (( RC_BLOCKS_UPDATED == 0 )); then
         log_warn "No shell rc files found. Add '$bin_dir' to PATH manually."
     fi
 
@@ -320,23 +351,27 @@ add_to_path_rc() {
 }
 
 remove_path_rc() {
-    local rc
-    while IFS= read -r rc; do
-        [[ -z "$rc" || ! -f "$rc" ]] && continue
-        if grep -qF "$PATH_MARKER_BEGIN" "$rc"; then
-            local tmp
-            tmp="$(mktemp)"
-            awk -v b="$PATH_MARKER_BEGIN" -v e="$PATH_MARKER_END" '
-                BEGIN { in_block=0 }
-                $0 == b { in_block=1; next }
-                $0 == e { in_block=0; next }
-                in_block == 1 { next }
-                { print }
-            ' "$rc" > "$tmp"
-            mv "$tmp" "$rc"
-            log_ok "Removed ccds PATH block from $rc"
-        fi
-    done < <(rc_targets)
+    remove_rc_block "PATH" "$PATH_MARKER_BEGIN" "$PATH_MARKER_END"
+}
+
+# Shell completion. The PowerShell installer has loaded both completions into
+# the PS profile since it shipped; the bash side never did, so bash users had
+# the file (in the ZIP) and no way it was ever loaded. Guarded by the same
+# --no-path flag: both write to the user's shell startup files, and that flag
+# is how the operator says "leave those alone".
+add_completion_rc() {
+    local prefix="$1"
+    local body
+    body="[ -f \"$prefix/scripts/ccds-completion.bash\" ] && . \"$prefix/scripts/ccds-completion.bash\""
+    body+=$'\n'"[ -f \"$prefix/scripts/claude-completion.bash\" ] && . \"$prefix/scripts/claude-completion.bash\""
+    write_rc_block "completion" "$COMPLETION_MARKER_BEGIN" "$COMPLETION_MARKER_END" "$body"
+    if (( RC_BLOCKS_UPDATED == 0 )); then
+        log_warn "No shell rc files found; source $prefix/scripts/ccds-completion.bash manually."
+    fi
+}
+
+remove_completion_rc() {
+    remove_rc_block "completion" "$COMPLETION_MARKER_BEGIN" "$COMPLETION_MARKER_END"
 }
 
 # ---------------------------------------------------------------------------
@@ -458,7 +493,7 @@ do_uninstall() {
 
     if (( DRY_RUN )); then
         [[ -d "$PREFIX" ]] && log_info "DRY RUN -- would remove $PREFIX"
-        (( NO_PATH == 0 )) && log_info "DRY RUN -- would remove ccds PATH block from shell rc files"
+        (( NO_PATH == 0 )) && log_info "DRY RUN -- would remove ccds PATH and completion blocks from shell rc files"
         log_info "DRY RUN -- would remove ccds block from $HOME/.claude/CLAUDE.md"
         log_info "DRY RUN -- note: agents in $HOME/.claude/agents and skills in $HOME/.claude/skills are NOT removed"
         return
@@ -474,6 +509,7 @@ do_uninstall() {
 
     if (( NO_PATH == 0 )); then
         remove_path_rc
+        remove_completion_rc
     fi
 
     # Remove the JIT block from ~/.claude/CLAUDE.md
@@ -566,6 +602,8 @@ bash "$PREFIX/scripts/ccds-user-setup.sh" "$PREFIX" ${setup_flags[@]+"${setup_fl
 
 if (( NO_PATH == 0 )); then
     add_to_path_rc "$PREFIX/bin"
+    log_step "Installing shell completion"
+    add_completion_rc "$PREFIX"
 fi
 
 printf '\n'

--- a/scripts/lint-playbook.py
+++ b/scripts/lint-playbook.py
@@ -33,6 +33,11 @@ This linter checks that what the files SAY is true:
                        a command added to one dispatcher must ship in the
                        other, in the same PR. Skipped when a tree ships
                        neither dispatcher (test fixtures).
+ 12. release-parity   build-release.sh (.deb/.rpm) and build-release.ps1 (ZIP)
+                       stage the same payload, minus a declared Windows-only
+                       set — the two lists are hand-maintained and had already
+                       drifted six files apart. Skipped when a tree ships
+                       neither builder (test fixtures).
  11. marketplace-fresh plugins/ + marketplace.json are byte-identical to what
                        build-marketplace.py regenerates — catches skill edits
                        that forget the regen locally, instead of in CI.
@@ -361,6 +366,71 @@ def check_descriptions_and_models():
              f"always-on agent descriptions ≈ {est_tokens} tokens (budget {AGENT_DESC_TOKEN_BUDGET}); trim descriptions")
 
 
+# --- 12: release-parity ---------------------------------------------------------
+# The two release builders stage the payload from independent, hand-maintained
+# lists with no cross-check, and they had already drifted six files apart: the
+# packages shipped bin/ccds.ps1 WITHOUT scripts/Sync-AgentPacks.ps1 (a
+# dispatcher that could only print "Cannot locate Sync-AgentPacks.ps1") and no
+# bash completion at all, while the ZIP shipped both.
+#
+# The contract: the ZIP payload is the deb payload plus a declared set of
+# Windows-only files. Adding a cross-platform file to one builder then fails
+# here; adding a Windows-only one requires declaring it below.
+WINDOWS_ONLY_PAYLOAD = {
+    "bin/ccds.ps1",
+    "scripts/Sync-AgentPacks.ps1",
+    "scripts/Verify-Agents.ps1",
+    "scripts/ccds-completion.ps1",
+    "scripts/claude-completion.ps1",
+}
+# `cp [-r] "$REPO_ROOT/<src>" "$PKG_ROOT/<dst>"` — a trailing slash on the
+# destination means "keep the source basename", as cp itself does.
+DEB_COPY_RE = re.compile(
+    r'cp (?:-r )?"\$REPO_ROOT/([^"]+)"\s+"\$PKG_ROOT/([^"]*)"')
+PS_COPY_RE = re.compile(r"Src = '([^']+)'\s*;\s*Dst = '([^']+)'")
+
+
+def _deb_payload(src):
+    out = set()
+    for m in DEB_COPY_RE.finditer(src):
+        source, dest = m.group(1), m.group(2)
+        if dest == "" or dest.endswith("/"):
+            dest += source.rstrip("/").split("/")[-1]
+        out.add(dest.replace("\\", "/").lstrip("./"))
+    return out
+
+
+def _zip_payload(src):
+    return {m.group(2).replace("\\", "/") for m in PS_COPY_RE.finditer(src)}
+
+
+def check_release_parity():
+    sh_path = os.path.join(REPO_ROOT, "build-release.sh")
+    ps_path = os.path.join(REPO_ROOT, "build-release.ps1")
+    if not os.path.isfile(sh_path) or not os.path.isfile(ps_path):
+        return  # fixture trees ship no builders
+    deb = _deb_payload(read(sh_path))
+    zipped = _zip_payload(read(ps_path))
+    if not deb or not zipped:
+        err("release-parity",
+            "could not parse a payload from build-release.sh (cp \"$REPO_ROOT/…\" "
+            "\"$PKG_ROOT/…\") or build-release.ps1 ($copyMap Src/Dst rows)")
+        return
+    for path in sorted(zipped - deb - WINDOWS_ONLY_PAYLOAD):
+        err("release-parity",
+            f"'{path}' is staged into the ZIP but not the .deb/.rpm — add it to "
+            f"build-release.sh, or declare it in WINDOWS_ONLY_PAYLOAD if it is "
+            f"Windows-only")
+    for path in sorted(deb - zipped):
+        err("release-parity",
+            f"'{path}' is staged into the .deb/.rpm but not the ZIP — add it to "
+            f"build-release.ps1's $copyMap")
+    for path in sorted(WINDOWS_ONLY_PAYLOAD & deb):
+        err("release-parity",
+            f"'{path}' is declared Windows-only but the .deb/.rpm stages it — "
+            f"remove it from build-release.sh or from WINDOWS_ONLY_PAYLOAD")
+
+
 def main():
     for d in (AGENTS_DIR, SKILLS_DIR):
         if not os.path.isdir(d):
@@ -373,6 +443,7 @@ def main():
     check_skill_voice()
     check_process_skills()
     check_cli_parity()
+    check_release_parity()
     check_marketplace_fresh()
     check_descriptions_and_models()
 

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -312,6 +312,84 @@ class TestCliParity(FixtureCase):
 
 @unittest.skipUnless(os.path.isfile(BUILD_MARKETPLACE),
                      "build-marketplace.py not on this branch yet")
+class TestReleaseParity(FixtureCase):
+    """Check 12: build-release.sh (.deb/.rpm) and build-release.ps1 (ZIP) must
+    stage the same payload, minus a declared Windows-only set.
+
+    The two lists are hand-maintained with no cross-check and had already
+    drifted six files apart — the packages shipped bin/ccds.ps1 without the
+    Sync-AgentPacks.ps1 it needs, and no bash completion at all.
+
+    Fixtures synthesize minimal builders carrying only the structures the
+    parser anchors to, so the real scripts are never mutated.
+    """
+
+    def write_builders(self, deb_paths, zip_paths):
+        copies = "\n".join('cp "$REPO_ROOT/%s" "$PKG_ROOT/%s"' % (p, p)
+                           for p in deb_paths)
+        write(os.path.join(self.root, "build-release.sh"),
+              "#!/usr/bin/env bash\nPKG_ROOT=x\n" + copies + "\n")
+        rows = "\n".join("    @{ Src = '%s' ; Dst = '%s' }"
+                         % (p.replace("/", "\\"), p.replace("/", "\\"))
+                         for p in zip_paths)
+        write(os.path.join(self.root, "build-release.ps1"),
+              "$copyMap = @(\n" + rows + "\n)\n")
+
+    def test_no_builders_is_exempt(self):
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertNotIn("release-parity", r.stdout)
+
+    def test_matching_payloads_pass(self):
+        shared = ["bin/ccds.sh", "catalog.json", "scripts/ccds-completion.bash"]
+        self.write_builders(shared, shared)
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+        self.assertNotIn("release-parity", r.stdout)
+
+    def test_windows_only_files_may_be_zip_only(self):
+        self.write_builders(["bin/ccds.sh"],
+                            ["bin/ccds.sh", "bin/ccds.ps1",
+                             "scripts/Sync-AgentPacks.ps1"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+
+    def test_shared_file_missing_from_the_package_fails(self):
+        self.write_builders(["bin/ccds.sh"],
+                            ["bin/ccds.sh", "scripts/ccds-completion.bash"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("release-parity", r.stdout)
+        self.assertIn("scripts/ccds-completion.bash", r.stdout)
+
+    def test_file_missing_from_the_zip_fails(self):
+        self.write_builders(["bin/ccds.sh", "scripts/stage-gates.py"],
+                            ["bin/ccds.sh"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("scripts/stage-gates.py", r.stdout)
+        self.assertIn("build-release.ps1", r.stdout)
+
+    def test_windows_only_file_in_the_package_fails(self):
+        """The original defect: the .deb staged bin/ccds.ps1, which cannot
+        work there because Sync-AgentPacks.ps1 is Windows-only."""
+        self.write_builders(["bin/ccds.sh", "bin/ccds.ps1"],
+                            ["bin/ccds.sh", "bin/ccds.ps1"])
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("declared Windows-only", r.stdout)
+
+    def test_trailing_slash_destination_keeps_the_basename(self):
+        # `cp "$REPO_ROOT/bin/ccds.sh" "$PKG_ROOT/bin/"` stages bin/ccds.sh,
+        # exactly as cp itself behaves.
+        write(os.path.join(self.root, "build-release.sh"),
+              '#!/usr/bin/env bash\ncp "$REPO_ROOT/bin/ccds.sh" "$PKG_ROOT/bin/"\n')
+        write(os.path.join(self.root, "build-release.ps1"),
+              "$copyMap = @(\n    @{ Src = 'bin\\ccds.sh' ; Dst = 'bin\\ccds.sh' }\n)\n")
+        r = self.lint()
+        self.assertEqual(r.returncode, 0, r.stdout)
+
+
 class TestBuildMarketplace(unittest.TestCase):
     """Runs the marketplace generator against the real repo tree (read-only
     inputs; output goes to the checked-in plugins/ dir, which the test
@@ -1695,7 +1773,13 @@ class TestInstallPlaybook(unittest.TestCase):
                          ("scripts/stage-gates.py", "scripts/stage-gates.py"),
                          ("scripts/jit-claude.md", "scripts/jit-claude.md"),
                          ("scripts/ccds-user-setup.sh",
-                          "scripts/ccds-user-setup.sh")):
+                          "scripts/ccds-user-setup.sh"),
+                         # Completion payload — the real ZIP ships these, and
+                         # the installer's rc block sources them.
+                         ("scripts/ccds-completion.bash",
+                          "scripts/ccds-completion.bash"),
+                         ("claude_auto_completion/Linux/claude-completion.bash",
+                          "scripts/claude-completion.bash")):
             shutil.copy(os.path.join(REPO_ROOT, src),
                         os.path.join(stage, dst))
         write(os.path.join(stage, "version.txt"), "v9.9.9-test\n")
@@ -1788,7 +1872,43 @@ class TestInstallPlaybook(unittest.TestCase):
         r = self.install("--no-path")
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertNotIn("ccds PATH", self.bashrc())
+        # --no-path means "leave my shell rc alone" — completion writes to the
+        # same files, so it honors the same flag.
+        self.assertNotIn("ccds-completion", self.bashrc())
         self.assertTrue(os.path.isfile(os.path.join(self.prefix, "bin", "ccds.sh")))
+
+    def test_completion_block_is_installed_and_actually_loads(self):
+        """The bash side shipped ccds-completion.bash and never sourced it, so
+        Windows users had completion and bash users never did. Asserting the
+        text landed is not enough — source the rc file in a real shell and
+        check the completion function exists."""
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        rc = self.bashrc()
+        self.assertIn("# >>> ccds-completion >>>", rc)
+        self.assertIn(os.path.join(self.prefix, "scripts", "ccds-completion.bash"), rc)
+        probe = subprocess.run(
+            [BASH, "-c",
+             'set +u; . "%s"; complete -p ccds >/dev/null 2>&1 && echo LOADED'
+             % os.path.join(self.home, ".bashrc")],
+            capture_output=True, text=True,
+            env={**os.environ, "HOME": self.home})
+        self.assertIn("LOADED", probe.stdout,
+                      "completion block present but does not register: %s%s"
+                      % (probe.stdout, probe.stderr))
+
+    def test_completion_block_is_idempotent_and_removed_on_uninstall(self):
+        self.assertEqual(self.install().returncode, 0)
+        self.assertEqual(self.install("--force").returncode, 0)
+        self.assertEqual(self.bashrc().count("# >>> ccds-completion >>>"), 1,
+                         "reinstall must refresh the block, not stack copies")
+        r = subprocess.run([BASH, INSTALLER, "--uninstall",
+                            "--prefix", self.prefix],
+                           capture_output=True, text=True,
+                           env={**os.environ, "HOME": self.home})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertNotIn("ccds-completion", self.bashrc())
+        self.assertIn("# existing content", self.bashrc())
 
     def test_reinstall_snapshots_the_previous_tree(self):
         self.assertEqual(self.install().returncode, 0)


### PR DESCRIPTION
First of two PRs closing the gaps ADR-0016 named. This is the Linux/payload half; the Windows half (PS installer tests) follows separately so a long Windows loop cannot block it.

## Summary

The two release builders stage the payload from **independent hand-maintained lists with no cross-check**, and had drifted six files apart:

```
in ZIP, not in deb:
  scripts/Sync-AgentPacks.ps1      scripts/ccds-completion.ps1
  scripts/Verify-Agents.ps1        scripts/claude-completion.ps1
  scripts/ccds-completion.bash     scripts/claude-completion.bash
```

**1. The packages shipped a dispatcher that cannot run.** `bin/ccds.ps1` was staged *without* `scripts/Sync-AgentPacks.ps1`, which it needs to resolve its layout (`bin/ccds.ps1:63-79`) — so invoking it on a package install could only ever print "Cannot locate Sync-AgentPacks.ps1". Dropped: Linux packages ship Linux tools.

**2. bash users never had shell completion at all.** Not just missing from the packages — tracing it showed `Install-Playbook.ps1:466-516` has loaded both completions into the PowerShell profile since it shipped, while `install-playbook.sh` and `packaging/postinst` had *no completion handling whatsoever*. Windows users had completion; bash users never did, on any outlet. Shipping the file without activating it would have fixed the drift and left the feature just as broken, so both land together.

Activation differs by outlet, correctly:
- **Script installer** — a marked `# >>> ccds-completion >>>` block in the same rc files as the PATH block, removed again by `--uninstall`.
- **deb/rpm** — `/usr/share/bash-completion/completions/ccds`, the distro-native path that loads for every user with **no dotfile edits**. A package may not edit a user's rc files; an explicitly-invoked installer may.

**3.** `build-release.sh`'s preflight omitted `scripts/stage-gates.py` and `templates`, both of which it copies — a missing one failed with a raw `cp` error instead of the script's own message.

## The anti-drift mechanism

New **`release-parity`** lint check (#12), modeled on the `cli-parity` check that already keeps the two dispatchers honest. The contract is stated once:

> ZIP payload == package payload ∪ `WINDOWS_ONLY_PAYLOAD`

It fails in all three directions with the offending file named. Adding a cross-platform file to one builder fails; adding a Windows-only file must be declared.

## Judgment calls worth your eye

- **`claude-completion.bash` completes a third-party binary.** Installing that system-wide from a ccds package overreaches, so the packages ship it under `/usr/share/ccds/scripts/` to source deliberately; the installer script, being an explicit per-user action, wires both.
- **`--no-path` now governs all shell-rc mutation**, not just PATH. Completion writes to the same files, and that flag is how an operator says "leave my startup files alone" — widening it beat adding a near-identical second flag. Documented in help, README and changelog.
- The PATH and completion blocks now share one `write_rc_block`/`remove_rc_block`. A refresh strips and re-appends, so the block **moves to the end of the rc file** — simpler for multi-line bodies, and the right place for PATH edits.

## Verification — mutation-tested, not trusted

| Mutation | Caught by |
|---|---|
| Drop a shared file from the deb | `release-parity` names it |
| Drop a file from the ZIP | `release-parity` names it |
| Re-add `bin/ccds.ps1` to the deb | `release-parity` names it |
| Skip `add_completion_rc` | 2 completion tests |
| Break block idempotency | idempotency + reinstall tests |
| Drop `remove_completion_rc` | uninstall test |

The completion test **sources the rc file in a real shell and asserts `complete -p ccds` resolves**, rather than asserting the text was written. That is what caught that my test ZIP fixture was missing the completion files — a gap a text assertion would have sailed through.

**Suite 261 passed** (was 252); `lint-playbook.py` → RESULT: PASS including the new check.

`build-release.sh` needs `fpm`, absent locally, so the staged set is verified by reading the stage block plus the lint; I'll confirm the `.deb` contents after the next release publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)