### PR TITLE
fix(agents): use the eight named colors Claude Code accepts, and stop asking the user from inside a subagent

### DIFF
--- a/.claude/agents/ai-architect.md
+++ b/.claude/agents/ai-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ai-architect
 model: opus
-color: "#6366f1"
+color: blue
 description: AI / LLM application domain specialist. Use proactively on AI / LLM work — model selection, serving topology, RAG-vs-finetune-vs-prompt, eval strategy, cost/latency budgets, and data policy. Owns AI architecture and composes the ai-* implementation skills.
 ---
 

--- a/.claude/agents/dataplat-architect.md
+++ b/.claude/agents/dataplat-architect.md
@@ -1,7 +1,7 @@
 ---
 name: dataplat-architect
 model: opus
-color: "#0f766e"
+color: cyan
 description: Data Platform domain specialist. Use proactively on data-platform work — warehouse/lakehouse topology, batch vs streaming, partitioning and storage format, governance, ingestion, quality, and serving. Owns data-platform architecture and composes the dataplat-* implementation skills.
 ---
 

--- a/.claude/agents/deploy-checklist.md
+++ b/.claude/agents/deploy-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: deploy-checklist
 model: haiku
-color: "#ff5a1f"
+color: orange
 disallowedTools: Write, Edit, NotebookEdit
 description: Deployment readiness and pre-production checklist specialist. Use proactively before any production deployment, environment promotion, release cut, or go/no-go assessment.
 ---

--- a/.claude/agents/desktop-architect.md
+++ b/.claude/agents/desktop-architect.md
@@ -1,7 +1,7 @@
 ---
 name: desktop-architect
 model: opus
-color: "#92400e"
+color: orange
 description: Desktop App domain specialist. Use proactively on desktop work — runtime choice, process/window model, IPC topology, OS integration, autoupdate, code signing, installers, and shell integration. Owns desktop architecture and composes the desktop-* implementation skills.
 ---
 

--- a/.claude/agents/devtool-architect.md
+++ b/.claude/agents/devtool-architect.md
@@ -1,7 +1,7 @@
 ---
 name: devtool-architect
 model: opus
-color: "#475569"
+color: blue
 description: DevTool / CLI / Library domain specialist. Use proactively on public-surface work — API and CLI surface design, versioning, distribution, extensibility, compatibility, docs, packaging, and telemetry. Owns devtool architecture and composes the devtool-* implementation skills.
 ---
 

--- a/.claude/agents/ecom-architect.md
+++ b/.claude/agents/ecom-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ecom-architect
 model: opus
-color: "#db2777"
+color: pink
 description: E-commerce domain specialist. Use proactively on storefront/checkout/OMS work — catalog vs cart vs order boundary, payment strategy, inventory reservation, tax/shipping, promotions, search, and peak-event scale. Owns e-commerce architecture and composes the ecom-* implementation skills.
 ---
 

--- a/.claude/agents/embed-architect.md
+++ b/.claude/agents/embed-architect.md
@@ -1,7 +1,7 @@
 ---
 name: embed-architect
 model: opus
-color: "#78350f"
+color: orange
 description: Embedded / IoT domain specialist. Use proactively on embedded / firmware / IoT work — SoC/MCU choice, RTOS vs bare-metal, memory/flash layout, secure boot chain, A/B partitioning, fleet OTA topology, and provisioning/attestation. Owns embedded architecture and composes the embed-* implementation skills.
 ---
 

--- a/.claude/agents/ext-architect.md
+++ b/.claude/agents/ext-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ext-architect
 model: opus
-color: "#4338ca"
+color: blue
 description: Browser extension domain specialist. Use proactively on browser-extension work — manifest version (MV3), permissions model, background/service-worker/content-script split, cross-browser strategy, store-review posture, and native-host bridges. Owns browser-extension architecture and composes the ext-* implementation skills.
 ---
 

--- a/.claude/agents/fintech-architect.md
+++ b/.claude/agents/fintech-architect.md
@@ -1,7 +1,7 @@
 ---
 name: fintech-architect
 model: opus
-color: "#365314"
+color: green
 description: Fintech domain specialist. Use proactively on regulated-money work — ledger topology, custody, KYC/AML and licensing, money-movement primitives, reconciliation, audit retention, and risk. Owns fintech architecture and composes the fintech-* implementation skills.
 ---
 

--- a/.claude/agents/game-architect.md
+++ b/.claude/agents/game-architect.md
@@ -1,7 +1,7 @@
 ---
 name: game-architect
 model: opus
-color: "#ea580c"
+color: orange
 description: Game domain specialist. Use proactively on game work — engine selection, core game loop, state architecture, asset pipeline, save/load topology, and platform-target strategy. Owns game architecture and composes the game-* implementation skills.
 ---
 

--- a/.claude/agents/infra-architect.md
+++ b/.claude/agents/infra-architect.md
@@ -1,7 +1,7 @@
 ---
 name: infra-architect
 model: opus
-color: "#334155"
+color: blue
 description: Infrastructure / dev-platform domain specialist. Use proactively on infra / platform work — cloud topology, network segmentation, environments, IaC strategy, secrets topology, and platform tenancy. Owns infrastructure architecture and composes the infra-* implementation skills.
 ---
 

--- a/.claude/agents/media-architect.md
+++ b/.claude/agents/media-architect.md
@@ -1,7 +1,7 @@
 ---
 name: media-architect
 model: opus
-color: "#0369a1"
+color: cyan
 description: Media / streaming domain specialist. Use proactively on media / streaming work — ingest → process → store → deliver pipeline, codec/container strategy, VOD vs live topology, DRM posture, CDN strategy, and QoE. Owns media architecture and composes the media-* implementation skills.
 ---
 

--- a/.claude/agents/mobile-architect.md
+++ b/.claude/agents/mobile-architect.md
@@ -1,7 +1,7 @@
 ---
 name: mobile-architect
 model: opus
-color: "#2563eb"
+color: blue
 description: Mobile domain specialist. Use proactively on iOS / Android work — framework choice, offline posture, background-execution strategy, release topology, and privacy posture. Owns mobile architecture and composes the mobile-* implementation skills.
 ---
 

--- a/.claude/agents/orch-architect.md
+++ b/.claude/agents/orch-architect.md
@@ -1,7 +1,7 @@
 ---
 name: orch-architect
 model: opus
-color: "#be123c"
+color: red
 description: Agent / orchestration domain specialist. Use proactively on agent / orchestration work — agent topology, tool-use contract, memory model, planning/looping control, sandbox boundaries, and eval strategy. Owns orchestration architecture and composes the orch-* implementation skills.
 ---
 

--- a/.claude/agents/plan-architect.md
+++ b/.claude/agents/plan-architect.md
@@ -1,7 +1,7 @@
 ---
 name: plan-architect
 model: opus
-color: "#1a56db"
+color: blue
 description: Universal system design and architecture planning specialist. Use proactively when defining component boundaries, data flows, integration patterns, or making major structural decisions before or during implementation.
 ---
 
@@ -35,7 +35,7 @@ You do NOT own:
 
 ## Approach
 
-1. **Understand constraints first** — ask about scale requirements, team size, deployment target, and non-functional requirements before proposing a design
+1. **Pin the constraints first** — scale requirements, team size, deployment target, and non-functional requirements. Use what the task and the repo give you; where they are silent, state the assumption you are designing under and proceed. List only the open questions whose answers would change the design, for the orchestrator to take back to the user — you cannot ask them yourself
 2. **Prefer simplicity** — recommend the least complex architecture that satisfies requirements; avoid over-engineering
 3. **Make trade-offs explicit** — present 2–3 options with clear pros/cons rather than a single opinionated answer when the choice is genuinely context-dependent
 4. **Design for change** — favor designs that isolate likely change points behind abstractions

--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-code-reviewer
 model: sonnet
-color: "#7e3af2"
+color: purple
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - code-review-checklist

--- a/.claude/agents/saas-architect.md
+++ b/.claude/agents/saas-architect.md
@@ -1,7 +1,7 @@
 ---
 name: saas-architect
 model: opus
-color: "#0ea5e9"
+color: cyan
 description: SaaS domain specialist. Use proactively on multi-tenant / productivity web-app work — tenancy model, data isolation, billing topology, entitlements, auth/SSO, realtime collab, and horizontal-scale decisions. Owns SaaS architecture and composes the saas-* implementation skills.
 ---
 
@@ -46,9 +46,12 @@ them yourself):
 
 ## Approach
 
-1. **Clarify constraints first** — B2B or B2C; tenant count and size distribution (the
+1. **Pin the constraints first** — B2B or B2C; tenant count and size distribution (the
    largest 10% dominates); compliance scope (SOC 2, HIPAA, PCI, GDPR); residency;
-   self-service vs sales-led; seats per tenant.
+   self-service vs sales-led; seats per tenant. Take them from the task and the repo;
+   where those are silent, state the assumption you are designing under and proceed,
+   and list only the open questions whose answers would change the topology for the
+   orchestrator to take back to the user — you cannot ask them yourself.
 2. **Start from the hardest-to-reverse decision** — tenancy model and identity topology
    shape everything downstream. Lock them first.
 3. **Present trade-offs explicitly** — 2–3 viable topologies with pros, cons, operational

--- a/.claude/agents/secure-auditor.md
+++ b/.claude/agents/secure-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: secure-auditor
 model: opus
-color: "#e3a008"
+color: yellow
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - security-checklist

--- a/.claude/agents/test-writer-runner.md
+++ b/.claude/agents/test-writer-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-writer-runner
 model: sonnet
-color: "#057a55"
+color: green
 description: Test writing and execution specialist. Use proactively after implementation is complete, after a PR review resolves issues, or when test coverage for a module or feature needs improving.
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent `color:` values are now the eight names Claude Code accepts** (`red`,
+  `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`). All 19 agents
+  carried hex values, which the sub-agents reference does not list, so the field
+  was silently ignored and every ccds agent rendered in the default color. A new
+  `agent-colors` lint check keeps it that way.
+- **`plan-architect` and `saas-architect` no longer "ask about constraints
+  first".** A subagent cannot converse with the user; that step returned a
+  question as the whole result and wasted the dispatch. They now take constraints
+  from the task and the repo, state the assumptions they design under where those
+  are silent, and hand back only the questions whose answers would change the
+  design — the shape the Claude 5 prompting guidance recommends for autonomous
+  work.
+
 ### Added
 
 - **`ccds doctor` now catches the double-loaded roster, and setup no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,11 @@ skills — no domain agent; skills-only, like `common-`).
   `PATH`; `TestReleaseZipPs1` runs `build-release.ps1` unmodified on Windows).
 - **The suite runs on both platforms** (ADR-0018): `python3 -m unittest discover -s
   tests` on Linux, and the same command under Windows Python in CI. Sessions here run
-  in WSL on a Windows box, so both are reachable locally — `python.exe -m unittest
-  discover -s tests` runs the Windows half against the same checkout. Platform-specific
-  classes guard on `sys.platform`; never "cover" a platform by running one hand-picked
-  class on it.
+  on native Debian (since 2026-08-14; the WSL-on-Windows setup ADR-0018 describes is
+  gone), so the Windows half — `TestInstallPlaybookPs1`, `TestReleaseZipPs1`,
+  `TestCcdsDoctorPs1` — is verified by the `windows-latest` CI job, not locally.
+  Platform-specific classes guard on `sys.platform`; never "cover" a platform by
+  running one hand-picked class on it.
 
 ---
 

--- a/plugins/ccds-ai/agents/ai-architect.md
+++ b/plugins/ccds-ai/agents/ai-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ai-architect
 model: opus
-color: "#6366f1"
+color: blue
 description: AI / LLM application domain specialist. Use proactively on AI / LLM work — model selection, serving topology, RAG-vs-finetune-vs-prompt, eval strategy, cost/latency budgets, and data policy. Owns AI architecture and composes the ai-* implementation skills.
 ---
 

--- a/plugins/ccds-core/agents/deploy-checklist.md
+++ b/plugins/ccds-core/agents/deploy-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: deploy-checklist
 model: haiku
-color: "#ff5a1f"
+color: orange
 disallowedTools: Write, Edit, NotebookEdit
 description: Deployment readiness and pre-production checklist specialist. Use proactively before any production deployment, environment promotion, release cut, or go/no-go assessment.
 ---

--- a/plugins/ccds-core/agents/plan-architect.md
+++ b/plugins/ccds-core/agents/plan-architect.md
@@ -1,7 +1,7 @@
 ---
 name: plan-architect
 model: opus
-color: "#1a56db"
+color: blue
 description: Universal system design and architecture planning specialist. Use proactively when defining component boundaries, data flows, integration patterns, or making major structural decisions before or during implementation.
 ---
 
@@ -35,7 +35,7 @@ You do NOT own:
 
 ## Approach
 
-1. **Understand constraints first** — ask about scale requirements, team size, deployment target, and non-functional requirements before proposing a design
+1. **Pin the constraints first** — scale requirements, team size, deployment target, and non-functional requirements. Use what the task and the repo give you; where they are silent, state the assumption you are designing under and proceed. List only the open questions whose answers would change the design, for the orchestrator to take back to the user — you cannot ask them yourself
 2. **Prefer simplicity** — recommend the least complex architecture that satisfies requirements; avoid over-engineering
 3. **Make trade-offs explicit** — present 2–3 options with clear pros/cons rather than a single opinionated answer when the choice is genuinely context-dependent
 4. **Design for change** — favor designs that isolate likely change points behind abstractions

--- a/plugins/ccds-core/agents/pr-code-reviewer.md
+++ b/plugins/ccds-core/agents/pr-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-code-reviewer
 model: sonnet
-color: "#7e3af2"
+color: purple
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - code-review-checklist

--- a/plugins/ccds-core/agents/secure-auditor.md
+++ b/plugins/ccds-core/agents/secure-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: secure-auditor
 model: opus
-color: "#e3a008"
+color: yellow
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - security-checklist

--- a/plugins/ccds-core/agents/test-writer-runner.md
+++ b/plugins/ccds-core/agents/test-writer-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-writer-runner
 model: sonnet
-color: "#057a55"
+color: green
 description: Test writing and execution specialist. Use proactively after implementation is complete, after a PR review resolves issues, or when test coverage for a module or feature needs improving.
 ---
 

--- a/plugins/ccds-dataplat/agents/dataplat-architect.md
+++ b/plugins/ccds-dataplat/agents/dataplat-architect.md
@@ -1,7 +1,7 @@
 ---
 name: dataplat-architect
 model: opus
-color: "#0f766e"
+color: cyan
 description: Data Platform domain specialist. Use proactively on data-platform work — warehouse/lakehouse topology, batch vs streaming, partitioning and storage format, governance, ingestion, quality, and serving. Owns data-platform architecture and composes the dataplat-* implementation skills.
 ---
 

--- a/plugins/ccds-desktop/agents/desktop-architect.md
+++ b/plugins/ccds-desktop/agents/desktop-architect.md
@@ -1,7 +1,7 @@
 ---
 name: desktop-architect
 model: opus
-color: "#92400e"
+color: orange
 description: Desktop App domain specialist. Use proactively on desktop work — runtime choice, process/window model, IPC topology, OS integration, autoupdate, code signing, installers, and shell integration. Owns desktop architecture and composes the desktop-* implementation skills.
 ---
 

--- a/plugins/ccds-devtool/agents/devtool-architect.md
+++ b/plugins/ccds-devtool/agents/devtool-architect.md
@@ -1,7 +1,7 @@
 ---
 name: devtool-architect
 model: opus
-color: "#475569"
+color: blue
 description: DevTool / CLI / Library domain specialist. Use proactively on public-surface work — API and CLI surface design, versioning, distribution, extensibility, compatibility, docs, packaging, and telemetry. Owns devtool architecture and composes the devtool-* implementation skills.
 ---
 

--- a/plugins/ccds-ecom/agents/ecom-architect.md
+++ b/plugins/ccds-ecom/agents/ecom-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ecom-architect
 model: opus
-color: "#db2777"
+color: pink
 description: E-commerce domain specialist. Use proactively on storefront/checkout/OMS work — catalog vs cart vs order boundary, payment strategy, inventory reservation, tax/shipping, promotions, search, and peak-event scale. Owns e-commerce architecture and composes the ecom-* implementation skills.
 ---
 

--- a/plugins/ccds-embed/agents/embed-architect.md
+++ b/plugins/ccds-embed/agents/embed-architect.md
@@ -1,7 +1,7 @@
 ---
 name: embed-architect
 model: opus
-color: "#78350f"
+color: orange
 description: Embedded / IoT domain specialist. Use proactively on embedded / firmware / IoT work — SoC/MCU choice, RTOS vs bare-metal, memory/flash layout, secure boot chain, A/B partitioning, fleet OTA topology, and provisioning/attestation. Owns embedded architecture and composes the embed-* implementation skills.
 ---
 

--- a/plugins/ccds-ext/agents/ext-architect.md
+++ b/plugins/ccds-ext/agents/ext-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ext-architect
 model: opus
-color: "#4338ca"
+color: blue
 description: Browser extension domain specialist. Use proactively on browser-extension work — manifest version (MV3), permissions model, background/service-worker/content-script split, cross-browser strategy, store-review posture, and native-host bridges. Owns browser-extension architecture and composes the ext-* implementation skills.
 ---
 

--- a/plugins/ccds-fintech/agents/fintech-architect.md
+++ b/plugins/ccds-fintech/agents/fintech-architect.md
@@ -1,7 +1,7 @@
 ---
 name: fintech-architect
 model: opus
-color: "#365314"
+color: green
 description: Fintech domain specialist. Use proactively on regulated-money work — ledger topology, custody, KYC/AML and licensing, money-movement primitives, reconciliation, audit retention, and risk. Owns fintech architecture and composes the fintech-* implementation skills.
 ---
 

--- a/plugins/ccds-game/agents/game-architect.md
+++ b/plugins/ccds-game/agents/game-architect.md
@@ -1,7 +1,7 @@
 ---
 name: game-architect
 model: opus
-color: "#ea580c"
+color: orange
 description: Game domain specialist. Use proactively on game work — engine selection, core game loop, state architecture, asset pipeline, save/load topology, and platform-target strategy. Owns game architecture and composes the game-* implementation skills.
 ---
 

--- a/plugins/ccds-infra/agents/infra-architect.md
+++ b/plugins/ccds-infra/agents/infra-architect.md
@@ -1,7 +1,7 @@
 ---
 name: infra-architect
 model: opus
-color: "#334155"
+color: blue
 description: Infrastructure / dev-platform domain specialist. Use proactively on infra / platform work — cloud topology, network segmentation, environments, IaC strategy, secrets topology, and platform tenancy. Owns infrastructure architecture and composes the infra-* implementation skills.
 ---
 

--- a/plugins/ccds-media/agents/media-architect.md
+++ b/plugins/ccds-media/agents/media-architect.md
@@ -1,7 +1,7 @@
 ---
 name: media-architect
 model: opus
-color: "#0369a1"
+color: cyan
 description: Media / streaming domain specialist. Use proactively on media / streaming work — ingest → process → store → deliver pipeline, codec/container strategy, VOD vs live topology, DRM posture, CDN strategy, and QoE. Owns media architecture and composes the media-* implementation skills.
 ---
 

--- a/plugins/ccds-mobile/agents/mobile-architect.md
+++ b/plugins/ccds-mobile/agents/mobile-architect.md
@@ -1,7 +1,7 @@
 ---
 name: mobile-architect
 model: opus
-color: "#2563eb"
+color: blue
 description: Mobile domain specialist. Use proactively on iOS / Android work — framework choice, offline posture, background-execution strategy, release topology, and privacy posture. Owns mobile architecture and composes the mobile-* implementation skills.
 ---
 

--- a/plugins/ccds-orch/agents/orch-architect.md
+++ b/plugins/ccds-orch/agents/orch-architect.md
@@ -1,7 +1,7 @@
 ---
 name: orch-architect
 model: opus
-color: "#be123c"
+color: red
 description: Agent / orchestration domain specialist. Use proactively on agent / orchestration work — agent topology, tool-use contract, memory model, planning/looping control, sandbox boundaries, and eval strategy. Owns orchestration architecture and composes the orch-* implementation skills.
 ---
 

--- a/plugins/ccds-saas/agents/saas-architect.md
+++ b/plugins/ccds-saas/agents/saas-architect.md
@@ -1,7 +1,7 @@
 ---
 name: saas-architect
 model: opus
-color: "#0ea5e9"
+color: cyan
 description: SaaS domain specialist. Use proactively on multi-tenant / productivity web-app work — tenancy model, data isolation, billing topology, entitlements, auth/SSO, realtime collab, and horizontal-scale decisions. Owns SaaS architecture and composes the saas-* implementation skills.
 ---
 
@@ -46,9 +46,12 @@ them yourself):
 
 ## Approach
 
-1. **Clarify constraints first** — B2B or B2C; tenant count and size distribution (the
+1. **Pin the constraints first** — B2B or B2C; tenant count and size distribution (the
    largest 10% dominates); compliance scope (SOC 2, HIPAA, PCI, GDPR); residency;
-   self-service vs sales-led; seats per tenant.
+   self-service vs sales-led; seats per tenant. Take them from the task and the repo;
+   where those are silent, state the assumption you are designing under and proceed,
+   and list only the open questions whose answers would change the topology for the
+   orchestrator to take back to the user — you cannot ask them yourself.
 2. **Start from the hardest-to-reverse decision** — tenancy model and identity topology
    shape everything downstream. Lock them first.
 3. **Present trade-offs explicitly** — 2–3 viable topologies with pros, cons, operational

--- a/scripts/lint-playbook.py
+++ b/scripts/lint-playbook.py
@@ -404,6 +404,21 @@ def _zip_payload(src):
     return {m.group(2).replace("\\", "/") for m in PS_COPY_RE.finditer(src)}
 
 
+AGENT_COLORS = ("red", "blue", "green", "yellow", "purple", "orange", "pink", "cyan")
+
+
+def check_agent_colors():
+    """The subagent `color` field accepts exactly eight names (sub-agents doc:
+    "Accepts red, blue, green, yellow, purple, orange, pink, or cyan"). Every
+    agent shipped hex values for months; Claude Code ignored them silently."""
+    for fname in agent_files():
+        fm = frontmatter(read(os.path.join(AGENTS_DIR, fname)))
+        value = field(fm, "color") if fm else ""
+        if value and value not in AGENT_COLORS:
+            err("agent-colors", f"{fname}: color '{value}' is not one of "
+                f"{', '.join(AGENT_COLORS)} -- Claude Code ignores it")
+
+
 def check_release_parity():
     sh_path = os.path.join(REPO_ROOT, "build-release.sh")
     ps_path = os.path.join(REPO_ROOT, "build-release.ps1")
@@ -444,6 +459,7 @@ def main():
     check_process_skills()
     check_cli_parity()
     check_release_parity()
+    check_agent_colors()
     check_marketplace_fresh()
     check_descriptions_and_models()
 

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -139,6 +139,19 @@ class TestLintPlaybook(FixtureCase):
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertIn("RESULT: PASS", r.stdout)
 
+    def test_hex_agent_color_fails(self):
+        """`color:` accepts eight names only; hex is silently ignored by Claude
+        Code, which is how all 19 agents rendered in the default color."""
+        body = read(self.agent_path())
+        body = body.replace("\nname: ", "\ncolor: \"#1a56db\"\nname: ", 1)
+        self.assertIn('color: "#1a56db"', body)
+        write(self.agent_path(), body)
+        self.regen_catalog()
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("agent-colors", r.stdout)
+        self.assertIn("#1a56db", r.stdout)
+
     def test_ghost_skill_reference_fails(self):
         write(self.agent_path(), AGENT_TMPL.format(extra="Also pull `saas-ghost`."))
         r = self.lint()


### PR DESCRIPTION
## Summary

Second half of the Claude Code 2.1.263 / Claude 5 prompting-guidance audit (first half: #71). Everything structural in ccds still holds — every hook event, output field, CLI flag, and frontmatter field it uses is valid in 2.1.263, and the agents already avoid the emphatic "CRITICAL/MUST" register the Claude 5 guidance warns against. Three alignment gaps were real and cheap to fix.

## What changed

- **Agent `color:` values.** The sub-agents reference documents exactly eight names: `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`. All 19 agents carried hex values, so the field was silently ignored and every agent rendered in the default color. Mapped by hue, two by hand (amber → `yellow`, emerald → `green`). New `agent-colors` lint check with a unit test (verified to fire on a planted hex value and pass on the clean tree).
- **`plan-architect` and `saas-architect` no longer "ask about constraints first".** A subagent cannot converse with the user; that step returned a question as the whole result and wasted the dispatch. They now take constraints from the task and the repo, state the assumptions they design under where those are silent, and hand back only the questions whose answers would change the design — the shape the Opus 5 guidance recommends for autonomous work (agents run on `model: opus`, which resolves to Opus 5).
- **CLAUDE.md platform claim.** It said sessions run in WSL on a Windows box with `python.exe` reachable locally. That has been false since the move to native Debian; the Windows half of the suite is verified by the `windows-latest` CI job, and the text now says so and names the three Windows-only classes.
- Changelog entry under Changed; marketplace tree regenerated (plugin copies of the 19 agents).

Deferred on purpose (documented in the research notes at `~/.claude/research/claude-code-2-1-263-and-claude-5-prompting.md`): switching agents to the `fable` alias, adopting `effort` / `maxTurns` / `memory` frontmatter, and rewriting skill bodies — unknown minimum versions and untested effects, or a wholesale A/B the official skill-creator eval tooling should drive as its own project.

## Verification

- `python3 -m unittest discover -s tests`: 299 run, 19 skipped, 0 failures. `scripts/lint-playbook.py`: PASS. `scripts/eval-routing.py`: PASS, 0 failures, 0 known gaps (descriptions unchanged).
- Lint negative case: planting `color: "#1a56db"` in an agent produces `ERROR [agent-colors]`; restoring it passes.
- Rebased onto `develop` after #71 merged; one commit ahead.

## Post-merge

Squash-merge into `develop`, delete branch. Changelog entry rolls into the next version at promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRcT9LqHK3ftpoVNtjKjz7
