### PR TITLE
docs(branching): adopt develop as integration branch, keep main as release + default (ADR-0019)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,30 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read
 
 jobs:
+  promotion-only:
+    name: main accepts only develop
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-promotion PRs into main (ADR-0019)
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::PRs into main must have develop as their head branch (ADR-0019). Retarget this PR at develop: gh pr edit --base develop"
+            exit 1
+          fi
+          echo "promotion PR develop -> main: ok"
+
   verify-agents-nix:
     name: Verify agents (Linux)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Infrastructure
 
+- **The repo now has a `develop` integration branch; `main` is release-only and
+  stays the GitHub default** (ADR-0019). Feature PRs target `develop`
+  (`gh pr create --base develop`); `main` only receives `develop` → `main`
+  promotion PRs, merged without squashing and tagged. `main` has to remain the
+  default branch because `/plugin marketplace add` installs from the default
+  branch — flipping it would have shipped unreleased code to every marketplace
+  user. CI now runs on both branches, and a new `promotion-only` check fails
+  any PR into `main` that does not come from `develop`.
 - **Both release builders are now run for real in the test suite, and what they
   produce is asserted** (ADR-0017 amendment). The `release-parity` lint added
   in v0.18.0 proves the two builders' copy *lists* agree; nothing proved either

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,15 @@ skills — no domain agent; skills-only, like `common-`).
 
 ## Conventions
 
+- **Branch model (ADR-0019):** `develop` is the integration branch — cut every
+  feature/fix/docs branch from it and open the PR against it with an explicit
+  `gh pr create --base develop`. `main` is the release branch **and stays the GitHub
+  default branch**: `/plugin marketplace add ggrace519/claude-code-dev-studio` clones
+  and updates from the repository's default branch, so whatever `main` holds is what
+  every marketplace user installs. Promotion is a `develop` → `main` PR, merged as a
+  merge commit or fast-forward (never squash), then tagged on `main`. CI runs on both
+  branches, and the `promotion-only` job rejects any PR into `main` whose head is not
+  `develop`.
 - **Decisions are logged.** Every significant architectural/security/process decision is
   an ADR in `DECISIONS.md`. The shared `playbook-conventions` skill carries the ADR
   template and the output/handoff format — agents pull it rather than restating it.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1796,3 +1796,77 @@ existing rather than trusting one developer's box:
 
 ### Supersedes
 None.
+
+---
+
+## ADR-0019: `develop` Integrates, `main` Releases and Stays the Default Branch
+
+**Date:** 2026-09-06
+**Status:** Accepted
+**Phase:** Deployment
+**Deciders:** Greg Grace
+
+### Context
+
+Until now the repo had one long-lived branch. Every feature PR targeted `main`,
+so `main` was simultaneously the integration branch and the branch that
+`/plugin marketplace add ggrace519/claude-code-dev-studio` installs from. Any
+merged-but-unreleased change was immediately live for every marketplace user.
+
+The standing convention across Greg's repos is a two-branch model: `develop`
+for integration, `main` for what is released, with `develop` set as the GitHub
+default branch so PRs, clones, and the UI target it. Applying that here hit a
+conflict specific to this repo: **the default branch is a distribution
+channel.** The Claude Code plugin-marketplaces documentation states that a
+marketplace source's `ref` "defaults to repository default branch", and that a
+marketplace added without a ref updates from the default branch. The local
+evidence agrees — the marketplace clone on this machine
+(`~/.claude/plugins/marketplaces/ccds`) is a shallow clone whose only fetch
+refspec is `+refs/heads/main:refs/remotes/origin/main`, i.e. whatever the
+default branch was at add time. Making `develop` the default would have put
+every new install, and existing installs on their next `marketplace update`,
+onto unreleased code.
+
+### Decision
+
+1. **`develop` is the integration branch.** Every feature/fix/docs branch is
+   cut from it and its PR targets it. Because `develop` is *not* the default
+   branch, the PR base must be passed explicitly: `gh pr create --base develop`.
+2. **`main` is the release branch and remains the GitHub default branch.**
+   Only promotion PRs (`develop` as head, `main` as base) land on it, merged as
+   a merge commit or fast-forward — never squash, which would diverge the two
+   branches and make every later promotion conflict. Releases are tagged on
+   `main`.
+3. **CI covers both.** `ci.yml` triggers on pushes and PRs to `main` *and*
+   `develop`. A `promotion-only` job fails any PR into `main` whose head branch
+   is not `develop`, so a mis-targeted feature PR is caught by a red check
+   rather than by someone noticing.
+4. **`develop` is never deleted** and must always be promotable — nothing
+   known-broken lands on it; unfinished work stays on a stacked branch.
+
+### Rationale
+
+Pinning the marketplace source to `@main` everywhere it is written down was
+considered and rejected: it fixes only the invocations this repo controls,
+while the unpinned form already exists in earlier changelog entries, in
+`known_marketplaces.json` on every existing install, and anywhere the
+one-liner has been copied. Keeping `main` as the default makes the unpinned
+form correct by construction. The cost — one `--base develop` flag on PR
+creation — is small and is backstopped by the CI guard.
+
+### Consequences
+
+- Changelog entries accumulate under `## [Unreleased]` on `develop`; the
+  promotion PR rolls them into the dated version heading that matches the tag.
+- The raw-URL installer one-liners (`.../main/install-playbook.sh`,
+  `.../main/Install-Playbook.ps1`) and the marketplace source stay exactly as
+  documented — they already name `main` and now mean "released".
+- Stacked PRs still get no CI (a known limitation noted in v0.17.0 notes);
+  the base branch for stacks is the parent branch, not `develop`.
+- Follow-on: if the marketplace source is ever made pinnable in the
+  installers (`owner/repo@main`), that is an optional hardening, not a
+  requirement of this model.
+
+### Supersedes
+
+None.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Optional, opt-in tab-completion for the Claude Code CLI itself — independent o
 - Agents live in a **flat** `.claude/agents/` directory; skills are `skills/<name>/SKILL.md` (one dir per skill). Claude Code does not recurse `.claude/agents/`. See ADR-0001 / ADR-0007.
 - Release ZIPs are named `ccds-<tag>.zip` with a matching `ccds-<tag>.zip.sha256` sidecar. Installers verify SHA256 before extracting.
 - The `~/.claude/CLAUDE.md` ccds block is delimited by `# >>> ccds >>>` / `# <<< ccds <<<` markers. The installer is idempotent — re-running updates the block in place. See ADR-0006 / ADR-0007.
+- Contributions branch from **`develop`** and PRs target it (`gh pr create --base develop`). `main` is release-only and stays the default branch because `/plugin marketplace add` installs from the default branch. See ADR-0019.
 
 ## License
 


### PR DESCRIPTION
## Summary

Introduces the two-branch model for this repo and records why it deviates from the usual "develop is the default branch" convention.

- `develop` is the integration branch: every feature/fix/docs branch is cut from it and PRs target it (`gh pr create --base develop`).
- `main` is release-only and **stays the GitHub default branch**. The Claude Code plugin marketplace clones and updates from the repository default branch when a source is added without a ref (official plugin-marketplaces doc: ref "defaults to repository default branch"). The marketplace clone on the maintainer's machine confirms it: its only fetch refspec is `+refs/heads/main`. Making `develop` the default would have shipped unreleased code to every new install and to existing installs on their next `marketplace update`.
- Promotion is a `develop` → `main` PR merged as a merge commit or fast-forward (never squash), then tagged on `main`.

## What changed

- `.github/workflows/ci.yml`: triggers on pushes and PRs to `develop` as well as `main` (previously PRs into `develop` would have run no checks). New `promotion-only` job fails any PR into `main` whose head is not `develop`.
- `DECISIONS.md`: ADR-0019 with the evidence and the rejected alternative (pinning `@main` in our own scripts, which cannot fix the unpinned form already in every installed `known_marketplaces.json`).
- `CLAUDE.md`: branch-model bullet at the top of Conventions.
- `CHANGELOG.md`: Infrastructure entry under Unreleased.
- `README.md`: contributor-facing conventions line.

## Verification

- `python3 scripts/lint-playbook.py`: PASS, 0 errors, 0 warnings.
- `python3 -m unittest discover -s tests`: 286 run, 14 skipped, 0 failures.
- `ci.yml` parses; job list includes `promotion-only`; triggers show `[main, develop]` for both push and pull_request.
- `develop` was created from `main` and pushed; the GitHub default branch was set to `develop`, then reverted to `main` once the marketplace coupling was established.

## Post-merge

- Squash-merge into `develop` and delete the branch, per the feature-PR convention. This PR itself is the first under the new model.
- Its changelog entry rolls into the next version heading at promotion time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRcT9LqHK3ftpoVNtjKjz7
