### PR TITLE
fix(doctor): detect the double-loaded roster and stop setup from creating it (ADR-0020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ## [Unreleased]
 
+### Added
+
+- **`ccds doctor` now catches the double-loaded roster, and setup no longer
+  creates it** (ADR-0020). The 19 agents and cross-cutting skills reach Claude
+  Code either from the ccds plugins or from file copies in `~/.claude`; having
+  both means every agent is in the roster twice, with the stale file copy owning
+  the bare name. A new `plugin-file-overlap` check fails in that state and prints
+  the exact removal command (both dispatchers, first behavioral tests for the
+  PowerShell doctor). `ccds setup`, `ccds.ps1 setup` and `Install-Playbook.ps1`
+  skip the file copies when a content plugin is enabled and name any stale
+  copies instead of deleting them. `agents-installed` / `skills-installed`
+  report the plugin as the source when `ccds-core` is enabled.
+
 ### Fixed
+
+- **`ccds doctor` reported a DISABLED `ccds-guard` as enabled** (#70). The bash
+  check split `claude plugin list --json` into objects and looked for
+  `"enabled": false` on the same line as the plugin id — but the real CLI
+  pretty-prints one field per line, so the disabled branch could never match on
+  real output. The test stub emitted flat JSON, which is why the suite passed.
+  Newlines are now collapsed before splitting, the stub pretty-prints like the
+  CLI, and a regression test covers the disabled case on both platforms.
 
 - **`build-release.ps1` could build a structurally broken release ZIP without
   a single warning.** Entry names are produced by trimming the stage path off

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ its `<pack>-*` skills in a single coherent context. See `DECISIONS.md` ADR-0007.
 
 | Layer | Location | Loaded | Notes |
 |---|---|---|---|
-| 19 agents | `~/.claude/agents/` | always (session start) | 14 domain + 5 core; ~850 tokens of descriptions |
+| 19 agents | plugins (`ccds-core` + packs) **or** `~/.claude/agents/` — never both (ADR-0020) | always (session start) | 14 domain + 5 core; ~850 tokens of descriptions |
 | Cross-cutting skills | `~/.claude/skills/` | descriptions always; body JIT | `playbook-conventions`, `api-design`, `ux-design`, `security-checklist`, `code-review-checklist`, `inventive-engineer`, `common-*`, `loop-*` |
 | Domain skills | `~/.claude/playbook/skills/` → `.claude/skills/` | per project (JIT) | `<pack>-*`; staged by `ccds sync` (via the `sync-agents` skill) |
 | Gate templates | `~/.claude/playbook/templates/` → project files | per project (with sync) | settings denies, CLAUDE.md standards, pre-commit, CI — stack-matched via `stack-matrix.json`, never-destroy (ADR-0013); skip with `--no-gates` |

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1870,3 +1870,77 @@ creation — is small and is backstopped by the CI guard.
 ### Supersedes
 
 None.
+
+---
+
+## ADR-0020: The Always-On Roster Has One Source — Plugins or File Copies, Never Both
+
+**Date:** 2026-09-06
+**Status:** Accepted
+**Phase:** Deployment
+**Deciders:** Greg Grace
+
+### Context
+
+ccds ships the same 19 agents and 18 cross-cutting skills by two routes: the
+plugin marketplace (`ccds-core` + one plugin per archetype pack) and the file
+installers, which copy them into `~/.claude/agents/` and `~/.claude/skills/`.
+The README presented the ZIP route as "additionally" providing the CLI and
+library, and nothing stopped a user from having both. Claude Code loads both:
+every agent then appears twice in the roster (`plan-architect` and
+`ccds-core:plan-architect`), the router sees two identical descriptions, the
+file copy owns the bare name, and the ~850 tokens of agent descriptions plus
+the skill listing are paid twice. The file copies also go stale the moment the
+plugins update, because only the plugins auto-update.
+
+This was found on the maintainer's own machine, where a v0.11.0 file install
+had sat under current marketplace plugins for weeks — and `ccds doctor` said
+PASS, because it checked each route in isolation. The same investigation found
+#70: the bash doctor's disabled-plugin branch could never match the real
+`claude plugin list --json`, which pretty-prints one field per line, so a
+disabled `ccds-guard` was reported as enabled.
+
+### Decision
+
+1. **One source.** The always-on agents and cross-cutting skills come from the
+   ccds content plugins *or* from file copies, never both. The enforcement
+   plugins (`ccds-guard`, `ccds-loops`) are orthogonal: hooks ship only via
+   plugins (ADR-0012) and every route installs them.
+2. **Setup gates the copies.** `ccds-user-setup.sh`, `ccds.ps1 setup` and
+   `Install-Playbook.ps1` probe `claude plugin list --json` (read-only; skipped
+   under `--skip-plugins`, which means "never touch the CLI", and under
+   `--dry-run`). If any content plugin is enabled, steps 1/1b are skipped with
+   a one-line explanation, and stale copies are named with the exact removal
+   command. Setup never deletes a user's files.
+3. **Doctor sees both routes.** `agents-installed` and `skills-installed`
+   report the plugin as the source when `ccds-core` is enabled, and their FAIL
+   remedies name both fixes. A new `plugin-file-overlap` check FAILs when a
+   content plugin is enabled and ccds-owned copies (names from `catalog.json`)
+   are present, printing the removal command; it WARNs when the CLI cannot be
+   read. Both dispatchers, same 12-check contract.
+4. **Parsers collapse newlines first** (bash `tr -d '\n\r'`, PowerShell
+   `-join` before `ConvertFrom-Json`), and the test stubs pretty-print their
+   JSON so the suite exercises the real shape. Fixes #70.
+
+### Rationale
+
+Removing the file route entirely was considered: the CLI and per-project
+`ccds sync` still need the library on disk, and .deb/.rpm users have no
+marketplace step, so the file route stays. Making setup delete stale copies was
+rejected: the installers must never remove files they did not write in this
+run; naming the command is enough and reversible.
+
+### Consequences
+
+- A file-route user who later installs `ccds-core@ccds` gets a doctor FAIL
+  with the removal command, not a silent double roster.
+- The `~/.claude/CLAUDE.md` ccds block no longer claims the agents "live in
+  `~/.claude/agents/`"; it names both routes.
+- First behavioral coverage of `ccds.ps1 doctor` (Windows CI job).
+- Follow-on: `ccds doctor` could compare the file-install version against the
+  marketplace commit to flag a stale file route even when no plugin is
+  enabled; not done here.
+
+### Supersedes
+
+None.

--- a/Install-Playbook.ps1
+++ b/Install-Playbook.ps1
@@ -151,6 +151,61 @@ $Script:MarketplaceSource = if ($env:CCDS_MARKETPLACE_SOURCE) {
 } else { "$Script:Owner/$Script:Repo" }
 $Script:ClaudeCmd = if ($env:CCDS_CLAUDE_CMD) { $env:CCDS_CLAUDE_CMD } else { 'claude' }
 
+# ADR-0020: the always-on agents and cross-cutting skills reach Claude Code by
+# ONE of two routes -- the ccds content plugins (ccds-core + the archetype
+# packs) or the file copies this installer writes. Both at once loads every
+# agent twice. Returns the enabled content-plugin names (empty when none, or
+# when the CLI is absent/unreadable -- then the file route is taken and
+# `ccds doctor` reports any overlap). Read-only probe.
+function Get-EnabledContentPlugins {
+    $names = @()
+    if (-not (Get-Command $Script:ClaudeCmd -ErrorAction SilentlyContinue)) { return $names }
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        # Join first: the real CLI pretty-prints one field per line.
+        $raw = @(& $Script:ClaudeCmd plugin list --json 2>$null) -join "`n"
+        if (-not $raw.Trim()) { return $names }
+        foreach ($pl in @($raw | ConvertFrom-Json)) {
+            if ($null -eq $pl -or -not $pl.enabled) { continue }
+            if ("$($pl.id)" -match '^(ccds-[a-z]+)@') {
+                $n = $Matches[1]
+                if ($n -ne 'ccds-guard' -and $n -ne 'ccds-loops') { $names += $n }
+            }
+        }
+    } catch {
+        return @()
+    } finally {
+        $ErrorActionPreference = $prevEap
+    }
+    return @($names | Sort-Object -Unique)
+}
+
+# Stale file copies next to enabled plugins: say so with the exact removal
+# command, but never delete a user's files from the installer.
+function Show-StaleFileCopies {
+    param([string]$Prefix)
+    $agentsDir = Join-Path $env:USERPROFILE '.claude\agents'
+    $skillsDir = Join-Path $env:USERPROFILE '.claude\skills'
+    $srcDir    = Join-Path $Prefix 'agents'
+    $staleAgents = @()
+    if (Test-Path $srcDir) {
+        $staleAgents = @(Get-ChildItem -LiteralPath $srcDir -Filter *.md -File -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path -LiteralPath (Join-Path $agentsDir $_.Name) } | ForEach-Object { $_.Name })
+    }
+    $staleSkills = @($Script:GlobalSkills | Where-Object { Test-Path -LiteralPath (Join-Path $skillsDir "$_\SKILL.md") })
+    if ($staleAgents.Count -eq 0 -and $staleSkills.Count -eq 0) { return }
+    Write-WarnMsg "File copies from an earlier install are still present and are loaded in ADDITION to the plugins:"
+    Write-WarnMsg "  $($staleAgents.Count) agent file(s) in $agentsDir, $($staleSkills.Count) cross-cutting skill(s) in $skillsDir"
+    Write-WarnMsg "Remove them (the plugins keep working):"
+    if ($staleAgents.Count -gt 0) {
+        Write-WarnMsg ("  Remove-Item -Force " + (($staleAgents | ForEach-Object { "'" + (Join-Path $agentsDir $_) + "'" }) -join ', '))
+    }
+    if ($staleSkills.Count -gt 0) {
+        Write-WarnMsg ("  Remove-Item -Recurse -Force " + (($staleSkills | ForEach-Object { "'" + (Join-Path $skillsDir $_) + "'" }) -join ', '))
+    }
+}
+
 function Get-CcdsProfilePath {
     if ($env:CCDS_PS_PROFILE) { return $env:CCDS_PS_PROFILE }
     return $PROFILE.CurrentUserAllHosts
@@ -780,13 +835,23 @@ try {
         (Get-Content $installedVersionFile -Raw).Trim()
     } else { $resolvedTag }
 
-    # Copy all 19 always-on agents to ~/.claude/agents/ (always-loaded by Claude Code)
-    Write-Step "Installing always-on agents to $(Join-Path $env:USERPROFILE '.claude\agents')"
-    Install-AlwaysOnAgents -Prefix $Prefix -DryRun:$DryRun
+    # ADR-0020: plugins OR file copies, never both. -SkipPlugins means "never
+    # touch the claude CLI", so the probe is skipped with it too.
+    $contentPlugins = @()
+    if (-not $SkipPlugins) { $contentPlugins = @(Get-EnabledContentPlugins) }
+    if ($contentPlugins.Count -gt 0) {
+        Write-Step "Always-on agents and cross-cutting skills"
+        Write-OkMsg "Supplied by enabled plugin(s): $($contentPlugins -join ' ') -- skipping the file copies so Claude Code does not load the roster twice"
+        Show-StaleFileCopies -Prefix $Prefix
+    } else {
+        # Copy all 19 always-on agents to ~/.claude/agents/ (always-loaded by Claude Code)
+        Write-Step "Installing always-on agents to $(Join-Path $env:USERPROFILE '.claude\agents')"
+        Install-AlwaysOnAgents -Prefix $Prefix -DryRun:$DryRun
 
-    # Copy cross-cutting (global) skills to ~/.claude/skills/
-    Write-Step "Installing cross-cutting skills to $(Join-Path $env:USERPROFILE '.claude\skills')"
-    Install-GlobalSkills -Prefix $Prefix -DryRun:$DryRun
+        # Copy cross-cutting (global) skills to ~/.claude/skills/
+        Write-Step "Installing cross-cutting skills to $(Join-Path $env:USERPROFILE '.claude\skills')"
+        Install-GlobalSkills -Prefix $Prefix -DryRun:$DryRun
+    }
 
     # Inject/update ccds pointer block in ~/.claude/CLAUDE.md
     Write-Step "Updating ccds block in $(Join-Path $env:USERPROFILE '.claude\CLAUDE.md')"
@@ -865,7 +930,11 @@ try {
         Write-Host "Future shells : PATH update persists automatically." -ForegroundColor Yellow
     }
     Write-Host ""
-    Write-Host "Agents  : 19 always-on -> $(Join-Path $env:USERPROFILE '.claude\agents') (14 domain + 5 core)"
+    if ($contentPlugins.Count -gt 0) {
+        Write-Host "Agents  : 19 always-on from plugins ($($contentPlugins -join ' '))"
+    } else {
+        Write-Host "Agents  : 19 always-on -> $(Join-Path $env:USERPROFILE '.claude\agents') (14 domain + 5 core)"
+    }
     Write-Host "Skills  : $(Join-Path $Prefix 'skills') (domain skills, JIT per project; cross-cutting -> $(Join-Path $env:USERPROFILE '.claude\skills'))"
     Write-Host "CLAUDE  : $(Join-Path $env:USERPROFILE '.claude\CLAUDE.md') (ccds pointer block injected)"
     Write-Host "Plugins : $pluginsStatus"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,13 @@ source by `scripts/build-marketplace.py` and gated for freshness in CI.
 
 The ZIP installer below remains fully supported — it additionally provides the
 `ccds` CLI, the global `~/.claude/playbook/` library, and per-project skill
-staging via `ccds sync`.
+staging via `ccds sync`. The two routes are **alternatives for the always-on
+agents and cross-cutting skills, not layers** (ADR-0020): with `ccds-core` or a
+pack plugin enabled, Claude Code already loads that roster, so `ccds setup` and
+the installers skip the `~/.claude/agents` / `~/.claude/skills` copies, and
+`ccds doctor` fails with the exact removal command if both are ever present
+(every agent would be in the roster twice). Using both the CLI and the plugins
+is fine — the enforcement plugins are installed by every route.
 
 ## Install
 

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -365,12 +365,44 @@ function Invoke-SetupCommand {
     $skillsDst   = Join-Path $claudeHome 'skills'
     $claudeMd    = Join-Path $claudeHome 'CLAUDE.md'
 
-    # Step 1 -- always-on agents
-    Write-Host "==> Installing always-on agents to $agentsDst" -ForegroundColor Cyan
+    # Step 0 -- which route supplies the always-on roster? (ADR-0020) The
+    # roster reaches Claude Code by the ccds content plugins OR by the file
+    # copies below, never both: both at once loads every agent twice. Read-only
+    # probe; skipped under -SkipPlugins (never touch the CLI) and -DryRun.
+    $contentPlugins = @()
+    if (-not $Opts.SkipPlugins -and -not $Opts.DryRun) {
+        Resolve-ContentPlugins
+        if ($Script:ContentPluginsKnown) { $contentPlugins = @($Script:ContentPlugins) }
+    }
     $srcAgents = @()
     if (Test-Path -LiteralPath $agentsSrc) {
         $srcAgents = @(Get-ChildItem -LiteralPath $agentsSrc -Filter *.md -File -ErrorAction SilentlyContinue)
     }
+    $skillList = Get-GlobalSkillList
+    if ($contentPlugins.Count -gt 0) {
+        Write-Host "==> Always-on agents and cross-cutting skills" -ForegroundColor Cyan
+        Write-Host "OK  Supplied by enabled plugin(s): $($contentPlugins -join ' ') -- skipping the file copies so Claude Code does not load the roster twice" -ForegroundColor Green
+        # Stale copies next to enabled plugins: name them with the exact
+        # removal command, but never delete a user's files from setup.
+        $staleAgents = @($srcAgents | Where-Object { Test-Path -LiteralPath (Join-Path $agentsDst $_.Name) } | ForEach-Object { $_.Name })
+        $staleSkills = @()
+        if ($skillList) {
+            $staleSkills = @($skillList.Names | Where-Object { Test-Path -LiteralPath (Join-Path $skillsDst "$_\SKILL.md") })
+        }
+        if ($staleAgents.Count -gt 0 -or $staleSkills.Count -gt 0) {
+            Write-Host "!!  File copies from an earlier setup are still present and are loaded in ADDITION to the plugins:" -ForegroundColor Yellow
+            Write-Host "!!    $($staleAgents.Count) agent file(s) in $agentsDst, $($staleSkills.Count) cross-cutting skill(s) in $skillsDst" -ForegroundColor Yellow
+            Write-Host "!!  Remove them (the plugins keep working):" -ForegroundColor Yellow
+            if ($staleAgents.Count -gt 0) {
+                Write-Host ("!!    Remove-Item -Force " + (($staleAgents | ForEach-Object { "'" + (Join-Path $agentsDst $_) + "'" }) -join ', ')) -ForegroundColor Yellow
+            }
+            if ($staleSkills.Count -gt 0) {
+                Write-Host ("!!    Remove-Item -Recurse -Force " + (($staleSkills | ForEach-Object { "'" + (Join-Path $skillsDst $_) + "'" }) -join ', ')) -ForegroundColor Yellow
+            }
+        }
+    } else {
+    # Step 1 -- always-on agents
+    Write-Host "==> Installing always-on agents to $agentsDst" -ForegroundColor Cyan
     if ($Opts.DryRun) {
         Write-Host "    DRY RUN -- would copy $($srcAgents.Count) always-on agents to $agentsDst"
     } else {
@@ -387,7 +419,6 @@ function Invoke-SetupCommand {
 
     # Step 2 -- cross-cutting (global) skills
     Write-Host "==> Installing cross-cutting skills to $skillsDst" -ForegroundColor Cyan
-    $skillList = Get-GlobalSkillList
     if (-not $skillList) {
         Write-Error "cannot determine the global skill list (no parsable Install-Playbook.ps1 or scripts\ccds-user-setup.sh under $installRoot)" -ErrorAction Continue
         exit 2
@@ -413,6 +444,7 @@ function Invoke-SetupCommand {
         }
         Write-Host "OK  Copied $copied/$($skillList.Names.Count) cross-cutting skills to $skillsDst" -ForegroundColor Green
     }
+    } # end file route (Step 0 gate)
 
     # Step 3 -- ccds pointer block in ~/.claude/CLAUDE.md (idempotent)
     Write-Host "==> Updating ccds block in $claudeMd" -ForegroundColor Cyan
@@ -509,13 +541,20 @@ function Invoke-SetupCommand {
     } else {
         Write-Host ""
         Write-Host "User setup complete." -ForegroundColor Green
+        if ($contentPlugins.Count -gt 0) {
+            Write-Host "Agents      : from plugins ($($contentPlugins -join ' '))"
+            Write-Host "Skills      : from plugins ($($contentPlugins -join ' '))"
+        } else {
+            Write-Host "Agents      : $agentsDst (19 always-on)"
+            Write-Host "Skills      : $skillsDst ($(if ($skillList) { $skillList.Names.Count } else { '?' }) cross-cutting)"
+        }
         Write-Host "Plugins     : $pluginStatus"
     }
 }
 
 # ---------------------------------------------------------------------------
 # Command: doctor -- proactive environment health checks.
-# PowerShell twin of bin/ccds.sh cmd_doctor: same 11 checks, same output
+# PowerShell twin of bin/ccds.sh cmd_doctor: same 12 checks, same output
 # contract (one 'OK|WARN|FAIL  name: detail' line per check + indented remedy
 # on WARN/FAIL, summary block, exit 0 = no FAIL / 1 = FAIL found).
 #
@@ -617,17 +656,25 @@ function Test-DoctorVersion {
 
 function Test-DoctorAgents {
     $dir = Join-Path $env:USERPROFILE '.claude\agents'
+    if (Test-CorePluginEnabled) {
+        Write-DoctorLine OK 'agents-installed' "supplied by the enabled ccds-core plugin (no file copies needed in $dir)"
+        return
+    }
     if (Test-Path -LiteralPath (Join-Path $dir 'plan-architect.md')) {
         $n = @(Get-ChildItem -LiteralPath $dir -Filter *.md -File -ErrorAction SilentlyContinue).Count
         Write-DoctorLine OK 'agents-installed' "core sentinel plan-architect.md present ($n agent file(s) in $dir)"
     } else {
         Write-DoctorLine FAIL 'agents-installed' `
-            "plan-architect.md missing from $dir -- the always-on agents are not installed" `
-            "run 'ccds setup'"
+            "plan-architect.md missing from $dir and the ccds-core plugin is not enabled -- the always-on agents are not installed" `
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     }
 }
 
 function Test-DoctorSkills {
+    if (Test-CorePluginEnabled) {
+        Write-DoctorLine OK 'skills-installed' "supplied by the enabled ccds-core plugin (no file copies needed in $(Join-Path $env:USERPROFILE '.claude\skills'))"
+        return
+    }
     $skillList = Get-GlobalSkillList
     if (-not $skillList) {
         Write-DoctorLine WARN 'skills-installed' `
@@ -648,8 +695,65 @@ function Test-DoctorSkills {
     } else {
         Write-DoctorLine FAIL 'skills-installed' `
             "$($missing.Count)/$($skillList.Names.Count) cross-cutting skills missing from ${skillsDir}: $($missing -join ' ')" `
-            "run 'ccds setup'"
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     }
+}
+
+function Test-DoctorPluginFileOverlap {
+    # The always-on agents and cross-cutting skills reach Claude Code by ONE of
+    # two routes: the ccds content plugins, or file copies written by setup.
+    # Both at once means every agent is in the roster twice (two identical
+    # descriptions for the router, the stale file copy owns the bare name) and
+    # the descriptions cost context twice. Twin of bin/ccds.sh.
+    Resolve-ContentPlugins
+    if (-not $Script:ContentPluginsKnown) {
+        Write-DoctorLine WARN 'plugin-file-overlap' `
+            "cannot check: claude CLI not on PATH or 'claude plugin list --json' unreadable" `
+            "install Claude Code / run 'claude plugin list', then re-run 'ccds doctor'"
+        return
+    }
+    $agentsDir = Join-Path $env:USERPROFILE '.claude\agents'
+    $skillsDir = Join-Path $env:USERPROFILE '.claude\skills'
+    # ccds-owned agent names come from catalog.json (authoritative, shipped in
+    # every layout); the package's agents\ dir is the fallback for an old tree.
+    $owned = @()
+    $catalog = Join-Path $installRoot 'catalog.json'
+    if (Test-Path -LiteralPath $catalog) {
+        try {
+            $entries = @([System.IO.File]::ReadAllText($catalog) | ConvertFrom-Json)
+            $owned = @($entries | Where-Object { $_.kind -eq 'agent' } | ForEach-Object { "$($_.name).md" })
+        } catch { $owned = @() }
+    }
+    if ($owned.Count -eq 0) {
+        $src = Join-Path $installRoot 'agents'
+        if (-not (Test-Path -LiteralPath $src)) { $src = Join-Path $installRoot '.claude\agents' }
+        if (Test-Path -LiteralPath $src) {
+            $owned = @(Get-ChildItem -LiteralPath $src -Filter *.md -File -ErrorAction SilentlyContinue | ForEach-Object { $_.Name })
+        }
+    }
+    $agentFiles = @($owned | Where-Object { Test-Path -LiteralPath (Join-Path $agentsDir $_) })
+    $skillList = Get-GlobalSkillList
+    $skillNames = if ($skillList) { @($skillList.Names) } else { @() }
+    $skillDirs = @($skillNames | Where-Object { Test-Path -LiteralPath (Join-Path $skillsDir "$_\SKILL.md") })
+    if ($Script:ContentPlugins.Count -eq 0) {
+        Write-DoctorLine OK 'plugin-file-overlap' 'no ccds content plugin enabled; agents and skills come from the file copies only'
+        return
+    }
+    $pluginNames = $Script:ContentPlugins -join ' '
+    if ($agentFiles.Count -eq 0 -and $skillDirs.Count -eq 0) {
+        Write-DoctorLine OK 'plugin-file-overlap' "plugins ($pluginNames) supply the agents and skills; no file copies present"
+        return
+    }
+    $cmds = @()
+    if ($agentFiles.Count -gt 0) {
+        $cmds += 'Remove-Item -Force ' + (($agentFiles | ForEach-Object { "'" + (Join-Path $agentsDir $_) + "'" }) -join ', ')
+    }
+    if ($skillDirs.Count -gt 0) {
+        $cmds += 'Remove-Item -Recurse -Force ' + (($skillDirs | ForEach-Object { "'" + (Join-Path $skillsDir $_) + "'" }) -join ', ')
+    }
+    Write-DoctorLine FAIL 'plugin-file-overlap' `
+        "loaded twice: plugin(s) $pluginNames are enabled AND $($agentFiles.Count) agent file(s) + $($skillDirs.Count) cross-cutting skill(s) from a file install (version $(Get-InstalledVersion)) sit in $(Join-Path $env:USERPROFILE '.claude') -- Claude Code loads both copies, and the file copies (which own the bare names) go stale the moment the plugins update" `
+        ("remove the file copies (the plugins keep working): " + ($cmds -join '; '))
 }
 
 function Test-DoctorBom {
@@ -788,6 +892,47 @@ function Get-ClaudeCommand {
     return 'claude'
 }
 
+# Content plugins are the ccds-* plugins that ship agents and skills (ccds-core
+# + the archetype packs) -- every ccds plugin except the hooks-only enforcement
+# pair. When one is enabled, Claude Code already loads that roster from the
+# plugin, so file copies in ~/.claude/{agents,skills} are a SECOND load.
+# Twin of bin/ccds.sh content_plugins_enabled. Sets two script variables:
+#   $Script:ContentPluginsKnown  $false when the CLI is absent / unreadable
+#   $Script:ContentPlugins       enabled content-plugin names (may be empty)
+# Probed once per run.
+$Script:ContentPluginsProbed = $false
+$Script:ContentPluginsKnown  = $false
+$Script:ContentPlugins       = @()
+
+function Resolve-ContentPlugins {
+    if ($Script:ContentPluginsProbed) { return }
+    $Script:ContentPluginsProbed = $true
+    $claudeCmd = Get-ClaudeCommand
+    if (-not (Get-Command $claudeCmd -ErrorAction SilentlyContinue)) { return }
+    $plugins = $null
+    try {
+        # Join first: the real CLI pretty-prints one field per line, and a
+        # line-by-line pipe into ConvertFrom-Json parses each line alone.
+        $raw = @(& $claudeCmd plugin list --json 2>$null) -join "`n"
+        if ($raw.Trim()) { $plugins = @($raw | ConvertFrom-Json) } else { $plugins = @() }
+    } catch { return }
+    $names = @()
+    foreach ($pl in $plugins) {
+        if ($null -eq $pl -or -not $pl.enabled) { continue }
+        if ("$($pl.id)" -match '^(ccds-[a-z]+)@') {
+            $n = $Matches[1]
+            if ($n -ne 'ccds-guard' -and $n -ne 'ccds-loops') { $names += $n }
+        }
+    }
+    $Script:ContentPluginsKnown = $true
+    $Script:ContentPlugins = @($names | Sort-Object -Unique)
+}
+
+function Test-CorePluginEnabled {
+    Resolve-ContentPlugins
+    return ($Script:ContentPluginsKnown -and ($Script:ContentPlugins -contains 'ccds-core'))
+}
+
 function Test-DoctorClaudeCli {
     # WARN, not FAIL: an older CLI does not break ccds -- the guard's deny and
     # ask tiers work unchanged. It silently costs the unattended adjudicator.
@@ -830,8 +975,9 @@ function Test-DoctorPlugins {
     }
     $plugins = $null
     try {
-        $raw = & $claudeCmd plugin list --json 2>$null
-        $plugins = @($raw | ConvertFrom-Json)
+        # Join first: the real CLI pretty-prints one field per line (see #70).
+        $raw = @(& $claudeCmd plugin list --json 2>$null) -join "`n"
+        $plugins = if ($raw.Trim()) { @($raw | ConvertFrom-Json) } else { @() }
     } catch { }
     if ($null -eq $plugins) {
         Write-DoctorLine 'WARN' 'plugins-installed' `
@@ -876,6 +1022,7 @@ function Invoke-DoctorCommand {
         @{ Name = 'path-and-duals'  ; Fn = ${function:Test-DoctorPathDuals} }
         @{ Name = 'claude-cli'      ; Fn = ${function:Test-DoctorClaudeCli} }
         @{ Name = 'plugins-installed'; Fn = ${function:Test-DoctorPlugins} }
+        @{ Name = 'plugin-file-overlap'; Fn = ${function:Test-DoctorPluginFileOverlap} }
     )
 
     Write-Host "ccds doctor -- environment checks (version $(Get-InstalledVersion), $layoutKind layout)"

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -264,6 +264,48 @@ MIN_CLAUDE_VERSION="2.1.169"
 CLAUDE_CMD="${CCDS_CLAUDE_CMD:-claude}"
 ENFORCEMENT_PLUGINS=(ccds-guard ccds-loops)
 
+# Content plugins are the ccds-* plugins that ship agents and skills: ccds-core
+# and the archetype packs -- every ccds plugin except the hooks-only enforcement
+# pair above. When one is enabled, Claude Code already loads those agents and
+# skills from the plugin, so copies in ~/.claude/agents and ~/.claude/skills are
+# a SECOND load of the same roster. Echoes the enabled content-plugin names
+# (space-separated, possibly empty), or the literal "unknown" when the claude
+# CLI is absent or `claude plugin list --json` cannot be read. Cached per run.
+content_plugins_enabled() {
+    if [[ -z "${CONTENT_PLUGINS_CACHE+x}" ]]; then
+        local json
+        if ! command -v "$CLAUDE_CMD" >/dev/null 2>&1 \
+            || ! json="$("$CLAUDE_CMD" plugin list --json 2>/dev/null)"; then
+            CONTENT_PLUGINS_CACHE="unknown"
+        else
+            # The real CLI pretty-prints one field per line, so collapse newlines
+            # FIRST, then split into one object per line; keep the enabled ones,
+            # pull the "<name>@" id prefix, drop the hooks-only pair.
+            CONTENT_PLUGINS_CACHE="$(printf '%s' "$json" | tr -d '\n\r' | tr '{' '\n' \
+                | grep '"enabled"[[:space:]]*:[[:space:]]*true' \
+                | grep -o '"id"[[:space:]]*:[[:space:]]*"ccds-[a-z]*@' \
+                | sed -e 's/.*"\(ccds-[a-z]*\)@/\1/' \
+                | grep -v -x -e ccds-guard -e ccds-loops \
+                | sort -u | tr '\n' ' ' | sed -e 's/ $//' || true)"
+        fi
+    fi
+    printf '%s' "$CONTENT_PLUGINS_CACHE"
+}
+
+core_plugin_enabled() {  # true when ccds-core (the 5 core agents + cross-cutting skills) is enabled
+    case " $(content_plugins_enabled) " in *" ccds-core "*) return 0 ;; esac
+    return 1
+}
+
+# The authoritative GLOBAL_SKILLS list, read from the setup script at runtime --
+# never a second hardcoded copy that can drift. Prints one name per line;
+# prints nothing when the script is missing or the block cannot be parsed.
+global_skill_names() {
+    [[ -f "$SETUP_SCRIPT" ]] || return 0
+    sed -n '/^GLOBAL_SKILLS=(/,/^)/p' "$SETUP_SCRIPT" \
+        | sed -e '1d' -e '$d' -e 's/#.*$//' -e 's/[[:space:]]//g' | grep -v '^$' || true
+}
+
 # Numeric compare of dotted versions without sort -V (absent on some minimal
 # images). Echoes "older", "same" or "newer" for $1 relative to $2.
 version_cmp() {
@@ -332,7 +374,7 @@ doc_check_plugins() {
         # Match the plugin id from any marketplace: "<name>@<marketplace>".
         if ! printf '%s' "$json" | grep -q "\"id\"[[:space:]]*:[[:space:]]*\"${p}@"; then
             missing+=("$p")
-        elif printf '%s' "$json" \
+        elif printf '%s' "$json" | tr -d '\n\r' \
             | tr '{' '\n' | grep "\"${p}@" | grep -q '"enabled"[[:space:]]*:[[:space:]]*false'; then
             disabled+=("$p")
         fi
@@ -405,20 +447,26 @@ doc_check_version() {
 
 doc_check_agents() {
     local dir="$HOME/.claude/agents"
+    if core_plugin_enabled; then
+        doc_line OK agents-installed "supplied by the enabled ccds-core plugin (no file copies needed in $dir)"
+        return
+    fi
     if [[ -f "$dir/plan-architect.md" ]]; then
         local n
         n="$(find "$dir" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
         doc_line OK agents-installed "core sentinel plan-architect.md present ($n agent file(s) in $dir)"
     else
         doc_line FAIL agents-installed \
-            "plan-architect.md missing from $dir -- the always-on agents are not installed" \
-            "run 'ccds setup'"
+            "plan-architect.md missing from $dir and the ccds-core plugin is not enabled -- the always-on agents are not installed" \
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     fi
 }
 
 doc_check_skills() {
-    # Read the authoritative GLOBAL_SKILLS list from the setup script at
-    # runtime -- never a second hardcoded copy that can drift.
+    if core_plugin_enabled; then
+        doc_line OK skills-installed "supplied by the enabled ccds-core plugin (no file copies needed in $HOME/.claude/skills)"
+        return
+    fi
     if [[ ! -f "$SETUP_SCRIPT" ]]; then
         doc_line WARN skills-installed \
             "cannot determine expected skill list ($SETUP_SCRIPT not found)" \
@@ -426,8 +474,7 @@ doc_check_skills() {
         return
     fi
     local -a expected=()
-    mapfile -t expected < <(sed -n '/^GLOBAL_SKILLS=(/,/^)/p' "$SETUP_SCRIPT" \
-        | sed -e '1d' -e '$d' -e 's/#.*$//' -e 's/[[:space:]]//g' | grep -v '^$' || true)
+    mapfile -t expected < <(global_skill_names)
     if (( ${#expected[@]} == 0 )); then
         doc_line WARN skills-installed \
             "could not extract GLOBAL_SKILLS from $SETUP_SCRIPT" \
@@ -444,8 +491,64 @@ doc_check_skills() {
     else
         doc_line FAIL skills-installed \
             "${#missing[@]}/${#expected[@]} cross-cutting skills missing from $HOME/.claude/skills: ${missing[*]}" \
-            "run 'ccds setup'"
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     fi
+}
+
+doc_check_plugin_file_overlap() {
+    # The always-on agents and cross-cutting skills reach Claude Code by ONE of
+    # two routes: the ccds content plugins, or file copies written by setup.
+    # Both at once means every agent is in the roster twice (the router sees
+    # two identical descriptions and the stale file copy owns the bare name)
+    # and the descriptions cost context twice. Each route alone is fine.
+    local plugins
+    plugins="$(content_plugins_enabled)"
+    if [[ "$plugins" == "unknown" ]]; then
+        doc_line WARN plugin-file-overlap \
+            "cannot check: claude CLI not on PATH or 'claude plugin list --json' unreadable" \
+            "install Claude Code / run 'claude plugin list', then re-run 'ccds doctor'"
+        return
+    fi
+    # ccds-owned agent names come from catalog.json (authoritative, shipped in
+    # every layout); the package's agents/ dir is the fallback for an old tree.
+    local name
+    local -a owned=() agent_files=() skill_dirs=()
+    if [[ -f "$INSTALL_ROOT/catalog.json" ]]; then
+        mapfile -t owned < <(tr -d '\n\r' < "$INSTALL_ROOT/catalog.json" | tr '{' '\n' \
+            | grep '"kind"[[:space:]]*:[[:space:]]*"agent"' \
+            | grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | sed -e 's/.*"\([^"]*\)"$/\1.md/' || true)
+    fi
+    if (( ${#owned[@]} == 0 )); then
+        local agents_src="$INSTALL_ROOT/agents" f
+        [[ -d "$agents_src" ]] || agents_src="$INSTALL_ROOT/.claude/agents"
+        for f in "$agents_src"/*.md; do [[ -f "$f" ]] && owned+=("$(basename "$f")"); done
+    fi
+    for name in "${owned[@]}"; do
+        [[ -f "$HOME/.claude/agents/$name" ]] && agent_files+=("$name")
+    done
+    while IFS= read -r name; do
+        [[ -n "$name" && -f "$HOME/.claude/skills/$name/SKILL.md" ]] && skill_dirs+=("$name")
+    done < <(global_skill_names)
+    if [[ -z "$plugins" ]]; then
+        doc_line OK plugin-file-overlap "no ccds content plugin enabled; agents and skills come from the file copies only"
+        return
+    fi
+    if (( ${#agent_files[@]} == 0 && ${#skill_dirs[@]} == 0 )); then
+        doc_line OK plugin-file-overlap "plugins ($plugins) supply the agents and skills; no file copies present"
+        return
+    fi
+    local -a cmds=()
+    if (( ${#agent_files[@]} > 0 )); then
+        cmds+=("rm -f $(printf "$HOME/.claude/agents/%s " "${agent_files[@]}" | sed -e 's/ $//')")
+    fi
+    if (( ${#skill_dirs[@]} > 0 )); then
+        cmds+=("rm -rf $(printf "$HOME/.claude/skills/%s " "${skill_dirs[@]}" | sed -e 's/ $//')")
+    fi
+    local remedy="remove the file copies (the plugins keep working): $(IFS='&'; printf '%s' "${cmds[*]}" | sed -e 's/&/ \&\& /g')"
+    doc_line FAIL plugin-file-overlap \
+        "loaded twice: plugin(s) $plugins are enabled AND ${#agent_files[@]} agent file(s) + ${#skill_dirs[@]} cross-cutting skill(s) from a file install (version $(installed_version)) sit in $HOME/.claude -- Claude Code loads both copies, and the file copies (which own the bare names) go stale the moment the plugins update" \
+        "$remedy"
 }
 
 doc_check_bom() {
@@ -550,6 +653,7 @@ cmd_doctor() {
         "path-and-duals:doc_check_path_duals"
         "claude-cli:doc_check_claude_cli"
         "plugins-installed:doc_check_plugins"
+        "plugin-file-overlap:doc_check_plugin_file_overlap"
     )
 
     echo "ccds doctor -- environment checks (version $(installed_version), $LAYOUT_KIND layout)"

--- a/scripts/ccds-user-setup.sh
+++ b/scripts/ccds-user-setup.sh
@@ -2,6 +2,8 @@
 # ccds-user-setup.sh
 # ------------------
 # Performs per-user Claude Code Dev Studio setup (ADR-0007):
+#   0. Detects enabled ccds content plugins; if any, steps 1-1b are skipped
+#      (the plugins already supply that roster -- ADR-0020)
 #   1. Copies all 19 always-on agents to ~/.claude/agents/
 #   2. Copies the cross-cutting (global) skills to ~/.claude/skills/
 #   3. Injects / updates the ccds pointer block in ~/.claude/CLAUDE.md
@@ -276,13 +278,76 @@ install_plugins() {
 }
 
 # ---------------------------------------------------------------------------
+# Step 0 — Which route supplies the always-on roster?  (ADR-0020)
+#
+# The 19 agents and the cross-cutting skills reach Claude Code by ONE of two
+# routes: the ccds content plugins (ccds-core + the archetype packs, installed
+# from the marketplace) or the file copies steps 1/1b write. Both at once puts
+# every agent in the roster twice -- the router sees two identical
+# descriptions, the stale file copy owns the bare name, and the descriptions
+# cost context twice. So when a content plugin is enabled, the copies are
+# skipped. Detection is a read-only `claude plugin list --json`; it is not run
+# under --skip-plugins (never touch the CLI) or --dry-run (no calls at all).
+# `ccds doctor` reports the overlap either way.
+# ---------------------------------------------------------------------------
+CONTENT_PLUGINS=""
+
+detect_content_plugins() {
+    (( SKIP_PLUGINS || DRY_RUN )) && return 0
+    command -v "$CLAUDE_CMD" >/dev/null 2>&1 || return 0
+    local json
+    json="$("$CLAUDE_CMD" plugin list --json </dev/null 2>/dev/null)" || return 0
+    # The CLI pretty-prints one field per line: collapse newlines FIRST, then
+    # split into one object per line, keep enabled ones, take the "<name>@" id
+    # prefix, and drop the hooks-only enforcement pair.
+    CONTENT_PLUGINS="$(printf '%s' "$json" | tr -d '\n\r' | tr '{' '\n' \
+        | grep '"enabled"[[:space:]]*:[[:space:]]*true' \
+        | grep -o '"id"[[:space:]]*:[[:space:]]*"ccds-[a-z]*@' \
+        | sed -e 's/.*"\(ccds-[a-z]*\)@/\1/' \
+        | grep -v -x -e ccds-guard -e ccds-loops \
+        | sort -u | tr '\n' ' ' | sed -e 's/ $//' || true)"
+}
+
+# Stale file copies next to enabled plugins: say so, with the exact removal
+# command, but never delete a user's files from setup.
+warn_stale_file_copies() {
+    local -a agent_files=() skill_dirs=()
+    local src name
+    for src in "$INSTALL_ROOT"/agents/*.md; do
+        [[ -f "$src" ]] || continue
+        name="$(basename "$src")"
+        [[ -f "$HOME/.claude/agents/$name" ]] && agent_files+=("$name")
+    done
+    for name in "${GLOBAL_SKILLS[@]}"; do
+        [[ -f "$HOME/.claude/skills/$name/SKILL.md" ]] && skill_dirs+=("$name")
+    done
+    (( ${#agent_files[@]} == 0 && ${#skill_dirs[@]} == 0 )) && return 0
+    log_warn "File copies from an earlier setup are still present and are loaded in ADDITION to the plugins:"
+    log_warn "  ${#agent_files[@]} agent file(s) in $HOME/.claude/agents, ${#skill_dirs[@]} cross-cutting skill(s) in $HOME/.claude/skills"
+    log_warn "Remove them (the plugins keep working):"
+    if (( ${#agent_files[@]} > 0 )); then
+        log_warn "  rm -f $(printf "$HOME/.claude/agents/%s " "${agent_files[@]}")"
+    fi
+    if (( ${#skill_dirs[@]} > 0 )); then
+        log_warn "  rm -rf $(printf "$HOME/.claude/skills/%s " "${skill_dirs[@]}")"
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
-log_step "Installing always-on agents to $HOME/.claude/agents"
-install_agents
+detect_content_plugins
+if [[ -n "$CONTENT_PLUGINS" ]]; then
+    log_step "Always-on agents and cross-cutting skills"
+    log_ok "Supplied by enabled plugin(s): $CONTENT_PLUGINS -- skipping the file copies so Claude Code does not load the roster twice"
+    warn_stale_file_copies
+else
+    log_step "Installing always-on agents to $HOME/.claude/agents"
+    install_agents
 
-log_step "Installing cross-cutting skills to $HOME/.claude/skills"
-install_global_skills
+    log_step "Installing cross-cutting skills to $HOME/.claude/skills"
+    install_global_skills
+fi
 
 log_step "Updating ccds block in $HOME/.claude/CLAUDE.md"
 set_claude_playbook_block
@@ -294,8 +359,13 @@ if (( DRY_RUN )); then
     printf '\n%sDRY RUN -- no changes made.%s\n' "$C_YELLOW" "$C_RESET"
 else
     printf '\n%sUser setup complete.%s\n' "$C_GREEN" "$C_RESET"
-    printf 'Agents      : %s/.claude/agents/ (19 always-on)\n' "$HOME"
-    printf 'Skills      : %s/.claude/skills/ (%d cross-cutting)\n' "$HOME" "${#GLOBAL_SKILLS[@]}"
+    if [[ -n "$CONTENT_PLUGINS" ]]; then
+        printf 'Agents      : from plugins (%s)\n' "$CONTENT_PLUGINS"
+        printf 'Skills      : from plugins (%s)\n' "$CONTENT_PLUGINS"
+    else
+        printf 'Agents      : %s/.claude/agents/ (19 always-on)\n' "$HOME"
+        printf 'Skills      : %s/.claude/skills/ (%d cross-cutting)\n' "$HOME" "${#GLOBAL_SKILLS[@]}"
+    fi
     printf 'ccds block  : %s/.claude/CLAUDE.md\n' "$HOME"
     printf 'Plugins     : %s\n' "$PLUGINS_STATUS"
 fi

--- a/scripts/jit-claude.md
+++ b/scripts/jit-claude.md
@@ -7,12 +7,13 @@
 ## Claude Code Dev Studio
 
 Installed at `~/.claude/playbook/`. **19 agents** (14 domain agents + 5 core
-generalists) live in `~/.claude/agents/` and are always loaded. Each domain agent
+generalists) are always loaded — supplied either by the ccds plugins (`ccds-core`
++ the archetype packs) or by copies in `~/.claude/agents/`, never both. Each domain agent
 composes its `<pack>-*` **skills** — the just-in-time layer (`~/.claude/playbook/skills/`,
 indexed in `catalog.json`). Cross-cutting skills (`playbook-conventions`, `api-design`,
 `ux-design`, `security-checklist`, `code-review-checklist`, `inventive-engineer`,
-`common-*`, and the `loop-*` agent-loop process skills) are installed in
-`~/.claude/skills/` and always available.
+`common-*`, and the `loop-*` agent-loop process skills) come from the same
+route (plugins, or copies in `~/.claude/skills/`) and are always available.
 
 To activate a project's domain skills (on `/init`, a new task, "sync agents", or when a
 domain agent needs a `<pack>-*` skill not yet in `.claude/skills/`), use the

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -1497,11 +1497,14 @@ class TestCcdsDoctor(unittest.TestCase):
             plugins = [{"id": "ccds-guard@ccds", "enabled": True},
                        {"id": "ccds-loops@ccds", "enabled": True}]
         path = os.path.join(self.root, "claude-stub")
+        # indent=2: the real CLI pretty-prints one field per line. A flat
+        # single-line stub hid #70 (the disabled-plugin branch could never
+        # match on real output), so the stub must keep the real shape.
         write(path, "#!/usr/bin/env bash\ncase \"$1\" in\n"
                     "  --version) printf '%%s\\n' %s ;;\n"
                     "  plugin)    printf '%%s\\n' %s ;;\n"
                     "esac\n" % (shlex.quote(version),
-                                shlex.quote(json.dumps(plugins))))
+                                shlex.quote(json.dumps(plugins, indent=2))))
         os.chmod(path, 0o755)
         return path
 
@@ -1581,6 +1584,51 @@ class TestCcdsDoctor(unittest.TestCase):
         self.assertIn("WARN  claude-cli", r.stdout)
         self.assertIn("WARN  plugins-installed", r.stdout)
         self.assertIn("RESULT: PASS", r.stdout)
+
+    CONTENT_PLUGINS = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True},
+                       {"id": "ccds-core@ccds", "enabled": True},
+                       {"id": "ccds-saas@ccds", "enabled": True}]
+
+    def test_plugin_and_file_copies_overlap_fails(self):
+        """ADR-0020: the roster reaches Claude Code by plugins OR file copies.
+        Both at once = every agent loaded twice; doctor must name the copies
+        and hand over the removal command rather than say PASS (which is what
+        it did on the maintainer's own machine for weeks)."""
+        r = self.doctor(claude=self.stub_claude(plugins=self.CONTENT_PLUGINS))
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  plugin-file-overlap: loaded twice: plugin(s) ccds-core ccds-saas",
+                      r.stdout)
+        self.assertIn("1 agent file(s) + %d cross-cutting skill(s)"
+                      % len(self._global_skills()), r.stdout)
+        self.assertIn("rm -f " + os.path.join(self.home, ".claude", "agents",
+                                              "plan-architect.md"), r.stdout)
+        self.assertIn("rm -rf " + os.path.join(self.home, ".claude", "skills",
+                                               self._global_skills()[0]), r.stdout)
+        # the enforcement pair must never be reported as a content plugin
+        self.assertNotIn("ccds-guard ccds", r.stdout.split("plugin-file-overlap")[1])
+
+    def test_plugin_only_install_passes(self):
+        """No file copies + content plugins enabled is the recommended shape:
+        agents/skills checks report the plugin as the source and pass."""
+        shutil.rmtree(os.path.join(self.home, ".claude", "agents"))
+        shutil.rmtree(os.path.join(self.home, ".claude", "skills"))
+        r = self.doctor(claude=self.stub_claude(plugins=self.CONTENT_PLUGINS))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("OK  agents-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  skills-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  plugin-file-overlap: plugins (ccds-core ccds-saas) supply", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
+
+    def test_file_only_install_is_not_an_overlap(self):
+        r = self.doctor()
+        self.assertIn("OK  plugin-file-overlap: no ccds content plugin enabled", r.stdout)
+
+    def test_missing_core_agent_without_core_plugin_names_both_remedies(self):
+        os.remove(os.path.join(self.home, ".claude", "agents", "plan-architect.md"))
+        r = self.doctor()
+        self.assertIn("FAIL  agents-installed", r.stdout)
+        self.assertIn("claude plugin install ccds-core@ccds", r.stdout)
 
     def test_missing_core_agent_fails(self):
         os.remove(os.path.join(self.home, ".claude", "agents", "plan-architect.md"))
@@ -1738,6 +1786,7 @@ class TestDebPostinst(unittest.TestCase):
         r = self._run({"SUDO_USER": getpass.getuser()})
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertEqual(self.claude_calls(), [
+            "plugin list --json",   # ADR-0020 route probe, read-only
             "plugin marketplace add test-owner/test-repo",
             "plugin install ccds-guard@ccds --scope user",
             "plugin install ccds-loops@ccds --scope user",
@@ -1877,6 +1926,7 @@ class TestInstallPlaybook(unittest.TestCase):
         self.assertIn("# existing content", self.bashrc(),
                       "must not clobber the user's rc file")
         self.assertEqual(self.claude_calls(), [
+            "plugin list --json",   # ADR-0020 route probe, read-only
             "plugin marketplace add test-owner/test-repo",
             "plugin install ccds-guard@ccds --scope user",
             "plugin install ccds-loops@ccds --scope user",
@@ -2096,6 +2146,26 @@ class TestInstallPlaybookPs1(unittest.TestCase):
                         "completion block did not go to CCDS_PS_PROFILE")
         self.assertIn("# >>> ccds-completion >>>", read(self.profile))
         self.assertNotIn("ggrace519", " ".join(self.claude_calls()))
+
+    def test_enabled_content_plugin_skips_the_file_copies(self):
+        """ADR-0020: with ccds-core enabled the plugin already supplies the
+        roster, so the installer must not write a second copy into ~/.claude.
+        The stub prints pretty-printed JSON, the real CLI's shape."""
+        plugins_json = os.path.join(self.root, "plugins.json")
+        write(plugins_json, json.dumps(
+            [{"id": "ccds-guard@ccds", "enabled": True},
+             {"id": "ccds-core@ccds", "enabled": True}], indent=2))
+        write(self.claude,
+              "@echo off\r\necho %%* >> \"%s\"\r\n"
+              "if \"%%1\"==\"plugin\" if \"%%2\"==\"list\" type \"%s\"\r\n"
+              "exit /b 0\r\n" % (self.log, plugins_json))
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("Supplied by enabled plugin(s): ccds-core", r.stdout)
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "agents")))
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "skills")))
+        self.assertTrue(os.path.isfile(os.path.join(self.home, ".claude", "CLAUDE.md")))
+        self.assertIn("install ccds-guard@ccds", " ".join(self.claude_calls()))
 
     def test_skip_plugins_makes_no_claude_calls(self):
         r = self.install("-SkipPlugins")
@@ -2489,6 +2559,98 @@ class TestReleaseStagingSh(unittest.TestCase):
         self.assertIn("package not found after fpm run", r.stdout + r.stderr)
 
 
+@unittest.skipUnless(PWSH, "bin/ccds.ps1 doctor is the Windows twin; "
+                           "runs under Windows PowerShell only")
+class TestCcdsDoctorPs1(unittest.TestCase):
+    """`ccds.ps1 doctor` — the first behavioral coverage of the PowerShell
+    doctor. Mirrors TestCcdsDoctor: an installed-layout root, a synthetic
+    healthy USERPROFILE, and a recording `claude.cmd` whose `plugin list
+    --json` pretty-prints like the real CLI (the shape that hid #70)."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="ccds-doctor-ps-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.inst = os.path.join(self.root, "playbook")
+        os.makedirs(os.path.join(self.inst, "bin"))
+        os.makedirs(os.path.join(self.inst, "scripts"))
+        shutil.copy(os.path.join(REPO_ROOT, "bin", "ccds.ps1"),
+                    os.path.join(self.inst, "bin", "ccds.ps1"))
+        shutil.copy(os.path.join(REPO_ROOT, "Sync-AgentPacks.ps1"),
+                    os.path.join(self.inst, "scripts", "Sync-AgentPacks.ps1"))
+        shutil.copy(os.path.join(REPO_ROOT, "Verify-Agents.ps1"),
+                    os.path.join(self.inst, "scripts", "Verify-Agents.ps1"))
+        shutil.copy(os.path.join(SCRIPTS, "ccds-user-setup.sh"),
+                    os.path.join(self.inst, "scripts", "ccds-user-setup.sh"))
+        shutil.copy(os.path.join(REPO_ROOT, "catalog.json"),
+                    os.path.join(self.inst, "catalog.json"))
+        write(os.path.join(self.inst, "version.txt"), "0.0.1\n")
+        self.home = os.path.join(self.root, "home")
+        write(os.path.join(self.home, ".claude", "agents", "plan-architect.md"),
+              "---\nname: plan-architect\ndescription: test\n---\nbody\n")
+        for name in GLOBAL_SKILLS:
+            write(os.path.join(self.home, ".claude", "skills", name, "SKILL.md"),
+                  "---\nname: %s\ndescription: test\n---\nbody\n" % name)
+        write(os.path.join(self.home, ".claude", "CLAUDE.md"),
+              "# my own notes\n\n# >>> ccds >>>\nblock body\n# <<< ccds <<<\n")
+
+    def stub_claude(self, plugins=None):
+        if plugins is None:
+            plugins = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True}]
+        plugins_json = os.path.join(self.root, "plugins.json")
+        write(plugins_json, json.dumps(plugins, indent=2))
+        path = os.path.join(self.root, "claude.cmd")
+        write(path, "@echo off\r\n"
+                    "if \"%%1\"==\"--version\" echo 2.1.224 (Claude Code)\r\n"
+                    "if \"%%1\"==\"plugin\" type \"%s\"\r\n"
+                    "exit /b 0\r\n" % plugins_json)
+        return path
+
+    def doctor(self, plugins=None):
+        return subprocess.run(
+            [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", os.path.join(self.inst, "bin", "ccds.ps1"), "doctor"],
+            capture_output=True, text=True,
+            env={**os.environ, "USERPROFILE": self.home,
+                 "CCDS_DOCTOR_RELEASE_URL": "http://127.0.0.1:9/releases/latest",
+                 "CCDS_CLAUDE_CMD": self.stub_claude(plugins)})
+
+    CONTENT_PLUGINS = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True},
+                       {"id": "ccds-core@ccds", "enabled": True},
+                       {"id": "ccds-saas@ccds", "enabled": True}]
+
+    def test_healthy_file_install_passes(self):
+        r = self.doctor()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("FAIL  : 0", r.stdout)
+        self.assertIn("OK  plugin-file-overlap: no ccds content plugin enabled", r.stdout)
+
+    def test_disabled_plugin_in_pretty_printed_json_fails(self):
+        """#70 twin: the disabled branch must match on the real multi-line shape."""
+        r = self.doctor(plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                                 {"id": "ccds-loops@ccds", "enabled": True}])
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  plugins-installed: installed but DISABLED: ccds-guard", r.stdout)
+
+    def test_plugin_and_file_copies_overlap_fails(self):
+        r = self.doctor(plugins=self.CONTENT_PLUGINS)
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  plugin-file-overlap: loaded twice: plugin(s) ccds-core ccds-saas", r.stdout)
+        self.assertIn("Remove-Item -Force '%s'" % os.path.join(
+            self.home, ".claude", "agents", "plan-architect.md"), r.stdout)
+        self.assertIn("Remove-Item -Recurse -Force", r.stdout)
+
+    def test_plugin_only_install_passes(self):
+        shutil.rmtree(os.path.join(self.home, ".claude", "agents"))
+        shutil.rmtree(os.path.join(self.home, ".claude", "skills"))
+        r = self.doctor(plugins=self.CONTENT_PLUGINS)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("OK  agents-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  skills-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  plugin-file-overlap: plugins (ccds-core ccds-saas) supply", r.stdout)
+
+
 @unittest.skipUnless(PWSH, "build-release.ps1 is a PowerShell script "
                            "(Windows-targeted, like the ZIP it builds)")
 class TestReleaseZipPs1(unittest.TestCase):
@@ -2669,11 +2831,55 @@ class TestUserSetupPlugins(unittest.TestCase):
         r = self.setup()
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertEqual(self.calls(), [
+            "plugin list --json",   # ADR-0020 route detection, read-only
             "plugin marketplace add test-owner/test-repo",
             "plugin install ccds-guard@ccds --scope user",
             "plugin install ccds-loops@ccds --scope user",
         ])
         self.assertIn("Plugins     : installed", r.stdout)
+        # the stub prints no plugins -> file route -> copies happen
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.home, ".claude", "agents", "plan-architect.md")))
+        self.assertIn("Agents      : %s/.claude/agents/" % self.home, r.stdout)
+
+    def _plugin_stub(self, ids):
+        """A claude whose `plugin list --json` pretty-prints these enabled ids
+        (the real CLI's shape) and accepts every other command."""
+        body = json.dumps([{"id": i, "enabled": True} for i in ids], indent=2)
+        return self.stub_claude(
+            'case "$*" in "plugin list --json") cat <<\'JSON\'\n%s\nJSON\n;; esac\nexit 0'
+            % body)
+
+    def test_enabled_content_plugin_skips_the_file_copies(self):
+        """ADR-0020: with ccds-core enabled the plugin already supplies the
+        roster, so setup must not write a second copy into ~/.claude."""
+        r = self.setup(claude=self._plugin_stub(
+            ["ccds-guard@ccds", "ccds-loops@ccds", "ccds-core@ccds"]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("Supplied by enabled plugin(s): ccds-core", r.stdout)
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "agents")))
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "skills")))
+        self.assertIn("Agents      : from plugins (ccds-core)", r.stdout)
+        # the enforcement plugins are still installed on this route
+        self.assertIn("plugin install ccds-guard@ccds --scope user", self.calls())
+        # the ccds block still lands
+        self.assertTrue(os.path.isfile(os.path.join(self.home, ".claude", "CLAUDE.md")))
+
+    def test_enforcement_plugins_alone_do_not_skip_the_copies(self):
+        r = self.setup(claude=self._plugin_stub(["ccds-guard@ccds", "ccds-loops@ccds"]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.home, ".claude", "agents", "plan-architect.md")))
+        self.assertNotIn("Supplied by enabled plugin", r.stdout)
+
+    def test_stale_file_copies_next_to_plugins_are_named_not_deleted(self):
+        stale = os.path.join(self.home, ".claude", "agents", "plan-architect.md")
+        write(stale, "old copy\n")
+        r = self.setup(claude=self._plugin_stub(["ccds-core@ccds"]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("loaded in ADDITION to the plugins", r.stderr)
+        self.assertIn("rm -f " + stale, r.stderr)
+        self.assertTrue(os.path.isfile(stale), "setup must never delete user files")
 
     def test_skip_plugins_suppresses_every_call(self):
         r = self.setup("--skip-plugins")


### PR DESCRIPTION
## Summary

The 19 always-on agents and the cross-cutting skills reach Claude Code by two routes: the ccds content plugins (`ccds-core` + packs) or the file copies setup writes into `~/.claude/agents` and `~/.claude/skills`. Nothing stopped a machine from having both, and `ccds doctor` checked each route in isolation. Result on the maintainer's machine: a v0.11.0 file install under current plugins, every agent in the roster twice (`plan-architect` and `ccds-core:plan-architect`), the stale copy owning the bare name, and doctor reporting PASS.

ADR-0020: the roster has one source, plugins or file copies, never both.

## What changed

- **`ccds doctor`** (bash + PowerShell, same 12-check contract): new `plugin-file-overlap` check that FAILs when a content plugin is enabled and ccds-owned copies (names from `catalog.json`) are present, printing the exact removal command; WARNs when the CLI can't be read. `agents-installed` / `skills-installed` report the plugin as the source when `ccds-core` is enabled, so a plugin-only install passes; their FAIL remedies name both fixes.
- **Setup gate** in `scripts/ccds-user-setup.sh`, `bin/ccds.ps1 setup`, and `Install-Playbook.ps1`: a read-only `claude plugin list --json` probe (skipped under `--skip-plugins` = never touch the CLI, and `--dry-run` = no calls). With a content plugin enabled the file copies are skipped with a one-line explanation, and stale copies are named with the removal command. Setup never deletes user files.
- **Fixes #70** (found on the way): the bash doctor's disabled-plugin branch could never match real CLI output, which pretty-prints one field per line, so a disabled `ccds-guard` read as enabled. Newlines are collapsed before splitting; the PowerShell twin joins lines before `ConvertFrom-Json`; the test stubs now pretty-print so the suite exercises the real shape.
- Docs: ADR-0020, changelog (Added + Fixed), README (routes are alternatives, not layers), CLAUDE.md table row, and the `~/.claude/CLAUDE.md` ccds block no longer claims the agents live in `~/.claude/agents`.

## Verification

- `python3 -m unittest discover -s tests`: 298 run, 19 skipped, 0 failures (Linux). Lint PASS. Marketplace tree: no drift.
- Real system: the repo's `bin/ccds.sh doctor` on the maintainer's machine now reports `FAIL plugins-installed: installed but DISABLED: ccds-guard` and `FAIL plugin-file-overlap: ... 19 agent file(s) + 18 cross-cutting skill(s)` with the removal command, where it previously said PASS.
- New tests: 4 bash doctor cases (overlap FAIL with remedy, plugin-only PASS, file-only OK, both remedies named), 3 setup cases (gate skips copies, enforcement plugins alone don't, stale copies named not deleted), the two exact call-list expectations updated for the probe, and **5 Windows-only tests** — one installer gate test and a new `TestCcdsDoctorPs1` class, the first behavioral coverage of the PowerShell doctor.
- **PowerShell not run locally** (this box no longer has PowerShell); the Windows CI job is the verification for that half.

## Post-merge

- Squash-merge into `develop`, delete branch. Changelog entry rolls into the next version at promotion.
- Local cleanup for the maintainer's machine: run `ccds doctor` from the updated tree and paste its `plugin-file-overlap` remedy; then `claude plugin enable ccds-guard` if the guard should be on.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRcT9LqHK3ftpoVNtjKjz7
