### PR TITLE
test(release): run both release builders for real and assert what they produce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ __pycache__/
 
 # Project-staged domain skills (ccds sync / sync-agents output — per-clone state)
 .claude/skills/
+
+# ccds-loops runtime state, written into whatever repo the session runs in:
+# handoff.md by the PreCompact hook (a per-session snapshot, "overwritten on
+# every compaction" by its own header) and the evidence artifacts the Stop gate
+# reads. Both are session scratch, and neither should arrive as an untracked
+# file in `git status`.
+.claude/handoff.md
+.claude/evidence/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **A release build could abort with no error message.** `build-release.sh`
+  reads the built package's path out of fpm's output; if fpm ever prints it in
+  a different shape, the non-matching `grep` failed the whole pipeline under
+  `set -o pipefail` and killed the build — skipping the fallback that exists to
+  recover exactly that case, and printing nothing to explain itself. It now
+  falls back as designed, and says "package not found after fpm run" when there
+  is genuinely nothing to fall back to.
+
+### Infrastructure
+
+- **Both release builders are now run for real in the test suite, and what they
+  produce is asserted** (ADR-0017 amendment). The `release-parity` lint added
+  in v0.18.0 proves the two builders' copy *lists* agree; nothing proved either
+  list matches the tree that actually lands, and a copy that silently stages
+  nothing passed it — the bug `build-release.ps1` shipped once, when a wildcard
+  under `-LiteralPath` copied no skills at all while the list still read
+  correctly. 17 new cases cover the artifact instead: every declared path
+  present with matching bytes, the complete agents and skills trees, the
+  `usr/bin/ccds` symlink resolving, the bash-completion drop-in, mode 755 on
+  staged scripts, `version.txt`, the SHA256 sidecar, and — checked for the
+  first time — that ZIP entry names really use forward slashes.
+- **The installer suites' test ZIP is pinned to the real one.** Both installer
+  suites install from a hand-built fixture archive; if it drifted from
+  `build-release.ps1` they would have gone on passing while certifying a layout
+  no release produces. It had not drifted, and now it cannot.
+
+---
+
 ## v0.18.0 — 2026-08-07 — Windows was never actually tested. Now it is.
 
 ccds ships a bash half and a PowerShell half, and CI only ever ran the test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Fixed
 
+- **`build-release.ps1` could build a structurally broken release ZIP without
+  a single warning.** Entry names are produced by trimming the stage path off
+  each staged file's resolved path — but the prefix came from `-OutputDir`
+  exactly as the caller typed it. Any form that differs textually from the
+  resolved path (a relative directory, a trailing slash, or an 8.3 short path
+  like a Windows CI runner's `C:\Users\RUNNER~1`) silently corrupted **every**
+  name in the archive: `-OutputDir dist` produced entries such as
+  `studio/dist/stage/ccds-v0.18.0/catalog.json`. The ZIP was then checksummed
+  and, in a release, published. No shipped release was affected — the default
+  `-OutputDir` is already resolved, which is the only reason this never fired.
+  The path is now resolved once, and a mismatch throws instead of shipping.
 - **A release build could abort with no error message.** `build-release.sh`
   reads the built package's path out of fpm's output; if fpm ever prints it in
   a different shape, the non-matching `grep` failed the whole pipeline under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,10 @@ skills — no domain agent; skills-only, like `common-`).
   `skills/<name>/SKILL.md`. Claude Code does not recurse `.claude/agents/` (ADR-0001).
 - **CLI changes ship in both dispatchers (bash + PowerShell) in the same PR** — the
   cli-parity lint check enforces the command surface. `release-parity` does the same
-  for what the two release builders stage (ADR-0017).
+  for what the two release builders *declare* they stage (ADR-0017); the suite runs
+  both builders for real and asserts what they actually produce, so a copy that
+  silently stages nothing fails (`TestReleaseStagingSh` stubs `fpm`/`rpmbuild` onto
+  `PATH`; `TestReleaseZipPs1` runs `build-release.ps1` unmodified on Windows).
 - **The suite runs on both platforms** (ADR-0018): `python3 -m unittest discover -s
   tests` on Linux, and the same command under Windows Python in CI. Sessions here run
   in WSL on a Windows box, so both are reachable locally — `python.exe -m unittest

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1629,6 +1629,53 @@ multi-line body simple; the block therefore moves to the end of the rc file.
 - Every check above was mutation-verified: three drift directions for the lint,
   three broken behaviors for the completion, each caught by the intended test.
 
+### Amendment (2026-08-09): the contract is asserted against the artifact, not
+just the lists
+
+`release-parity` proves the two builders' **declared lists** agree. It cannot
+see whether either builder produces what its list claims — a copy that stages
+nothing passes it, which is exactly the bug `build-release.ps1` shipped once
+(`Join-Path $skillsSrc '*'` under `-LiteralPath` copied no skills while the
+`$copyMap` still read correctly). Nor did anything cover the payload no list
+mentions: the agents and skills trees, the `usr/bin/ccds` symlink, the
+bash-completion drop-in, exec bits, `version.txt`.
+
+Both builders are now run for real in the suite and their output asserted:
+
+- `TestReleaseStagingSh` (11 cases, Linux) stubs `fpm`/`rpmbuild` onto `PATH`
+  rather than adding a `--stage-only` flag. fpm's preflight sits before the
+  stage block, so the script is otherwise unreachable on any dev box; stubbing
+  runs strictly more of it (flag assembly, `ensure_path`) and adds no product
+  surface needing bash/PS parity.
+- `TestReleaseZipPs1` (6 cases, Windows) runs `build-release.ps1` unmodified —
+  it has no external dependency, so the artifact under test is the shipped one.
+
+Two things this found:
+
+1. **`fpm_build` died silently when fpm's output format didn't match.** Under
+   `set -o pipefail`, `grep -oP ':path=>…'` matching nothing failed the whole
+   pipeline, killing the build before `ensure_path`'s glob fallback — the case
+   that fallback exists for — with no diagnostic of our own. Same shape as the
+   `ccds doctor` version-parse bug. Fixed with `|| true`; empty stdout is a
+   valid answer meaning "fpm succeeded, I could not read the path from it".
+2. **A separator assertion that could not fail.** `zipfile`'s `ZipInfo.__init__`
+   rewrites `os.sep` to `/` on read, so on Windows `namelist()` reports clean
+   names for an archive full of backslashes. The test now parses the central
+   directory directly. Mutation-checked: removing `.Replace('\', '/')` really
+   does produce `agents\ai-architect.md` entries, and is now caught.
+
+Both suites are mutation-verified case by case. One assertion needed the
+environment forced to have teeth: `cp` carries the source mode through, so
+under the usual umask 022 (and on a drvfs checkout, where every file reports
+0777) the package lands 0755 with or without the script's `chmod`. The staging
+build runs under `umask 077`, where the chmod is the only thing producing an
+executable package — and removing it drops the package to 0700, which fails.
+
+`build_test_release_zip()` — a third hand-maintained copy of the payload, and
+the fixture **both** installer suites install from — is now pinned to the real
+ZIP's entry set. It had not drifted; nothing would have noticed if it had, and
+those suites would have been certifying a layout no release produces.
+
 ### Supersedes
 None. Extends ADR-0012's every-outlet principle from hooks to the release
 payload itself.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1650,8 +1650,22 @@ Both builders are now run for real in the suite and their output asserted:
 - `TestReleaseZipPs1` (6 cases, Windows) runs `build-release.ps1` unmodified —
   it has no external dependency, so the artifact under test is the shipped one.
 
-Two things this found:
+Three things this found:
 
+0. **`build-release.ps1` could produce a structurally broken ZIP silently.**
+   Entry names are derived by trimming the stage path off each staged file's
+   resolved `.FullName`, but the prefix was `-OutputDir` as typed. A relative
+   directory, a trailing separator, or an 8.3 short path all differ in length
+   from the resolved form, and every entry name in the archive came out wrong
+   — `-OutputDir dist` yielded `studio/dist/stage/ccds-v0.18.0/catalog.json`.
+   Production was safe only because the default `-OutputDir` is
+   `Join-Path $PSScriptRoot 'dist'`, already resolved. Found by CI, not
+   locally: a GitHub Windows runner's `TEMP` is `C:\Users\RUNNER~1`, three
+   characters shorter than `runneradmin`, so every entry kept an `est/`
+   prefix. The path is resolved once now, and — the part that matters — a
+   prefix mismatch **throws** rather than producing a name, because silent
+   prefix arithmetic is how a broken archive gets built, checksummed, and
+   published without anyone noticing.
 1. **`fpm_build` died silently when fpm's output format didn't match.** Under
    `set -o pipefail`, `grep -oP ':path=>…'` matching nothing failed the whole
    pipeline, killing the build before `ensure_path`'s glob fallback — the case

--- a/build-release.ps1
+++ b/build-release.ps1
@@ -95,6 +95,15 @@ if (-not (Test-Path -LiteralPath $OutputDir)) {
     New-Item -ItemType Directory -Path $OutputDir | Out-Null
 }
 
+# Resolve the stage path ONCE and use the resolved form from here on. ZIP entry
+# names are produced by trimming this prefix off each staged file's .FullName
+# (already resolved), so the two must be the same textual form. -OutputDir may
+# arrive relative, with a trailing separator, or as an 8.3 short path (a GitHub
+# Windows runner's TEMP is C:\Users\RUNNER~1\...). Any such difference used to
+# corrupt EVERY entry name in the archive instead of failing: `-OutputDir dist`
+# produced entries like 'studio/dist/stage/ccds-v0.0.0/catalog.json'.
+$stageDir = (Get-Item -LiteralPath $stageDir).FullName.TrimEnd('\', '/')
+
 # ---------------------------------------------------------------------------
 # Copy map: source (repo-relative) -> destination (stage-relative)
 # ---------------------------------------------------------------------------
@@ -200,7 +209,12 @@ $zipStream = [System.IO.File]::Open($zipPath, [System.IO.FileMode]::Create, [Sys
 $archive   = New-Object System.IO.Compression.ZipArchive($zipStream, [System.IO.Compression.ZipArchiveMode]::Create)
 try {
     Get-ChildItem -LiteralPath $stageDir -Recurse -File | ForEach-Object {
-        # Strip the stageDir prefix and normalise separators to forward slashes
+        # Strip the stageDir prefix and normalise separators to forward slashes.
+        # The guard is the point: prefix arithmetic that silently misses is how
+        # a structurally broken archive ships without anyone noticing.
+        if (-not $_.FullName.StartsWith($stageDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Staged file is not under the stage root, so its archive entry name cannot be derived:`n  file: $($_.FullName)`n  root: $stageDir"
+        }
         $entryName = $_.FullName.Substring($stageDir.Length).TrimStart('\', '/').Replace('\', '/')
         [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
             $archive, $_.FullName, $entryName,

--- a/build-release.sh
+++ b/build-release.sh
@@ -128,11 +128,18 @@ FPM_FLAGS=(
 # Run fpm and return the path of the created package.
 # Display output goes to stderr so it shows in terminal even when called with $().
 # Only the package path is printed to stdout (captured by the caller).
+#
+# The trailing `|| true` is load-bearing: under `set -o pipefail` a grep that
+# matches nothing fails the whole pipeline, so an fpm whose output format no
+# longer carries `:path=>"..."` killed this function -- and with it the build --
+# before ensure_path's glob fallback (which exists for exactly that case) ever
+# ran, printing no diagnostic of our own. Empty stdout is a valid answer here:
+# "fpm succeeded, I could not read the path from it".
 fpm_build() {
     local out
     out=$(fpm "$@" 2>&1) || { printf '%s\n' "$out" | sed 's/^/    /' >&2; return 1; }
     printf '%s\n' "$out" | sed 's/^/    /' >&2
-    printf '%s\n' "$out" | grep -oP '(?<=:path=>")[^"]+' | tail -1
+    printf '%s\n' "$out" | grep -oP '(?<=:path=>")[^"]+' | tail -1 || true
 }
 
 # Ensure the package ended up at the expected path (rename if fpm added iteration suffix)

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -12,6 +12,8 @@ Run: python3 -m unittest discover -s tests -v
 
 import ast
 import getpass
+import hashlib
+import importlib.util
 import json
 import shlex
 import os
@@ -21,12 +23,15 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import zipfile
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPTS = os.path.join(REPO_ROOT, "scripts")
 BUILD_CATALOG = os.path.join(SCRIPTS, "build-catalog.py")
 LINT_PLAYBOOK = os.path.join(SCRIPTS, "lint-playbook.py")
 BUILD_MARKETPLACE = os.path.join(SCRIPTS, "build-marketplace.py")
+BUILD_RELEASE_SH = os.path.join(REPO_ROOT, "build-release.sh")
+BUILD_RELEASE_PS1 = os.path.join(REPO_ROOT, "build-release.ps1")
 
 AGENT_TMPL = """---
 name: saas-architect
@@ -2147,6 +2152,435 @@ class TestInstallPlaybookPs1(unittest.TestCase):
         self.assertIn("archive layout is unexpected", r.stdout + r.stderr)
         self.assertTrue(os.path.isfile(os.path.join(self.prefix, "bin", "ccds.ps1")),
                         "the good install must survive a failed one")
+
+
+def lint_module():
+    """scripts/lint-playbook.py loaded as a module (the filename is hyphenated,
+    so a plain import cannot reach it).
+
+    The release tests parse the builders with the linter's own regexes rather
+    than copies of them: "what this script says it stages" must mean exactly
+    one thing across the lint and these tests, or the two can agree with each
+    other while both being wrong about the script.
+    """
+    spec = importlib.util.spec_from_file_location("ccds_lint", LINT_PLAYBOOK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def declared_copies():
+    """(deb_pairs, zip_pairs) of (repo source, staged destination).
+
+    The lint only needs destinations; these tests also need the source, to
+    compare the bytes that landed against the bytes that should have.
+    """
+    mod = lint_module()
+    deb = []
+    for m in mod.DEB_COPY_RE.finditer(read(BUILD_RELEASE_SH)):
+        src, dst = m.group(1), m.group(2)
+        if dst == "" or dst.endswith("/"):
+            dst += src.rstrip("/").split("/")[-1]
+        deb.append((src, dst.replace("\\", "/").lstrip("./")))
+    zipped = [(m.group(1).replace("\\", "/"), m.group(2).replace("\\", "/"))
+              for m in mod.PS_COPY_RE.finditer(read(BUILD_RELEASE_PS1))]
+    return deb, zipped
+
+
+def lf(data):
+    """CRLF-insensitive bytes. build-release.sh normalizes line endings in the
+    stage, and a Windows checkout may carry CRLF sources."""
+    return data.replace(b"\r\n", b"\n")
+
+
+def read_bytes(path):
+    with open(path, "rb") as f:
+        return f.read()
+
+
+def raw_zip_entry_names(path):
+    """Entry names exactly as the archive stores them.
+
+    zipfile.namelist() cannot answer this: ZipInfo.__init__ rewrites os.sep to
+    '/', so on Windows an archive full of backslash entry names reads back
+    clean and a separator assertion passes vacuously. Parse the central
+    directory instead.
+    """
+    data = read_bytes(path)
+    eocd = data.rfind(b"PK\x05\x06")
+    if eocd < 0:
+        raise AssertionError("no end-of-central-directory record in " + path)
+    total = int.from_bytes(data[eocd + 10:eocd + 12], "little")
+    off = int.from_bytes(data[eocd + 16:eocd + 20], "little")
+    names = []
+    for _ in range(total):
+        if data[off:off + 4] != b"PK\x01\x02":
+            raise AssertionError("central directory truncated in " + path)
+        n = int.from_bytes(data[off + 28:off + 30], "little")
+        extra = int.from_bytes(data[off + 30:off + 32], "little")
+        comment = int.from_bytes(data[off + 32:off + 34], "little")
+        names.append(data[off + 46:off + 46 + n].decode("utf-8"))
+        off += 46 + n + extra + comment
+    return names
+
+
+def rel_files(root):
+    """Every file under root, as '/'-joined paths relative to it."""
+    out = set()
+    for base, _dirs, names in os.walk(root):
+        for n in names:
+            out.add(os.path.relpath(os.path.join(base, n), root)
+                    .replace(os.sep, "/"))
+    return out
+
+
+REPO_AGENTS = os.path.join(REPO_ROOT, ".claude", "agents")
+REPO_SKILLS = os.path.join(REPO_ROOT, "skills")
+
+
+def repo_agent_names():
+    return {n for n in os.listdir(REPO_AGENTS) if n.endswith(".md")}
+
+
+def repo_skill_names():
+    return {n for n in os.listdir(REPO_SKILLS)
+            if os.path.isfile(os.path.join(REPO_SKILLS, n, "SKILL.md"))}
+
+
+def make_fpm_stub_bin(root, name="stubbin", emit_path=True, create_file=True):
+    """A PATH directory carrying fpm + rpmbuild stand-ins.
+
+    build-release.sh checks for fpm before it stages anything, so on a machine
+    without fpm (every dev box — fpm is CI-only) the staging block is
+    unreachable. Stubbing the two binaries runs the real script end to end,
+    including the fpm flag assembly and ensure_path, which a `--stage-only`
+    flag would skip — and adds no product surface to keep in bash/PS parity.
+
+    emit_path   -- print fpm's `:path=>"..."` token. False simulates a future
+                   fpm whose output format changed.
+    create_file -- actually create the package artifact.
+    """
+    bindir = os.path.join(root, name)
+    body = [
+        "#!/usr/bin/env bash",
+        'pkgdir=""; typ="deb"',
+        'while (( $# )); do case "$1" in',
+        '  --package) pkgdir="$2"; shift 2 ;;',
+        '  -t) typ="$2"; shift 2 ;;',
+        '  *) shift ;;',
+        "esac; done",
+        'out="$pkgdir/${CCDS_STUB_PKG_BASE:-ccds-stub}.$typ"',
+    ]
+    if create_file:
+        body.append("printf 'stub package\\n' > \"$out\"")
+    body.append('echo "fpm stub: built $typ"')
+    if emit_path:
+        body.append('echo "Created package {:path=>\\"$out\\"}"')
+    write(os.path.join(bindir, "fpm"), "\n".join(body) + "\n")
+    write(os.path.join(bindir, "rpmbuild"), "#!/usr/bin/env bash\nexit 0\n")
+    for f in ("fpm", "rpmbuild"):
+        os.chmod(os.path.join(bindir, f), 0o755)
+    return bindir
+
+
+STAGE_LINE_RE = re.compile(r"^==> Staging files to (.+)$", re.MULTILINE)
+
+
+def run_build_release_sh(bindir, outdir, version="v0.0.0-test",
+                         keep_stage=False, skip_rpm=False, env_extra=None,
+                         umask="077"):
+    """Run the real builder with fpm stubbed onto PATH.
+
+    The restrictive default umask is deliberate. `cp` carries the source mode
+    through, so under the usual 022 a 0755 source lands 0755 whether or not the
+    script chmods it — the mode assertion below could not fail, and on a drvfs
+    checkout (every source reports 0777) it especially could not. Under 077 the
+    `chmod 755` is the only thing that yields an executable package, which is
+    also the real case it guards: a build host with a tight umask shipping a
+    package nobody can run.
+    """
+    inner = [BASH, BUILD_RELEASE_SH, "--version", version,
+             "--output-dir", outdir]
+    if keep_stage:
+        inner.append("--keep-stage")
+    if skip_rpm:
+        inner.append("--skip-rpm")
+    args = [BASH, "-c", 'umask "$1"; shift; exec "$@"', "ccds-build",
+            umask] + inner
+    env = {**os.environ, "PATH": bindir + os.pathsep + os.environ["PATH"]}
+    env.update(env_extra or {})
+    return subprocess.run(args, capture_output=True, text=True, env=env,
+                          cwd=REPO_ROOT)
+
+
+@unittest.skipUnless(BASH and sys.platform != "win32",
+                     "build-release.sh is a bash script (POSIX shells only)")
+class TestReleaseStagingSh(unittest.TestCase):
+    """What build-release.sh ACTUALLY stages — not what its copy list says.
+
+    The release-parity lint (check 12) proves the two builders' declared lists
+    agree with each other. Nothing proved either list matches the tree that
+    lands on disk, and a copy that silently stages nothing passes that lint:
+    build-release.ps1 shipped exactly that bug once (`Join-Path $skillsSrc '*'`
+    under -LiteralPath copied no skills at all, and the list still looked
+    right). These tests assert against the artifact.
+
+    They also cover the payload no list mentions — the agents/skills trees, the
+    usr/bin/ccds symlink, the bash-completion drop-in, exec bits, version.txt.
+    """
+
+    # The two source files build-release.sh rewrites in place (`sed -i`, to
+    # strip CR before fpm picks them up). Snapshotted before any build runs.
+    SED_TARGETS = [os.path.join(REPO_ROOT, "packaging", "postinst"),
+                   os.path.join(REPO_ROOT, "packaging", "prerm")]
+
+    @classmethod
+    def setUpClass(cls):
+        # BEFORE the build, not inside a test method: the class-level build
+        # below would absorb any pending rewrite, leaving a later snapshot
+        # comparing post-normalization bytes with themselves.
+        cls.repo_before = {p: read_bytes(p) for p in cls.SED_TARGETS}
+        cls.tmp = tempfile.mkdtemp(prefix="ccds-relstage-")
+        cls.stage = None
+        bindir = make_fpm_stub_bin(cls.tmp)
+        cls.out = os.path.join(cls.tmp, "out")
+        r = run_build_release_sh(bindir, cls.out, keep_stage=True)
+        # Read the stage path BEFORE deciding whether the build succeeded:
+        # --keep-stage disarms the script's own cleanup trap, so a build that
+        # fails after staging leaks the tree unless we can name it.
+        m = STAGE_LINE_RE.search(r.stdout)
+        if m:
+            cls.pkg = m.group(1).strip()           # <stage>/usr/share/ccds
+            cls.stage = os.path.normpath(os.path.join(cls.pkg, "..", "..", ".."))
+        if r.returncode != 0 or not m:
+            cls.tearDownClass()
+            raise AssertionError(
+                ("build-release.sh failed:\n" if r.returncode
+                 else "could not find the stage path in:\n") + r.stdout + r.stderr)
+        cls.stdout = r.stdout
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+        if cls.stage:
+            shutil.rmtree(cls.stage, ignore_errors=True)
+
+    def test_helper_agrees_with_the_linters_own_parser(self):
+        """declared_copies() re-derives destinations; if it ever disagrees with
+        the lint, every assertion below is measuring the wrong thing."""
+        deb, zipped = declared_copies()
+        mod = lint_module()
+        self.assertEqual({d for _s, d in deb},
+                         mod._deb_payload(read(BUILD_RELEASE_SH)))
+        self.assertEqual({d for _s, d in zipped},
+                         mod._zip_payload(read(BUILD_RELEASE_PS1)))
+
+    def test_every_declared_path_lands_with_matching_content(self):
+        deb, _zipped = declared_copies()
+        self.assertTrue(deb, "parsed no copies out of build-release.sh")
+        for src, dst in sorted(deb):
+            staged = os.path.join(self.pkg, *dst.split("/"))
+            source = os.path.join(REPO_ROOT, *src.split("/"))
+            self.assertTrue(os.path.exists(staged),
+                            "build-release.sh declares '%s' but nothing landed "
+                            "at that path in the package" % dst)
+            if os.path.isdir(source):
+                self.assertEqual(rel_files(staged), rel_files(source),
+                                 "'%s' staged an incomplete directory" % dst)
+            else:
+                self.assertEqual(lf(read_bytes(staged)), lf(read_bytes(source)),
+                                 "'%s' staged content that is not %s" % (dst, src))
+
+    def test_the_agents_and_skills_trees_land_complete(self):
+        """Neither is in the copy list — both are loop-copied, so the lint is
+        blind to them, and they are most of what a release IS."""
+        self.assertEqual(
+            {n for n in os.listdir(os.path.join(self.pkg, "agents"))
+             if n.endswith(".md")},
+            repo_agent_names())
+        staged_skills = {
+            n for n in os.listdir(os.path.join(self.pkg, "skills"))
+            if os.path.isfile(os.path.join(self.pkg, "skills", n, "SKILL.md"))}
+        self.assertEqual(staged_skills, repo_skill_names())
+
+    def test_dispatcher_symlink_resolves_to_the_staged_script(self):
+        link = os.path.join(self.stage, "usr", "bin", "ccds")
+        self.assertTrue(os.path.islink(link), "usr/bin/ccds must be a symlink")
+        self.assertEqual(os.readlink(link), "../share/ccds/bin/ccds.sh")
+        # Resolve it the way the installed filesystem will.
+        self.assertTrue(os.path.isfile(os.path.realpath(link)),
+                        "usr/bin/ccds dangles: %s" % os.readlink(link))
+
+    def test_bash_completion_drop_in_is_staged_under_its_command_name(self):
+        """ADR-0017: the package activates completion the distro-native way —
+        the file must be named for the command, not for its source."""
+        drop_in = os.path.join(self.stage, "usr", "share",
+                               "bash-completion", "completions", "ccds")
+        self.assertTrue(os.path.isfile(drop_in), rel_files(self.stage))
+        self.assertEqual(
+            lf(read_bytes(drop_in)),
+            lf(read_bytes(os.path.join(SCRIPTS, "ccds-completion.bash"))))
+
+    def test_version_txt_reads_back_as_the_requested_tag(self):
+        with open(os.path.join(self.pkg, "version.txt")) as f:
+            self.assertEqual(f.read().strip(), "v0.0.0-test")
+
+    def test_staged_scripts_carry_exactly_mode_755(self):
+        """Exact, not `& 0o111`: `cp` preserves the source mode, and on a
+        checkout where that is already executable (or on a filesystem that
+        reports 0777, like NTFS under WSL) a permissive assertion passes even
+        with the chmod removed. 0o755 is what the chmod imposes and what a
+        package must ship."""
+        for rel in ["bin/ccds.sh", "scripts/Sync-AgentPacks.sh",
+                    "scripts/verify-agents.sh", "scripts/ccds-user-setup.sh"]:
+            mode = os.stat(os.path.join(self.pkg, *rel.split("/"))).st_mode
+            self.assertEqual(mode & 0o777, 0o755,
+                             "%s is %o in the package, want 755"
+                             % (rel, mode & 0o777))
+
+    def test_no_windows_only_file_reaches_a_linux_package(self):
+        """The ADR-0017 defect, asserted against the artifact rather than the
+        list: the .deb shipped bin/ccds.ps1 without the Sync-AgentPacks.ps1 it
+        needs, so the dispatcher could only ever error."""
+        produced = rel_files(self.pkg)
+        for rel in sorted(lint_module().WINDOWS_ONLY_PAYLOAD):
+            self.assertNotIn(rel, produced)
+        self.assertFalse([p for p in produced if p.endswith(".ps1")],
+                         "a Linux package staged PowerShell files")
+
+    def test_building_does_not_modify_the_repository(self):
+        """The script runs `sed -i` against packaging/postinst and prerm in the
+        source tree. It is meant to be a no-op on an LF checkout; if it ever
+        rewrites them, a release build silently dirties the working tree.
+
+        Compares against the setUpClass snapshot, which is the only honest
+        baseline — a snapshot taken here would already be post-build.
+        """
+        for p in self.SED_TARGETS:
+            self.assertEqual(read_bytes(p), self.repo_before[p],
+                             "%s was rewritten by a release build" % p)
+
+    def test_unreadable_fpm_output_falls_back_to_the_glob(self):
+        """`grep -oP ':path=>...'` matching nothing fails the pipeline under
+        `set -o pipefail`, which used to kill the build before ensure_path's
+        fallback — the very case that fallback exists for — with no diagnostic
+        of our own."""
+        bindir = make_fpm_stub_bin(self.tmp, name="stubbin-nopath",
+                                   emit_path=False)
+        out = os.path.join(self.tmp, "out-nopath")
+        # The stub names its artifact after the .deb the glob looks for; the
+        # .rpm half of the same run would need a differently-shaped name, and
+        # one recovery is enough to prove the mechanism.
+        r = run_build_release_sh(
+            bindir, out, skip_rpm=True,
+            env_extra={"CCDS_STUB_PKG_BASE": "ccds_0.0.0-test_all"})
+        self.assertEqual(r.returncode, 0,
+                         "the glob fallback should have recovered:\n"
+                         + r.stdout + r.stderr)
+        self.assertTrue(os.path.isfile(
+            os.path.join(out, "ccds_0.0.0-test_all.deb")))
+
+    def test_a_missing_package_after_fpm_reports_clearly(self):
+        bindir = make_fpm_stub_bin(self.tmp, name="stubbin-nofile",
+                                   emit_path=False, create_file=False)
+        out = os.path.join(self.tmp, "out-nofile")
+        r = run_build_release_sh(bindir, out)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("package not found after fpm run", r.stdout + r.stderr)
+
+
+@unittest.skipUnless(PWSH, "build-release.ps1 is a PowerShell script "
+                           "(Windows-targeted, like the ZIP it builds)")
+class TestReleaseZipPs1(unittest.TestCase):
+    """What build-release.ps1 ACTUALLY produces. Runs the real builder — it has
+    no external dependency, so the artifact under test is the shipped one.
+
+    Also pins build_test_release_zip() to it: that fixture is a third
+    hand-maintained copy of the payload, and both installer suites install from
+    it. If it drifts, those suites certify a layout no release ever has.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.mkdtemp(prefix="ccds-relzip-")
+        r = subprocess.run(
+            [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", BUILD_RELEASE_PS1,
+             "-Version", "v0.0.0-test", "-OutputDir", cls.tmp],
+            capture_output=True, text=True, cwd=REPO_ROOT)
+        if r.returncode != 0:
+            shutil.rmtree(cls.tmp, ignore_errors=True)
+            raise AssertionError("build-release.ps1 failed:\n"
+                                 + r.stdout + r.stderr)
+        cls.zip = os.path.join(cls.tmp, "ccds-v0.0.0-test.zip")
+        with zipfile.ZipFile(cls.zip) as z:
+            cls.names = z.namelist()
+            cls.blobs = {n: z.read(n) for n in cls.names}
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp, ignore_errors=True)
+
+    def test_every_declared_path_is_in_the_zip_with_matching_content(self):
+        _deb, zipped = declared_copies()
+        self.assertTrue(zipped, "parsed no copies out of build-release.ps1")
+        present = set(self.names)
+        for src, dst in sorted(zipped):
+            source = os.path.join(REPO_ROOT, *src.split("/"))
+            if os.path.isdir(source):
+                staged = {n[len(dst) + 1:] for n in present
+                          if n.startswith(dst + "/")}
+                self.assertEqual(staged, rel_files(source),
+                                 "'%s' staged an incomplete directory" % dst)
+            else:
+                self.assertIn(dst, present,
+                              "build-release.ps1 declares '%s' but the ZIP has "
+                              "no such entry" % dst)
+                self.assertEqual(lf(self.blobs[dst]), lf(read_bytes(source)),
+                                 "'%s' holds content that is not %s" % (dst, src))
+
+    def test_the_agents_and_skills_trees_are_complete(self):
+        self.assertEqual({n[len("agents/"):] for n in self.names
+                          if n.startswith("agents/")},
+                         repo_agent_names())
+        self.assertEqual({n.split("/")[1] for n in self.names
+                          if n.startswith("skills/") and n.endswith("/SKILL.md")},
+                         repo_skill_names())
+
+    def test_entry_names_use_posix_separators(self):
+        """build-release.ps1 builds the archive by hand specifically to avoid
+        Compress-Archive's backslashes, which make `unzip` warn on Linux. The
+        claim was never checked — and cannot be, through namelist(), which
+        normalizes the very thing under test."""
+        raw = raw_zip_entry_names(self.zip)
+        self.assertFalse([n for n in raw if "\\" in n],
+                         "archive stores Windows separators; `unzip` will warn")
+        self.assertEqual(set(raw), set(self.names),
+                         "raw central-directory names disagree with namelist() "
+                         "— raw_zip_entry_names() is misparsing")
+
+    def test_version_txt_reads_back_as_the_requested_tag(self):
+        self.assertEqual(self.blobs["version.txt"].decode("utf-8").strip(),
+                         "v0.0.0-test")
+
+    def test_sha256_sidecar_matches_the_archive(self):
+        sidecar = read(self.zip + ".sha256").strip()
+        digest, _, name = sidecar.partition("  ")
+        self.assertEqual(digest,
+                         hashlib.sha256(read_bytes(self.zip)).hexdigest())
+        self.assertEqual(name, "ccds-v0.0.0-test.zip",
+                         "the sidecar must name the file `sha256sum -c` will "
+                         "look for next to it")
+
+    def test_the_installer_test_fixture_matches_the_real_artifact(self):
+        tmp, fixture_zip, _stage = build_test_release_zip()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        with zipfile.ZipFile(fixture_zip) as z:
+            fixture = {n for n in z.namelist() if not n.endswith("/")}
+        self.assertEqual(fixture, set(self.names),
+                         "build_test_release_zip() has drifted from "
+                         "build-release.ps1; the installer suites are "
+                         "certifying a layout no release produces")
 
 
 @unittest.skipUnless(BASH and sys.platform != "win32",

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -2582,6 +2582,35 @@ class TestReleaseZipPs1(unittest.TestCase):
                          "build-release.ps1; the installer suites are "
                          "certifying a layout no release produces")
 
+    def test_an_unresolved_output_dir_does_not_corrupt_entry_names(self):
+        """Entry names are derived by trimming the stage path off each file's
+        resolved .FullName, so the prefix has to be resolved too. A relative
+        -OutputDir used to yield entries like
+        'studio/dist/stage/ccds-v0.0.0/catalog.json' — a structurally broken
+        archive, built and checksummed without a single warning.
+
+        The same divergence bit on CI, where a GitHub Windows runner's TEMP is
+        the 8.3 short path C:\\Users\\RUNNER~1: three characters shorter than
+        the resolved form, so every entry kept an 'est/' prefix. A relative
+        path reproduces it deterministically anywhere.
+        """
+        work = tempfile.mkdtemp(prefix="ccds-relzip-cwd-")
+        self.addCleanup(shutil.rmtree, work, ignore_errors=True)
+        r = subprocess.run(
+            [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", BUILD_RELEASE_PS1,
+             "-Version", "v0.0.0-rel", "-OutputDir", "out-rel"],
+            capture_output=True, text=True, cwd=work)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        built = os.path.join(work, "out-rel", "ccds-v0.0.0-rel.zip")
+        self.assertTrue(os.path.isfile(built), r.stdout + r.stderr)
+        names = raw_zip_entry_names(built)
+        self.assertIn("catalog.json", names,
+                      "entry names carry a path prefix: %s" % sorted(names)[:3])
+        self.assertEqual(set(names), set(self.names),
+                         "a relative -OutputDir produced a different archive "
+                         "layout than an absolute one")
+
 
 @unittest.skipUnless(BASH and sys.platform != "win32",
                      "ccds-user-setup.sh is a bash script (POSIX shells only)")


### PR DESCRIPTION
## Summary

`release-parity` (ADR-0017, shipped in v0.18.0) proves the two release builders' declared copy lists agree **with each other**. Nothing proved either list matches the tree that actually lands — and a copy that silently stages nothing passes that lint. That is not hypothetical: `build-release.ps1` shipped exactly that bug once, when a wildcard under `-LiteralPath` copied no skills at all while `$copyMap` still read correctly.

Both builders now run for real in the suite and their output is asserted. Four hand-maintained payload lists existed; this closes the gap between what they say and what ships.

## What changed

**17 new cases against the artifact**

- `TestReleaseStagingSh` (11, Linux) stubs `fpm`/`rpmbuild` onto `PATH` rather than adding a `--stage-only` flag. fpm's preflight sits before the stage block, so the script is otherwise unreachable on any dev box; stubbing runs strictly more of it (flag assembly, `ensure_path`) and adds no product surface needing bash/PS parity.
- `TestReleaseZipPs1` (6, Windows) runs `build-release.ps1` unmodified — it has no external dependency, so the artifact under test is the shipped one.
- Both cover the payload no list mentions: the agents and skills trees, the `usr/bin/ccds` symlink, the bash-completion drop-in, mode 755 on staged scripts, `version.txt`, the SHA256 sidecar, and — checked for the first time — that ZIP entry names really use forward slashes.
- `build_test_release_zip()`, a third hand-maintained copy of the payload and the fixture **both** installer suites install from, is pinned to the real ZIP's entry set. It had not drifted; nothing would have noticed if it had.

**One defect fixed in shipped code**

`build-release.sh`'s `fpm_build` died silently when fpm's output didn't carry a `:path=>` token: under `set -o pipefail` the non-matching `grep` failed the whole pipeline and killed the build *before* `ensure_path`'s glob fallback — the case that fallback exists for — printing no diagnostic of its own. Same shape as the `ccds doctor` version-parse bug. Empty stdout is now a valid answer meaning "fpm succeeded, I could not read the path from it".

**Repo hygiene** (second commit, separate theme)

`.claude/handoff.md` and `.claude/evidence/` are ccds-loops runtime state written into whatever repo the session runs in. Neither was ignored, so every compaction left an untracked file in `git status`.

## Three tests that could not fail, caught and fixed

Worth calling out, because each is the failure mode this whole line of work exists to hunt:

1. **`zipfile` normalizes `os.sep` → `/` on read** (`ZipInfo.__init__`), so `namelist()` can never expose backslash entry names on Windows. Verified the mutation really does produce `agents\ai-architect.md`; the test now parses the central directory raw.
2. **The mode assertion passed with the `chmod` removed** — `cp` carries the source mode through, and on a drvfs checkout every file reports 0777. The staging build now runs under `umask 077`, where removing the chmod drops the package to 0700 and the test fails.
3. **The repo-immutability test snapshotted after `setUpClass`'s build** had already absorbed the rewrite it was meant to detect. It now snapshots before any build; proven by CRLF-ing `packaging/postinst` and watching it fail.

## Verification

| Check | Result |
|---|---|
| `python3 -m unittest discover -s tests` (Linux) | 285 passed, 13 skipped |
| `python -m unittest discover -s tests` (Windows, WinPS 5.1 + Windows Python) | 285 passed, 70 skipped |
| `python3 scripts/lint-playbook.py` | 0 errors, 0 warnings |
| Mutation coverage | every case except `test_helper_agrees_with_the_linters_own_parser` (a consistency check by construction); each mutation caught by exactly the intended test |
| Tree state | clean after every run; no leaked stage dirs; `build-release.{sh,ps1}` byte-identical after all mutation runs |

**What CI adds that local runs cannot:** the release workflow builds the ZIP with `shell: pwsh` on `windows-latest`, so `build-release.ps1` runs under **PowerShell 7** in production. `pwsh` is not installed on the dev box, so local Windows runs used Windows PowerShell 5.1. The Windows CI job will exercise `TestReleaseZipPs1` under pwsh 7 for the first time.

## Post-merge note

No release. The only shipped-code fix is to the machinery that builds releases, not to anything an installed user touches — the changelog entry sits under `[Unreleased]` and rides the next release.

Known and deliberately **not** in scope: `TestBuildMarketplace` rewrites 160 checked-in files under `plugins/` on every suite run, which on drvfs leaves `git status` reporting ~166 phantom modifications until you stage (`git diff HEAD` is authoritative; the content is identical). And the loops hooks dirty every *consumer* repo the same way — giving `stage-gates.py` a `.gitignore` contribution touches ADR-0013's never-destroy rule and wants its own plan.

Refs ADR-0017 (amended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
