### PR TITLE
docs: retitle changelog [Unreleased] as v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## [Unreleased]
+## v0.18.0 — 2026-08-07 — Windows was never actually tested. Now it is.
+
+ccds ships a bash half and a PowerShell half, and CI only ever ran the test
+suite on Linux. Running it on Windows for the first time found **three
+Windows-only bugs in already-released code** — including a `ccds sync` that
+rewrote your `CLAUDE.md` and left a fresh backup file behind on every single
+run. If you use ccds on Windows, this is the release to take.
+
+Also fixes the release payload: the `.deb`/`.rpm` shipped a PowerShell
+dispatcher that could never run, and shipped no bash completion — which
+turned out to mean bash users never had completion on any outlet.
 
 ### Fixed
 


### PR DESCRIPTION
Cuts v0.18.0 for ADR-0017 (payload parity + bash completion, #65) and ADR-0018 (the suite runs on both platforms, #66).

The heading leads with the finding rather than the feature list: Windows was never actually tested, and testing it surfaced three bugs in already-released code. The upgrade note names who should care and why — a Windows user has been accumulating a `CLAUDE.md.ccds-backup-*` file on every `ccds sync`.

## Verification

- `python3 -m pytest tests/ -q` → **261 passed, 7 skipped, 162 subtests**
- Docs-only change.

## Post-merge

Tag `v0.18.0` → `release.yml` builds and publishes the ZIP/deb/rpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)