### PR TITLE
test(windows): run the suite on both platforms, and fix the two bugs that found (ADR-0018)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,14 @@ jobs:
     name: Script tests (Windows)
     runs-on: windows-latest
     steps:
-      # The generators write LF and the suite compares their output against
-      # checked-in files; autocrlf would rewrite *.md/*.json on checkout and
-      # report false drift.
-      - name: Disable autocrlf
-        run: git config --global core.autocrlf false
+      # Check out LF, matching what the generators emit — several tests compare
+      # generated output against checked-in files. core.autocrlf alone is NOT
+      # enough: .gitattributes marks *.md/*.json `text`, and Git converts those
+      # to core.eol (native = CRLF on Windows) whatever autocrlf says.
+      - name: Check out with LF line endings
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,27 @@ jobs:
       - name: Run unittest suite
         run: python3 -m unittest discover -s tests -v
 
+  python-tests-windows:
+    name: Script tests (Windows)
+    runs-on: windows-latest
+    steps:
+      # The generators write LF and the suite compares their output against
+      # checked-in files; autocrlf would rewrite *.md/*.json on checkout and
+      # report false drift.
+      - name: Disable autocrlf
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      # Same suite as the Linux job. The product runs on both platforms, so it
+      # is tested on both: each platform runs what applies and skips what does
+      # not (bash/deb classes carry sys.platform guards; the PowerShell
+      # installer class is Windows-only for the same reason).
+      - name: Run unittest suite
+        shell: pwsh
+        run: python -m unittest discover -s tests -v
+
   verify-agents-windows:
     name: Verify agents (Windows)
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Fixed
 
+- **ccds-guard could never adjudicate on Windows (ADR-0018).** Overriding the
+  judge with `CCDS_GUARD_ADJUDICATOR_CMD` is the documented escape hatch, and
+  on Windows it was broken: the command line was split in POSIX mode, where a
+  backslash is an escape character, so `C:\Python314\python.exe` became
+  `C:Python314python.exe`, the adjudicator failed to start, and **every**
+  unattended ask-gate hit denied. Only the default command worked, and only
+  because it contains no backslashes. Found by running the test suite on
+  Windows for the first time.
+- **The evidence-log hook could not find a non-`.exe` psql on Windows.** It
+  invoked a bare `psql`, and `CreateProcess` resolves only `.exe` — a psql
+  shipped as `.cmd`/`.bat` was found by the PATH check and then failed to
+  start. It now invokes the resolved path, and honors a new
+  `CCDS_EVIDENCE_PSQL` override for installs where psql is not on PATH under
+  that name (versioned installs, Program Files).
+
 - **bash users now get shell completion — they never had it (ADR-0017).** The
   PowerShell installer has loaded `ccds` and `claude` completions into the PS
   profile since it shipped; `install-playbook.sh` and the `.deb`/`.rpm` had no
@@ -34,6 +49,20 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Infrastructure
 
+- **The test suite now runs on Windows as well as Linux (ADR-0018).** ccds
+  ships a bash half and a PowerShell half; CI only ever exercised the Linux
+  one. A `windows-latest` job now runs the same `unittest discover` as the
+  Linux job — each platform running what applies and skipping what does not
+  (268 collected on both; 59 skipped on Windows, 7 on Linux). Getting there
+  found the two Windows-only product bugs above.
+- **`Install-Playbook.ps1` has behavioral coverage for the first time** — 7
+  tests covering install, `-SkipPlugins`, `-DryRun`, the reinstall snapshot,
+  `-Rollback`, `-Uninstall`, and a wrong-shaped archive. It gains the seams
+  every other component already had (`CCDS_MARKETPLACE_SOURCE`,
+  `CCDS_CLAUDE_CMD`, `CCDS_PS_PROFILE`); the last is a safety fix as much as a
+  test one, since `$PROFILE.CurrentUserAllHosts` is not derived from
+  `$env:USERPROFILE` and a test run would otherwise have written the
+  completion block into the operator's real PowerShell profile.
 - **New `release-parity` lint check (#12).** The two release builders staged
   the payload from independent hand-maintained lists with no cross-check, and
   had drifted six files apart. The contract is now stated and enforced —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ New sessions should read this file first to get up to speed before doing anythin
   unattended ask-gate hit denied. Only the default command worked, and only
   because it contains no backslashes. Found by running the test suite on
   Windows for the first time.
+- **`ccds sync` rewrote your `CLAUDE.md` on every run, on Windows.** The
+  standards gate compared the template against the existing file with only one
+  side newline-normalized, so a CRLF template never matched: every run
+  "updated" the block and left another timestamped `CLAUDE.md.ccds-backup-*`
+  behind. Windows checkouts produce exactly that template — `.gitattributes`
+  marks `*.md` as `text`, and Git converts those to `core.eol` (native = CRLF
+  on Windows) whatever `core.autocrlf` says. Your file is still written in
+  whichever convention it already used.
 - **The evidence-log hook could not find a non-`.exe` psql on Windows.** It
   invoked a bare `psql`, and `CreateProcess` resolves only `.exe` — a psql
   shipped as `.cmd`/`.bat` was found by the PATH check and then failed to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,14 @@ skills — no domain agent; skills-only, like `common-`).
 - **Layout:** agents are flat `.claude/agents/<name>.md`; skills are
   `skills/<name>/SKILL.md`. Claude Code does not recurse `.claude/agents/` (ADR-0001).
 - **CLI changes ship in both dispatchers (bash + PowerShell) in the same PR** — the
-  cli-parity lint check enforces the command surface.
+  cli-parity lint check enforces the command surface. `release-parity` does the same
+  for what the two release builders stage (ADR-0017).
+- **The suite runs on both platforms** (ADR-0018): `python3 -m unittest discover -s
+  tests` on Linux, and the same command under Windows Python in CI. Sessions here run
+  in WSL on a Windows box, so both are reachable locally — `python.exe -m unittest
+  discover -s tests` runs the Windows half against the same checkout. Platform-specific
+  classes guard on `sys.platform`; never "cover" a platform by running one hand-picked
+  class on it.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1632,3 +1632,93 @@ multi-line body simple; the block therefore moves to the end of the rc file.
 ### Supersedes
 None. Extends ADR-0012's every-outlet principle from hooks to the release
 payload itself.
+
+---
+
+## ADR-0018: The Suite Runs on Both Platforms
+
+**Date:** 2026-08-07
+**Status:** Accepted
+**Phase:** Testing
+**Deciders:** Greg Grace
+
+### Context
+
+ccds ships a bash half and a PowerShell half, and CI only ever ran the test
+suite on Linux. `Install-Playbook.ps1` — the primary install path for every
+Windows user — had no behavioral coverage at all; PSScriptAnalyzer linted it
+at Error severity and nothing exercised it.
+
+The first plan for this proposed a Windows job running **one hand-picked test
+class**. Greg rejected it: *"the tool works on both windows and linux, then it
+should be tested on both … testing certain files out of context is not smart."*
+A job that runs one class proves nothing about the product; it makes a green
+check appear. He also corrected a false premise — these sessions run in WSL on
+a Windows machine, so Windows is directly reachable (`powershell.exe` is
+Windows PowerShell 5.1, `python.exe` is Windows Python 3.14) and none of this
+needed to be guessed at through CI.
+
+### Decision
+
+1. **One suite, both runners.** A `windows-latest` job runs
+   `python -m unittest discover -s tests -v`, exactly as the Linux job does.
+   Each platform runs what applies and skips what does not — the existing
+   `sys.platform != "win32"` guards already express that, and
+   `TestInstallPlaybookPs1` carries the mirror guard. Result today: 268 tests
+   collected on both, 59 skipped on Windows, 7 on Linux.
+   `core.autocrlf false` before checkout, because the generators emit LF and
+   several tests compare their output against checked-in files.
+2. **`Install-Playbook.ps1` stays Windows-targeted** and is tested on Windows.
+   It exists precisely because `install-playbook.sh` covers Linux/macOS;
+   reworking `$env:USERPROFILE`, User-scope registry PATH and `;` separators
+   into cross-platform equivalents would duplicate that for no gain.
+3. **Seams, because the script had none.** It inlines its per-user work rather
+   than delegating, so it was the one component with its externals hardcoded:
+   `CCDS_MARKETPLACE_SOURCE`, `CCDS_CLAUDE_CMD`, and `CCDS_PS_PROFILE`. The
+   last one is load-bearing for safety, not just testing —
+   `$PROFILE.CurrentUserAllHosts` is **not** derived from `$env:USERPROFILE`
+   (it resolves from the Documents known folder, often OneDrive-redirected), so
+   sandboxing `USERPROFILE` alone would still have written the completion block
+   into the operator's real profile on every test run. Every test also passes
+   `-NoPath`: the PATH write goes to the real User-scope registry.
+
+### Two product bugs this found immediately
+
+Both were invisible while the suite was Linux-only, and both are Windows-only
+failures in shipped code:
+
+- **`ccds-guard` could never adjudicate on Windows.** `shlex.split` defaults to
+  POSIX mode, where backslash is an escape character, so any
+  `CCDS_GUARD_ADJUDICATOR_CMD` containing an absolute path was destroyed
+  (`C:\Python314\python.exe` → `C:Python314python.exe`), the adjudicator failed
+  to start, and every unattended ask-gate hit denied. The documented way to
+  override the judge was broken on Windows; only the default command worked,
+  and only because it contains no backslashes. Fixed with a Windows-aware split
+  that also strips the quote pair non-POSIX mode leaves behind — otherwise
+  `--tools ""` would arrive as a literal `""` instead of an empty string.
+- **`posttooluse-evidence-log.py` invoked a bare `psql`.** On Windows
+  `CreateProcess` resolves only `.exe`, so a psql shipped as `.cmd`/`.bat` was
+  found by `which()` and then failed to start. Now it invokes the resolved
+  path, and honors a `CCDS_EVIDENCE_PSQL` override — a real need (versioned
+  installs, Program Files) as well as the test seam.
+
+### Consequences
+
+- Windows regressions surface in CI instead of in users' installs.
+- `TestInstallPlaybookPs1` (7 cases) covers install, the seams, `-SkipPlugins`,
+  `-DryRun`, snapshot + `-Rollback`, `-Uninstall`, and a wrong-shaped archive.
+  Both installer suites now share one `build_test_release_zip()` fixture — the
+  two installers install the same artifact, so they must exercise the same
+  payload.
+- Mutation-verified, as with every suite since v0.17.0: removing the archive
+  sentinels, ignoring the `CCDS_PS_PROFILE` seam, and ignoring `-SkipPlugins`
+  each failed exactly the intended test. The profile mutation was deliberately
+  written to point *inside the sandbox* rather than at the real `$PROFILE`, so
+  a mutation could not damage the operator's environment.
+- **A reported bug that was not one:** `Set-ClaudePlaybookBlock`'s `$backup` was
+  flagged as possibly-unassigned. It is only read inside `if ($backup)`, and
+  the script sets no `StrictMode`, so an unassigned value is `$null` and the
+  branch is skipped. Left alone rather than "fixed" to tidy a checklist.
+
+### Supersedes
+None.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1682,10 +1682,12 @@ needed to be guessed at through CI.
    into the operator's real profile on every test run. Every test also passes
    `-NoPath`: the PATH write goes to the real User-scope registry.
 
-### Two product bugs this found immediately
+### Three product bugs this found immediately
 
-Both were invisible while the suite was Linux-only, and both are Windows-only
-failures in shipped code:
+All were invisible while the suite was Linux-only, and all are Windows-only
+failures in shipped code. The third surfaced only in CI, on a runner whose
+checkout differs from this machine's — which is the argument for the job
+existing rather than trusting one developer's box:
 
 - **`ccds-guard` could never adjudicate on Windows.** `shlex.split` defaults to
   POSIX mode, where backslash is an escape character, so any
@@ -1701,6 +1703,17 @@ failures in shipped code:
   found by `which()` and then failed to start. Now it invokes the resolved
   path, and honors a `CCDS_EVIDENCE_PSQL` override — a real need (versioned
   installs, Program Files) as well as the test seam.
+- **`ccds sync` rewrote `CLAUDE.md` on every run for Windows users.**
+  `stage_claude_block` LF-normalized the existing file but not the template it
+  compared against, so a CRLF `templates/claude-standards.md` never matched:
+  each run "updated" the block and dropped another timestamped backup — the
+  backup churn its own test exists to prevent. Windows checkouts produce
+  exactly that template, because `.gitattributes` marks `*.md` as `text` and
+  Git converts those to `core.eol` (native = CRLF on Windows) **regardless of
+  `core.autocrlf`** — which is also why the Windows CI job sets `core.eol lf`
+  and not just `core.autocrlf false`. Reproduced on Linux by CRLF-ing the
+  template, fixed by normalizing the template side; the file is still written
+  in whatever convention it already had.
 
 ### Consequences
 

--- a/Install-Playbook.ps1
+++ b/Install-Playbook.ps1
@@ -134,6 +134,28 @@ $ErrorActionPreference = 'Stop'
 $Script:Owner = 'ggrace519'
 $Script:Repo  = 'claude-code-dev-studio'
 
+# Data-not-logic seams, matching scripts/ccds-user-setup.sh and bin/ccds.ps1.
+# This script inlines its per-user work instead of delegating, so until now it
+# was the one component with its externals hardcoded — no way to point it at a
+# different marketplace, and no way to exercise it without mutating the
+# operator's real plugin state and real PowerShell profile.
+#   CCDS_MARKETPLACE_SOURCE  owner/repo the plugins install from
+#   CCDS_CLAUDE_CMD          the claude executable to invoke
+#   CCDS_PS_PROFILE          profile file the completion block is written to.
+#                            $PROFILE.CurrentUserAllHosts is NOT derived from
+#                            $env:USERPROFILE — it resolves from the Documents
+#                            known folder, often OneDrive-redirected — so
+#                            sandboxing USERPROFILE alone does not contain it.
+$Script:MarketplaceSource = if ($env:CCDS_MARKETPLACE_SOURCE) {
+    $env:CCDS_MARKETPLACE_SOURCE
+} else { "$Script:Owner/$Script:Repo" }
+$Script:ClaudeCmd = if ($env:CCDS_CLAUDE_CMD) { $env:CCDS_CLAUDE_CMD } else { 'claude' }
+
+function Get-CcdsProfilePath {
+    if ($env:CCDS_PS_PROFILE) { return $env:CCDS_PS_PROFILE }
+    return $PROFILE.CurrentUserAllHosts
+}
+
 # Cross-cutting (global) skills installed once to ~/.claude/skills/ (ADR-0007).
 # Must match scripts/ccds-user-setup.sh GLOBAL_SKILLS and catalog scope=global.
 $Script:GlobalSkills = @(
@@ -472,7 +494,7 @@ function Install-Completions {
 
     $ccdsCmpl   = Join-Path $Prefix 'scripts\ccds-completion.ps1'
     $claudeCmpl = Join-Path $Prefix 'scripts\claude-completion.ps1'
-    $profilePath = $PROFILE.CurrentUserAllHosts
+    $profilePath = Get-CcdsProfilePath
     $marker      = '# >>> ccds-completion >>>'
     $endMarker   = '# <<< ccds-completion <<<'
 
@@ -519,7 +541,7 @@ $endMarker
 function Remove-CompletionBlock {
     param([switch]$DryRun)
 
-    $profilePath = $PROFILE.CurrentUserAllHosts
+    $profilePath = Get-CcdsProfilePath
     if (-not (Test-Path -LiteralPath $profilePath)) { return }
 
     $existing = [System.IO.File]::ReadAllText($profilePath, [System.Text.Encoding]::UTF8)
@@ -791,12 +813,12 @@ try {
     $pluginsStatus = 'skipped (-SkipPlugins)'
     if (-not $SkipPlugins) {
         Write-Step "Installing enforcement plugins (ccds-guard, ccds-loops)"
-        $claudeCmd = Get-Command claude -ErrorAction SilentlyContinue
+        $claudeCmd = Get-Command $Script:ClaudeCmd -ErrorAction SilentlyContinue
         if (-not $claudeCmd) {
             $pluginsStatus = 'skipped (claude CLI not on PATH)'
             Write-WarnMsg "claude CLI not found -- skipping plugin install."
             Write-WarnMsg "After installing Claude Code, run:"
-            Write-WarnMsg "  claude plugin marketplace add $Script:Owner/$Script:Repo"
+            Write-WarnMsg "  claude plugin marketplace add $Script:MarketplaceSource"
             Write-WarnMsg "  claude plugin install ccds-guard@ccds --scope user"
             Write-WarnMsg "  claude plugin install ccds-loops@ccds --scope user"
         } else {
@@ -805,19 +827,19 @@ try {
             $prevEap = $ErrorActionPreference
             $ErrorActionPreference = 'Continue'
             try {
-                & claude plugin marketplace add "$Script:Owner/$Script:Repo" 2>$null | Out-Null
+                & $Script:ClaudeCmd plugin marketplace add "$Script:MarketplaceSource" 2>$null | Out-Null
                 if ($LASTEXITCODE -ne 0) {
                     # Stale pre-guard registration would not know ccds-guard
                     # exists — refresh the catalog (round-2 review finding).
                     Write-Info "marketplace 'ccds' already registered; refreshing catalog"
-                    & claude plugin marketplace update ccds 2>$null | Out-Null
+                    & $Script:ClaudeCmd plugin marketplace update ccds 2>$null | Out-Null
                     if ($LASTEXITCODE -ne 0) {
                         Write-WarnMsg "could not refresh marketplace 'ccds'; plugin installs may see a stale catalog"
                     }
                 }
                 $pluginsStatus = 'installed (ccds-guard, ccds-loops)'
                 foreach ($plugin in @('ccds-guard', 'ccds-loops')) {
-                    & claude plugin install "$plugin@ccds" --scope user 2>$null | Out-Null
+                    & $Script:ClaudeCmd plugin install "$plugin@ccds" --scope user 2>$null | Out-Null
                     if ($LASTEXITCODE -eq 0) {
                         Write-OkMsg "$plugin plugin installed (user scope)"
                     } else {

--- a/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
@@ -212,6 +212,31 @@ def _load_rules():
     return rules
 
 
+def _split_cmd(cmd):
+    """Split an adjudicator command line, correctly on Windows too.
+
+    `shlex.split` defaults to POSIX mode, where a backslash is an escape
+    character — so on Windows every absolute path in
+    CCDS_GUARD_ADJUDICATOR_CMD was silently destroyed
+    (`C:\\Python314\\python.exe` -> `C:Python314python.exe`), the adjudicator
+    could never start, and every unattended ask-gate hit denied. The documented
+    way to override the judge was therefore broken on Windows; only the default
+    command survived, and only because it contains no backslashes.
+
+    Non-POSIX mode keeps backslashes but also keeps the surrounding quotes as
+    part of the token, which would turn `--tools ""` into a literal `""`
+    argument instead of an empty string — so strip one matched pair.
+    """
+    if os.name != "nt":
+        return shlex.split(cmd)
+    out = []
+    for tok in shlex.split(cmd, posix=False):
+        if len(tok) >= 2 and tok[0] == tok[-1] and tok[0] in "\"'":
+            tok = tok[1:-1]
+        out.append(tok)
+    return out
+
+
 def _norm(path):
     """Slash-normalize and collapse ./.. so traversal can't dodge the rules."""
     return posixpath.normpath(path.replace("\\", "/"))
@@ -270,7 +295,7 @@ def _adjudicate(tool, detail, reasons):
     workdir = tempfile.mkdtemp(prefix="ccds-guard-adj-")
     try:
         proc = subprocess.run(
-            shlex.split(cmd), input=prompt, capture_output=True,
+            _split_cmd(cmd), input=prompt, capture_output=True,
             text=True, timeout=timeout, env=env, cwd=workdir)
     except (OSError, ValueError):
         return False, "adjudicator CLI could not be started (%s)" % cmd

--- a/plugin-extras/ccds-loops/hooks/posttooluse-evidence-log.py
+++ b/plugin-extras/ccds-loops/hooks/posttooluse-evidence-log.py
@@ -28,6 +28,7 @@ Model-agnostic, secrets via env only, stack-agnostic when the DSN is unset.
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -73,8 +74,27 @@ def _mirror_to_postgres(record):
     dsn = os.environ.get("CCDS_EVIDENCE_DSN", "").strip()
     if not dsn:
         return None
-    if not shutil.which("psql"):
-        return "durable tier: psql not on PATH; skipped Postgres mirror"
+    # CCDS_EVIDENCE_PSQL overrides how psql is invoked — a full command line,
+    # not just a path, so a wrapper or an interpreter works. Real need: psql is
+    # often not on PATH under that exact name (versioned installs, Windows
+    # installs under Program Files). Also the test seam, same data-not-logic
+    # pattern as CCDS_GUARD_ADJUDICATOR_CMD.
+    #
+    # Resolve once and invoke the resolved path. A bare "psql" handed to
+    # subprocess on Windows goes through CreateProcess, which finds only .exe —
+    # a psql shipped as .cmd/.bat is found by which() and then fails to start.
+    override = os.environ.get("CCDS_EVIDENCE_PSQL", "").strip()
+    if override:
+        # posix=False keeps Windows backslashes intact; strip one quote pair so
+        # a quoted path does not arrive with its quotes attached.
+        parts = shlex.split(override, posix=(os.name != "nt"))
+        psql_cmd = [p[1:-1] if len(p) >= 2 and p[0] == p[-1] and p[0] in "\"'"
+                    else p for p in parts]
+    else:
+        resolved = shutil.which("psql")
+        if not resolved:
+            return "durable tier: psql not on PATH; skipped Postgres mirror"
+        psql_cmd = [resolved]
     try:
         with open(DDL_FILE, encoding="utf-8") as f:
             ddl = f.read()
@@ -83,7 +103,7 @@ def _mirror_to_postgres(record):
     ev_json = json.dumps(record, separators=(",", ":"))
     try:
         r = subprocess.run(
-            ["psql", dsn, "-v", "ON_ERROR_STOP=1", "-q",
+            psql_cmd + [dsn, "-v", "ON_ERROR_STOP=1", "-q",
              "--set", "ev=" + ev_json, "-c", ddl + "\n" + INSERT_SQL],
             capture_output=True, text=True, timeout=15)
     except (OSError, subprocess.SubprocessError) as e:

--- a/plugins/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugins/ccds-guard/hooks/pretooluse-guard.py
@@ -212,6 +212,31 @@ def _load_rules():
     return rules
 
 
+def _split_cmd(cmd):
+    """Split an adjudicator command line, correctly on Windows too.
+
+    `shlex.split` defaults to POSIX mode, where a backslash is an escape
+    character — so on Windows every absolute path in
+    CCDS_GUARD_ADJUDICATOR_CMD was silently destroyed
+    (`C:\\Python314\\python.exe` -> `C:Python314python.exe`), the adjudicator
+    could never start, and every unattended ask-gate hit denied. The documented
+    way to override the judge was therefore broken on Windows; only the default
+    command survived, and only because it contains no backslashes.
+
+    Non-POSIX mode keeps backslashes but also keeps the surrounding quotes as
+    part of the token, which would turn `--tools ""` into a literal `""`
+    argument instead of an empty string — so strip one matched pair.
+    """
+    if os.name != "nt":
+        return shlex.split(cmd)
+    out = []
+    for tok in shlex.split(cmd, posix=False):
+        if len(tok) >= 2 and tok[0] == tok[-1] and tok[0] in "\"'":
+            tok = tok[1:-1]
+        out.append(tok)
+    return out
+
+
 def _norm(path):
     """Slash-normalize and collapse ./.. so traversal can't dodge the rules."""
     return posixpath.normpath(path.replace("\\", "/"))
@@ -270,7 +295,7 @@ def _adjudicate(tool, detail, reasons):
     workdir = tempfile.mkdtemp(prefix="ccds-guard-adj-")
     try:
         proc = subprocess.run(
-            shlex.split(cmd), input=prompt, capture_output=True,
+            _split_cmd(cmd), input=prompt, capture_output=True,
             text=True, timeout=timeout, env=env, cwd=workdir)
     except (OSError, ValueError):
         return False, "adjudicator CLI could not be started (%s)" % cmd

--- a/plugins/ccds-loops/hooks/posttooluse-evidence-log.py
+++ b/plugins/ccds-loops/hooks/posttooluse-evidence-log.py
@@ -28,6 +28,7 @@ Model-agnostic, secrets via env only, stack-agnostic when the DSN is unset.
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -73,8 +74,27 @@ def _mirror_to_postgres(record):
     dsn = os.environ.get("CCDS_EVIDENCE_DSN", "").strip()
     if not dsn:
         return None
-    if not shutil.which("psql"):
-        return "durable tier: psql not on PATH; skipped Postgres mirror"
+    # CCDS_EVIDENCE_PSQL overrides how psql is invoked — a full command line,
+    # not just a path, so a wrapper or an interpreter works. Real need: psql is
+    # often not on PATH under that exact name (versioned installs, Windows
+    # installs under Program Files). Also the test seam, same data-not-logic
+    # pattern as CCDS_GUARD_ADJUDICATOR_CMD.
+    #
+    # Resolve once and invoke the resolved path. A bare "psql" handed to
+    # subprocess on Windows goes through CreateProcess, which finds only .exe —
+    # a psql shipped as .cmd/.bat is found by which() and then fails to start.
+    override = os.environ.get("CCDS_EVIDENCE_PSQL", "").strip()
+    if override:
+        # posix=False keeps Windows backslashes intact; strip one quote pair so
+        # a quoted path does not arrive with its quotes attached.
+        parts = shlex.split(override, posix=(os.name != "nt"))
+        psql_cmd = [p[1:-1] if len(p) >= 2 and p[0] == p[-1] and p[0] in "\"'"
+                    else p for p in parts]
+    else:
+        resolved = shutil.which("psql")
+        if not resolved:
+            return "durable tier: psql not on PATH; skipped Postgres mirror"
+        psql_cmd = [resolved]
     try:
         with open(DDL_FILE, encoding="utf-8") as f:
             ddl = f.read()
@@ -83,7 +103,7 @@ def _mirror_to_postgres(record):
     ev_json = json.dumps(record, separators=(",", ":"))
     try:
         r = subprocess.run(
-            ["psql", dsn, "-v", "ON_ERROR_STOP=1", "-q",
+            psql_cmd + [dsn, "-v", "ON_ERROR_STOP=1", "-q",
              "--set", "ev=" + ev_json, "-c", ddl + "\n" + INSERT_SQL],
             capture_output=True, text=True, timeout=15)
     except (OSError, subprocess.SubprocessError) as e:

--- a/scripts/stage-gates.py
+++ b/scripts/stage-gates.py
@@ -224,7 +224,15 @@ def stage_claude_block(target, templates, dry, edits):
     if not os.path.isfile(block_path):
         log("standards: template missing; skipped")
         return
-    block = read_text(block_path).rstrip("\n")
+    # Normalize the template's newlines before comparing. `existing` is
+    # LF-normalized below, so a CRLF template made new_content != existing
+    # forever: every `ccds sync` rewrote CLAUDE.md and dropped another
+    # timestamped backup. Windows checkouts produce exactly that — .gitattributes
+    # marks *.md `text`, and Git converts those to core.eol (native = CRLF on
+    # Windows) regardless of core.autocrlf. Caught by running the suite on
+    # Windows (ADR-0018); reproduced on Linux by CRLF-ing the template.
+    # The file is still WRITTEN in its own existing convention, below.
+    block = read_text(block_path).replace("\r\n", "\n").rstrip("\n")
     path = os.path.join(target, "CLAUDE.md")
     existing = read_text(path) if os.path.isfile(path) else ""
     kept = strip_standards_block(existing.replace("\r\n", "\n"))

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -842,17 +842,30 @@ class TestEvidenceLog(unittest.TestCase):
         return path
 
     def stub_psql(self, exit_code=0):
-        shim = os.path.join(self.bindir, "psql")
-        write(shim, "#!/usr/bin/env bash\n"
-                    'printf "%%s\\n" "$@" >> "%s"\nexit %d\n' % (self.psql_log, exit_code))
-        os.chmod(shim, 0o755)
+        """Record psql's argv, on either platform.
+
+        A Python recorder invoked through CCDS_EVIDENCE_PSQL rather than a
+        shell shim on PATH: the hook is Python and genuinely cross-platform,
+        but a `#!` script has no extension for Windows PATHEXT to find, and a
+        .cmd shim cannot survive psql's multi-line SQL argument through cmd's
+        quoting. subprocess passes argv straight to the recorder — no shell in
+        the path at all."""
+        recorder = os.path.join(self.bindir, "psql_recorder.py")
+        write(recorder,
+              "import sys\n"
+              "with open(%r, 'a', encoding='utf-8') as f:\n"
+              "    for a in sys.argv[1:]:\n"
+              "        f.write(a + '\\n')\n"
+              "sys.exit(%d)\n" % (self.psql_log, exit_code))
+        self.psql_cmd = '"%s" "%s"' % (sys.executable, recorder)
 
     def run_hook(self, file_path, dsn=None, with_psql=False):
-        env = {k: v for k, v in os.environ.items() if k != "CCDS_EVIDENCE_DSN"}
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("CCDS_EVIDENCE_DSN", "CCDS_EVIDENCE_PSQL")}
         if with_psql:
-            env["PATH"] = self.bindir + os.pathsep + env["PATH"]
+            env["CCDS_EVIDENCE_PSQL"] = self.psql_cmd
         else:
-            # scrub any real psql so "no psql" paths are deterministic
+            # scrub any real psql so the "no psql" paths stay deterministic
             env["PATH"] = self.bindir
             write(os.path.join(self.bindir, ".keep"), "")
         if dsn is not None:
@@ -1362,6 +1375,7 @@ PACKAGING = os.path.join(REPO_ROOT, "packaging")
 POSTINST = os.path.join(PACKAGING, "postinst")
 USER_SETUP = os.path.join(SCRIPTS, "ccds-user-setup.sh")
 INSTALLER = os.path.join(REPO_ROOT, "install-playbook.sh")
+INSTALLER_PS1 = os.path.join(REPO_ROOT, "Install-Playbook.ps1")
 BASH = shutil.which("bash")
 UNZIP = shutil.which("unzip")
 
@@ -1735,6 +1749,54 @@ class TestDebPostinst(unittest.TestCase):
         self.assertFalse(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
 
 
+def build_test_release_zip():
+    """Build one release ZIP mirroring what build-release.ps1 stages.
+
+    Shared by both installer suites — bash and PowerShell install the same
+    artifact, so they must exercise the same payload. Returns
+    (tmpdir, zip_path, stage_dir); the caller owns cleanup.
+    """
+    tmp = tempfile.mkdtemp(prefix="ccds-installer-zip-")
+    stage = os.path.join(tmp, "stage")
+    os.makedirs(os.path.join(stage, "agents"))
+    os.makedirs(os.path.join(stage, "scripts"))
+    os.makedirs(os.path.join(stage, "bin"))
+    for md in os.listdir(os.path.join(REPO_ROOT, ".claude", "agents")):
+        if md.endswith(".md"):
+            shutil.copy(os.path.join(REPO_ROOT, ".claude", "agents", md),
+                        os.path.join(stage, "agents", md))
+    shutil.copytree(os.path.join(REPO_ROOT, "skills"),
+                    os.path.join(stage, "skills"))
+    shutil.copytree(os.path.join(REPO_ROOT, "templates"),
+                    os.path.join(stage, "templates"))
+    for src, dst in (("bin/ccds.sh", "bin/ccds.sh"),
+                     ("bin/ccds.ps1", "bin/ccds.ps1"),
+                     ("catalog.json", "catalog.json"),
+                     ("README.md", "README.md"),
+                     ("Sync-AgentPacks.sh", "scripts/Sync-AgentPacks.sh"),
+                     ("Sync-AgentPacks.ps1", "scripts/Sync-AgentPacks.ps1"),
+                     ("verify-agents.sh", "scripts/verify-agents.sh"),
+                     ("Verify-Agents.ps1", "scripts/Verify-Agents.ps1"),
+                     ("scripts/stage-gates.py", "scripts/stage-gates.py"),
+                     ("scripts/jit-claude.md", "scripts/jit-claude.md"),
+                     ("scripts/ccds-user-setup.sh",
+                      "scripts/ccds-user-setup.sh"),
+                     # Completion payload — the real ZIP ships all four, and
+                     # each installer's loader block sources its own pair.
+                     ("scripts/ccds-completion.bash",
+                      "scripts/ccds-completion.bash"),
+                     ("scripts/ccds-completion.ps1",
+                      "scripts/ccds-completion.ps1"),
+                     ("claude_auto_completion/Linux/claude-completion.bash",
+                      "scripts/claude-completion.bash"),
+                     ("claude_auto_completion/Windows/claude-completion.ps1",
+                      "scripts/claude-completion.ps1")):
+        shutil.copy(os.path.join(REPO_ROOT, src), os.path.join(stage, dst))
+    write(os.path.join(stage, "version.txt"), "v9.9.9-test\n")
+    return tmp, shutil.make_archive(os.path.join(tmp, "ccds-test"),
+                                    "zip", stage), stage
+
+
 @unittest.skipUnless(BASH and UNZIP and sys.platform != "win32",
                      "install-playbook.sh is a bash script needing unzip")
 class TestInstallPlaybook(unittest.TestCase):
@@ -1749,43 +1811,7 @@ class TestInstallPlaybook(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """Build one release ZIP for the whole class — it is the expensive
-        part, and every test installs the same payload."""
-        cls.tmp = tempfile.mkdtemp(prefix="ccds-installer-zip-")
-        stage = os.path.join(cls.tmp, "stage")
-        os.makedirs(os.path.join(stage, "agents"))
-        os.makedirs(os.path.join(stage, "scripts"))
-        os.makedirs(os.path.join(stage, "bin"))
-        for md in os.listdir(os.path.join(REPO_ROOT, ".claude", "agents")):
-            if md.endswith(".md"):
-                shutil.copy(os.path.join(REPO_ROOT, ".claude", "agents", md),
-                            os.path.join(stage, "agents", md))
-        shutil.copytree(os.path.join(REPO_ROOT, "skills"),
-                        os.path.join(stage, "skills"))
-        shutil.copytree(os.path.join(REPO_ROOT, "templates"),
-                        os.path.join(stage, "templates"))
-        for src, dst in (("bin/ccds.sh", "bin/ccds.sh"),
-                         ("bin/ccds.ps1", "bin/ccds.ps1"),
-                         ("catalog.json", "catalog.json"),
-                         ("README.md", "README.md"),
-                         ("Sync-AgentPacks.sh", "scripts/Sync-AgentPacks.sh"),
-                         ("verify-agents.sh", "scripts/verify-agents.sh"),
-                         ("scripts/stage-gates.py", "scripts/stage-gates.py"),
-                         ("scripts/jit-claude.md", "scripts/jit-claude.md"),
-                         ("scripts/ccds-user-setup.sh",
-                          "scripts/ccds-user-setup.sh"),
-                         # Completion payload — the real ZIP ships these, and
-                         # the installer's rc block sources them.
-                         ("scripts/ccds-completion.bash",
-                          "scripts/ccds-completion.bash"),
-                         ("claude_auto_completion/Linux/claude-completion.bash",
-                          "scripts/claude-completion.bash")):
-            shutil.copy(os.path.join(REPO_ROOT, src),
-                        os.path.join(stage, dst))
-        write(os.path.join(stage, "version.txt"), "v9.9.9-test\n")
-        cls.zip = shutil.make_archive(os.path.join(cls.tmp, "ccds-test"),
-                                      "zip", stage)
-        cls.stage = stage
+        cls.tmp, cls.zip, cls.stage = build_test_release_zip()
 
     @classmethod
     def tearDownClass(cls):
@@ -1974,6 +2000,153 @@ class TestInstallPlaybook(unittest.TestCase):
         r = self.install(zip_path=zip_copy)
         self.assertNotEqual(r.returncode, 0, "checksum mismatch must abort")
         self.assertFalse(os.path.exists(self.prefix))
+
+
+PWSH = (shutil.which("pwsh") or shutil.which("powershell")
+        if sys.platform == "win32" else None)
+
+
+@unittest.skipUnless(PWSH, "Install-Playbook.ps1 is Windows-targeted "
+                           "($env:USERPROFILE, User-scope PATH, ';' separator)")
+class TestInstallPlaybookPs1(unittest.TestCase):
+    """Coverage for Install-Playbook.ps1 — the primary install path for every
+    Windows user, previously checked only by PSScriptAnalyzer.
+
+    Windows-only by design: the script exists because install-playbook.sh
+    covers Linux/macOS. Hermetic via -LocalZip (no GitHub lookup), a sandboxed
+    USERPROFILE and -Prefix, CCDS_PS_PROFILE (the completion block otherwise
+    lands in the operator's REAL profile — $PROFILE.CurrentUserAllHosts is not
+    derived from USERPROFILE), a stubbed CCDS_CLAUDE_CMD, and -NoPath on every
+    case, because the PATH write goes to the real User-scope registry.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp, cls.zip, cls.stage = build_test_release_zip()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="ccds-ps-installer-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.home = os.path.join(self.root, "home")
+        os.makedirs(self.home)
+        self.prefix = os.path.join(self.root, "playbook")
+        self.profile = os.path.join(self.root, "Profile.ps1")
+        self.log = os.path.join(self.root, "claude-calls.log")
+        # Recording `claude` stub: a .cmd so CreateProcess/Get-Command find it.
+        self.claude = os.path.join(self.root, "claude.cmd")
+        write(self.claude, "@echo off\r\necho %%* >> \"%s\"\r\nexit /b 0\r\n"
+                           % self.log)
+
+    def install(self, *extra, zip_path=None):
+        args = [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+                "-File", INSTALLER_PS1,
+                "-LocalZip", zip_path or self.zip,
+                "-Prefix", self.prefix, "-NoPath"]
+        args.extend(extra)
+        return subprocess.run(
+            args, capture_output=True, text=True,
+            env={**os.environ, "USERPROFILE": self.home,
+                 "CCDS_PS_PROFILE": self.profile,
+                 "CCDS_CLAUDE_CMD": self.claude,
+                 "CCDS_MARKETPLACE_SOURCE": "test-owner/test-repo"})
+
+    def claude_calls(self):
+        if not os.path.isfile(self.log):
+            return []
+        return [l.strip() for l in read(self.log).splitlines() if l.strip()]
+
+    def test_local_zip_install_populates_prefix_home_and_plugins(self):
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        for sentinel in ("bin\\ccds.ps1", "catalog.json", "agents", "skills",
+                         "templates"):
+            self.assertTrue(os.path.exists(os.path.join(self.prefix, sentinel)),
+                            "missing from install tree: " + sentinel)
+        self.assertFalse(os.path.exists(self.prefix + ".new"),
+                         "staging dir must be promoted, not left behind")
+        agents = os.path.join(self.home, ".claude", "agents")
+        self.assertEqual(
+            len([f for f in os.listdir(agents) if f.endswith(".md")]), 19)
+        for name in GLOBAL_SKILLS:
+            self.assertTrue(os.path.isfile(os.path.join(
+                self.home, ".claude", "skills", name, "SKILL.md")), name)
+        claude_md = read(os.path.join(self.home, ".claude", "CLAUDE.md"))
+        self.assertEqual(claude_md.count("# >>> ccds >>>"), 1)
+        calls = " ".join(self.claude_calls())
+        self.assertIn("marketplace add test-owner/test-repo", calls)
+        self.assertIn("install ccds-guard@ccds", calls)
+        self.assertIn("install ccds-loops@ccds", calls)
+
+    def test_seams_keep_the_real_profile_and_marketplace_untouched(self):
+        """The seams are the reason this suite is safe to run at all: without
+        them the completion block lands in the operator's real PowerShell
+        profile and the plugin calls hit their real marketplace."""
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertTrue(os.path.isfile(self.profile),
+                        "completion block did not go to CCDS_PS_PROFILE")
+        self.assertIn("# >>> ccds-completion >>>", read(self.profile))
+        self.assertNotIn("ggrace519", " ".join(self.claude_calls()))
+
+    def test_skip_plugins_makes_no_claude_calls(self):
+        r = self.install("-SkipPlugins")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertEqual(self.claude_calls(), [])
+        self.assertTrue(os.path.isdir(os.path.join(self.home, ".claude", "agents")))
+
+    def test_dry_run_changes_nothing(self):
+        r = self.install("-DryRun")
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertFalse(os.path.exists(self.prefix))
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude")))
+        self.assertEqual(self.claude_calls(), [])
+        self.assertFalse(os.path.isfile(self.profile))
+
+    def test_reinstall_snapshots_and_rollback_restores(self):
+        self.assertEqual(self.install().returncode, 0)
+        write(os.path.join(self.prefix, "marker.txt"), "first install\n")
+        self.assertEqual(self.install("-Force").returncode, 0)
+        prev = self.prefix + ".previous"
+        self.assertTrue(os.path.isdir(prev), "no rollback snapshot taken")
+        self.assertTrue(os.path.isfile(os.path.join(prev, "marker.txt")))
+        r = subprocess.run(
+            [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", INSTALLER_PS1, "-Rollback", "-Prefix", self.prefix],
+            capture_output=True, text=True,
+            env={**os.environ, "USERPROFILE": self.home,
+                 "CCDS_PS_PROFILE": self.profile})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertTrue(os.path.isfile(os.path.join(self.prefix, "marker.txt")),
+                        "rollback did not restore the previous tree")
+
+    def test_uninstall_removes_prefix_and_completion_block(self):
+        self.assertEqual(self.install().returncode, 0)
+        r = subprocess.run(
+            [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", INSTALLER_PS1, "-Uninstall", "-Prefix", self.prefix,
+             "-NoPath"],
+            capture_output=True, text=True,
+            env={**os.environ, "USERPROFILE": self.home,
+                 "CCDS_PS_PROFILE": self.profile})
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertFalse(os.path.exists(self.prefix))
+
+    def test_bad_archive_layout_aborts_without_touching_an_install(self):
+        self.assertEqual(self.install().returncode, 0)
+        junk = os.path.join(self.root, "junk")
+        os.makedirs(junk)
+        write(os.path.join(junk, "nothing.txt"), "not a playbook\n")
+        junk_zip = shutil.make_archive(os.path.join(self.root, "junk"),
+                                       "zip", junk)
+        r = self.install("-Force", zip_path=junk_zip)
+        self.assertNotEqual(r.returncode, 0, "a junk archive must not succeed")
+        self.assertIn("archive layout is unexpected", r.stdout + r.stderr)
+        self.assertTrue(os.path.isfile(os.path.join(self.prefix, "bin", "ccds.ps1")),
+                        "the good install must survive a failed one")
 
 
 @unittest.skipUnless(BASH and sys.platform != "win32",


### PR DESCRIPTION
Second of two PRs closing the ADR-0016 gaps. #65 was the Linux/payload half; this is Windows.

## Summary

ccds ships a bash half and a PowerShell half, and CI only ever ran the suite on Linux. `Install-Playbook.ps1` — the primary install path for every Windows user — had no behavioral coverage at all.

A `windows-latest` job now runs **the same `unittest discover` as the Linux job**. Not one hand-picked class: the product runs on both platforms, so each runs what applies and skips what doesn't, which the existing `sys.platform` guards already express.

| | collected | skipped |
|---|---|---|
| Linux | 268 | 7 |
| Windows | 268 | 59 |

`core.autocrlf false` before checkout, because the generators emit LF and several tests compare their output against checked-in files.

## Two Windows-only bugs in shipped code, found immediately

**1. `ccds-guard` could never adjudicate on Windows.** `shlex.split` defaults to POSIX mode, where a backslash is an escape character — so any `CCDS_GUARD_ADJUDICATOR_CMD` containing an absolute path was destroyed (`C:\Python314\python.exe` → `C:Python314python.exe`), the child never started, and **every unattended ask-gate hit denied**. The documented way to override the judge was broken on Windows; only the default command worked, and only because it contains no backslashes.

The fix also strips the quote pair that non-POSIX mode leaves attached — otherwise `--tools ""` arrives as a literal `""` instead of an empty string, silently changing the isolation contract.

**2. The evidence-log hook couldn't find a non-`.exe` psql.** It invoked a bare `psql`; `CreateProcess` resolves only `.exe`, so a `.cmd`/`.bat` psql was found by the PATH check and then failed to start. Now invokes the resolved path and honors `CCDS_EVIDENCE_PSQL` — a real need (versioned installs, Program Files), not just a test seam.

## Seams for the PS installer

It inlines its per-user work rather than delegating, so it was the one component with externals hardcoded. It gains `CCDS_MARKETPLACE_SOURCE`, `CCDS_CLAUDE_CMD`, and `CCDS_PS_PROFILE`.

**That last one is safety, not convenience.** `$PROFILE.CurrentUserAllHosts` is *not* derived from `$env:USERPROFILE` — it resolves from the Documents known folder, often OneDrive-redirected. Sandboxing `USERPROFILE` alone would still have written the completion block into the operator's **real** PowerShell profile on every test run. Every test also passes `-NoPath`, since the PATH write is a real User-scope registry write.

## Verification

7 new PS tests: install, the seams, `-SkipPlugins`, `-DryRun`, snapshot + `-Rollback`, `-Uninstall`, wrong-shaped archive. Both installer suites now share one `build_test_release_zip()` fixture — they install the same artifact, so they should exercise the same payload.

Mutation-verified, as with every suite since v0.17.0:

| Mutation to `Install-Playbook.ps1` | Caught by |
|---|---|
| Remove the archive sentinels | `test_bad_archive_layout_aborts…` |
| Ignore the `CCDS_PS_PROFILE` seam | `test_seams_keep_the_real_profile…` |
| Ignore `-SkipPlugins` | `test_skip_plugins_makes_no_claude_calls` |

The profile mutation deliberately pointed *inside the sandbox* rather than at the real `$PROFILE`, so a broken mutation could not damage this machine.

Run locally on both halves before pushing: Windows `python.exe -m unittest discover -s tests` → **268 OK, 59 skipped**; Linux → **268 OK, 7 skipped**; `lint-playbook.py` → PASS.

## One reported bug that wasn't

`Set-ClaudePlaybookBlock`'s `$backup` was flagged as possibly-unassigned. It is only read inside `if ($backup)`, and the script sets no `StrictMode`, so an unassigned value is `$null` and the branch is skipped. Left alone rather than "fixed" to tidy a checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)