### PR TITLE
fix(guard): exempt source code from the secret scan, add operator rules and a deliberate opt-out (ADR-0021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Added
 
+- **The guard takes operator rules and a deliberate opt-out** (ADR-0021).
+  `~/.claude/ccds-guard-rules.txt` accepts the same five rule categories as the
+  shipped table, loads after it, survives plugin updates, and is tamper-watched
+  — its intended use is `allow-path: (^|/)\.claude/credentials/` to declare the
+  key files your own skills read, so they stop being adjudicated on every call.
+  `~/.claude/ccds-guard.disabled` (first line = reason) makes `ccds doctor`
+  report a switched-off guard as WARN "disabled on purpose" instead of FAIL.
+  Switching the guard off now asks first: writing that marker, and
+  `claude plugin disable|uninstall|remove` of an enforcement plugin, are
+  tamper-watched like settings writes.
+
 - **`ccds doctor` now catches the double-loaded roster, and setup no longer
   creates it** (ADR-0020). The 19 agents and cross-cutting skills reach Claude
   Code either from the ccds plugins or from file copies in `~/.claude`; having
@@ -36,6 +47,22 @@ New sessions should read this file first to get up to speed before doing anythin
   report the plugin as the source when `ccds-core` is enabled.
 
 ### Fixed
+
+- **The guard flagged source code as secrets** (#74). Evidence from a month of
+  unattended adjudications: 49 of 52 were the secrets-path rule, and half were
+  denied — nearly all reads of an open-source repo's `src/credentials/` module
+  (TypeScript, matched by the `credentials/` directory rule) or key files the
+  operator's own skills are designed to read. Source-code files inside a
+  source tree (`src/`, `lib/`, `packages/`, `tests/` …) are now exempt from
+  the secret scan, while data files in a `credentials/` or `secrets/`
+  directory, code outside a source tree, dotfiles, anything under a
+  dot-directory, and key stems with a code suffix (`server.key.md`) still
+  block. Reviewed by a three-model panel before merge; its findings are folded
+  in (operator deny rules beat shipped exemptions, empty rules are rejected,
+  the watches match by filename, a symlinked operator file is ignored). Found on the way: in a
+  Bash command an `allow-path` hit also skipped the tamper watch, so with the
+  new exemption `sed -i … .claude/hooks/x.py` would have passed silently; the
+  Bash path now exempts from the secret scan only, matching the file-tool path.
 
 - **`ccds doctor` reported a DISABLED `ccds-guard` as enabled** (#70). The bash
   check split `claude plugin list --json` into objects and looked for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ postinst, `ccds setup`, `ccds sync`'s first run, and the installers all funnel t
 (ADR-0016). Put outlet-wide install behavior there, never in an installer.
 `ccds-loops` carries the process-enforcement hooks (ADR-0011) and
 `ccds-guard` the zero-config security guard (secret-path denies, dangerous-command
-blocks, install ask-gate, config tamper watch; rules in `hooks/guard-rules.txt`, kill
-switch `CCDS_GUARD_DISABLE=1`; in unattended/auto-accept sessions ask-gates are decided
+blocks, install ask-gate, config tamper watch; rules in `hooks/guard-rules.txt`,
+operator additions in `~/.claude/ccds-guard-rules.txt` (ADR-0021), kill switch
+`CCDS_GUARD_DISABLE=1`, deliberate opt-out marker `~/.claude/ccds-guard.disabled`; in unattended/auto-accept sessions ask-gates are decided
 by a fresh-context LLM adjudicator instead of a prompt, except safety-config writes,
 which deny outright — ADR-0015). That adjudicator sets the project's **minimum Claude
 Code version, v2.1.169** (the release that added `--safe-mode`); its three isolation

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1944,3 +1944,117 @@ run; naming the command is enough and reversible.
 ### Supersedes
 
 None.
+
+---
+
+## ADR-0021: The Guard Exempts Source Code and Takes Operator Rules
+
+**Date:** 2026-09-06
+**Status:** Accepted
+**Phase:** Hardening
+**Deciders:** Greg Grace
+
+### Context
+
+The guard was too strict to leave on: the maintainer disabled it (#74). The
+adjudicator's own transcripts showed why — 49 of 52 unattended adjudications
+in a month were the secrets-path rule, and the judge denied half of them. Two
+patterns accounted for nearly all hits: reads of an open-source repo's
+`src/credentials/` module (TypeScript files matched by the `credentials/`
+directory rule that ADR-0012's review round had deliberately restored), and
+key files the operator's own skills are designed to read, adjudicated on
+every single call because nothing let the operator declare them.
+
+A third, smaller issue: `ccds doctor` reports a disabled guard as FAIL by
+design (ADR-0016), which is right for an accidental state and wrong for a
+recorded decision.
+
+### Decision
+
+1. **Source code is exempt from the secret scan wherever it lives.** A new
+   `allow-path` for source extensions (`.ts .py .go .rs .java .md …`) means
+   `credentials/credentials.service.ts` passes while `credentials/api_key.txt`
+   and `credentials/service-account.json` still deny. The `credentials/` and
+   `secrets/` directory rules stay — narrowing them to dot-directories was
+   considered and rejected because it would have let data files in a repo's
+   `credentials/` through.
+2. **`allow-path` exempts from `deny-path` only.** The Bash path had let an
+   allow-path hit skip the tamper watch too; with hook scripts being `.py`
+   files, the new exemption made `sed -i … .claude/hooks/x.py` pass silently
+   until the panel matrix caught it. The file-tool path already had the
+   right contract; the Bash path now matches it.
+3. **Operator rules file** `~/.claude/ccds-guard-rules.txt`: same five
+   categories, loaded after the shipped table, never overwritten by a plugin
+   update, relocatable via `CCDS_GUARD_USER_RULES` (test seam). Declaring
+   `allow-path: (^|/)\.claude/credentials/` is the intended use; it can also
+   tighten. The file is tamper-watched (`ask-write-path`), so the model
+   cannot add an exemption silently — unattended, that write denies outright
+   like every other safety-config write. Operator rules never mask an empty
+   shipped table (the inert warning keys on the shipped file alone).
+4. **Deliberate opt-out marker** `~/.claude/ccds-guard.disabled`: with it
+   present and only `ccds-guard` disabled, doctor reports WARN "disabled on
+   purpose (<first line>)" instead of FAIL, in both dispatchers. A disabled
+   `ccds-loops` is never excused. Writing the marker asks (tamper watch), and
+   so does `claude plugin disable|uninstall|remove` of an enforcement plugin
+   — a gap the review probes found: the CLI edits settings.json out of the
+   guard's sight, so the command text itself is the only place to catch it.
+5. **The exemption cannot launder a key.** Review probes showed the first cut
+   let `.ssh/id_rsa.md`, `.ssh/config.ts` and `.env.ts` through. The
+   exemption is now off inside any dot-directory, for any dotfile, and for
+   key/env stems with a code suffix (`server.key.md`, `id_rsa.md`). Files the
+   shipped table never matched by shape (`credentials.md`, `backend.env.ts`)
+   remain out of scope, as before: the guard classifies by shape, not content.
+6. **A symlinked operator file is ignored, loudly.** The tamper watch is on
+   the path; a symlink would move the effective content to a target the watch
+   never sees (creating the link asks once, later writes to the target would
+   not — review finding). The loader refuses a symlink at the operator path
+   and says so on stderr; a symlinked `~/.claude` *directory* (dotfiles
+   managers) is still fine, since only the file itself is checked.
+
+7. **Review-panel refinements** (codex + a Claude reviewer, both read-only,
+   both REQUEST CHANGES on the first cut; grok returned nothing): the
+   exemption additionally requires a source-tree segment (`src/ lib/ app/
+   packages/ tests/ …`), so `secrets/keys.py` at a repo root denies as
+   before while `packages/cli/src/credentials/x.ts` passes; docs/data
+   suffixes (`.md .rst .sql`) are not exempt; operator `deny-path` rules are
+   checked before any exemption, so "can also tighten" is true; an empty rule
+   body (`allow-path:` alone would match every path), an invalid regex, or an
+   unknown category in the operator file is skipped and named on stderr with
+   file:line; the two tamper watches match by filename (and by the resolved
+   `CCDS_GUARD_USER_RULES` path), so `cd ~/.claude && … > ccds-guard-rules.txt`
+   and Windows trailing-dot aliases ask; the doctor marker must be a regular
+   file (PowerShell `-PathType Leaf`) and an unreadable one no longer aborts
+   the bash doctor under `pipefail`.
+
+### Rationale
+
+Telling the adjudicator about declared paths was the alternative for (3);
+exempting them before the scan is simpler and cheaper, and keeps the judge's
+"on its face" contract intact. Extension-based exemption over
+directory-narrowing (1) keeps the panel's earlier decision where it was
+right (data files in `credentials/`) and removes it only where the evidence
+showed it wrong (code). The allow-path contract fix (2) is a correctness
+change independent of the evidence and would have been needed anyway.
+
+### Consequences
+
+- Of the 49 real hits, every source read and every declared-key call clears;
+  a bare `ls …/credentials/` still asks (one hit), and reads of
+  `~/.aws/credentials`, `.env`, `.ssh` are unchanged.
+- The teaching messages now point at the operator file, not the plugin's
+  own rules table (which an update overwrites).
+- Follow-on: a `ccds guard` subcommand to add/list operator rules is
+  possible; not needed for the fix.
+- Follow-on (review finding, deliberately not in this change): in the Bash
+  path an unambiguous WRITE to a safety path (`> file`, `>>`, `tee`) is still
+  adjudicated unattended rather than denied outright like a file-tool write,
+  because a name in a command line does not prove a write (ADR-0015 comment).
+  Classifying redirection targets and `tee` arguments as tamper writes is a
+  precise improvement worth its own change and tests.
+- Known limitation, unchanged: shell quoting/concatenation
+  (`ccds-guard-rules'.txt'`) defeats every regex-over-string rule in the table
+  (ADR-0012 threat model, pinned by `test_known_limitation_quoting_bypasses_pinned`).
+
+### Supersedes
+
+None (amends ADR-0012's rule table and ADR-0016's doctor contract).

--- a/README.md
+++ b/README.md
@@ -78,8 +78,16 @@ updates, and enable/disable — no installer, no PATH, no restart dance.
 The guard stops model mistakes and casual prompt injection — it is a teaching
 backstop on top of Claude Code's permission modes, not a sandbox. Never run
 with permissions bypassed (`--dangerously-skip-permissions`) outside an
-isolated container, guard or no guard. Kill switch: `CCDS_GUARD_DISABLE=1`;
-tune rules in the plugin's `hooks/guard-rules.txt`. The hooks need `python3`
+isolated container, guard or no guard. Kill switch: `CCDS_GUARD_DISABLE=1`.
+Tune it without editing the plugin: `~/.claude/ccds-guard-rules.txt` takes the
+same five rule categories and loads after the shipped table (ADR-0021) — the
+usual entry is `allow-path: (^|/)\.claude/credentials/` to declare the key
+files your own skills are meant to read, so they stop being adjudicated on
+every call; the file is tamper-watched like settings, and its `deny-path`
+lines beat any shipped exemption. Source code inside a source tree is exempt
+from the secret scan (`src/credentials/foo.ts` is a module, not a key). If you switch the guard off on purpose, record why in
+`~/.claude/ccds-guard.disabled` and `ccds doctor` reports it as a choice
+(WARN) rather than a broken install. The hooks need `python3`
 on PATH (macOS/Linux/WSL have it; on native Windows install Python 3 or the
 guard is inert).
 

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -999,9 +999,22 @@ function Test-DoctorPlugins {
         return
     }
     if ($disabled.Count -gt 0) {
+        # A deliberate opt-out is not a broken install: the operator records
+        # the reason in ~/.claude/ccds-guard.disabled and doctor downgrades the
+        # guard line to WARN (ADR-0021). Only ccds-guard can be opted out.
+        $marker = Join-Path $env:USERPROFILE '.claude\ccds-guard.disabled'
+        if ($disabled.Count -eq 1 -and $disabled[0] -eq 'ccds-guard' -and (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            $why = ''
+            try { $why = @(Get-Content -LiteralPath $marker -TotalCount 1 -ErrorAction Stop)[0] } catch { }
+            if (-not $why) { $why = 'no reason recorded' }
+            Write-DoctorLine 'WARN' 'plugins-installed' `
+                "ccds-guard disabled on purpose (${marker}: $why); ccds-loops installed and enabled" `
+                "when the guard is revisited: claude plugin enable ccds-guard; Remove-Item '$marker'"
+            return
+        }
         Write-DoctorLine 'FAIL' 'plugins-installed' `
             "installed but DISABLED: $($disabled -join ' ') -- a disabled guard protects nothing" `
-            "claude plugin enable $($disabled[0])"
+            "claude plugin enable $($disabled[0]) (or, if deliberate: Set-Content '$marker' 'reason' so doctor reports it as a choice)"
         return
     }
     Write-DoctorLine 'OK' 'plugins-installed' 'ccds-guard ccds-loops installed and enabled'

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -386,9 +386,22 @@ doc_check_plugins() {
         return
     fi
     if (( ${#disabled[@]} > 0 )); then
+        # A deliberate opt-out is not a broken install: the operator records
+        # the reason in ~/.claude/ccds-guard.disabled and doctor downgrades the
+        # guard line to WARN (ADR-0021). Only ccds-guard can be opted out; a
+        # disabled ccds-loops is still an incomplete install.
+        local marker="$HOME/.claude/ccds-guard.disabled"
+        if [[ "${disabled[*]}" == "ccds-guard" && -f "$marker" ]]; then
+            local why
+            why="$(head -n 1 "$marker" 2>/dev/null | tr -d '\r' || true)"
+            doc_line WARN plugins-installed \
+                "ccds-guard disabled on purpose (${marker}: ${why:-no reason recorded}); ccds-loops installed and enabled" \
+                "when the guard is revisited: claude plugin enable ccds-guard && rm $marker"
+            return
+        fi
         doc_line FAIL plugins-installed \
             "installed but DISABLED: ${disabled[*]} -- a disabled guard protects nothing" \
-            "claude plugin enable ${disabled[0]}"
+            "claude plugin enable ${disabled[0]} (or, if deliberate: echo 'reason' > $HOME/.claude/ccds-guard.disabled so doctor reports it as a choice)"
         return
     fi
     doc_line OK plugins-installed "${ENFORCEMENT_PLUGINS[*]} installed and enabled"

--- a/plugin-extras/ccds-guard/hooks/guard-rules.txt
+++ b/plugin-extras/ccds-guard/hooks/guard-rules.txt
@@ -24,6 +24,13 @@
 # NOT in this table (lives in pretooluse-guard.py as path logic, because a
 # regex cannot resolve paths): recursive force-delete outside the project.
 #
+# Operator additions live in ~/.claude/ccds-guard-rules.txt (same five
+# categories; loaded after this file, never replaced by a plugin update, and
+# tamper-watched like settings). Typical use: declare the credential files your
+# own skills are meant to read, so they stop being adjudicated on every call:
+#   allow-path: (^|/)\.claude/credentials/   # keys my skills read by design
+# Override the location with CCDS_GUARD_USER_RULES (a test seam).
+#
 # Charter: protective only. This guard exists so that projects built by people
 # who configure nothing still refuse to leak secrets, run curl|bash, or install
 # hallucinated packages. It is a teaching backstop layered on Claude Code's
@@ -35,6 +42,7 @@
 allow-path: \.env\.(example|sample|template|dist)$                              # env templates are meant to be edited
 allow-path: (^|/)tests?/fixtures?/                                              # test fixtures named like secrets
 allow-path: \.pub$                                                              # public keys are not secrets
+allow-path: ^(?=.*(?:^|/)(?:src|lib|app|apps|packages|pkg|internal|cmd|tests?|spec|__tests__|e2e|examples?)/)(?!.*(?:^|/)\.[^/]+/)(?:.*/)?(?!\.)(?![^/]*\.(?:key|pem|p12|pfx|jks|keystore|env|tfstate)\.)(?!id_(?:rsa|dsa|ecdsa|ed25519)\b)[^/]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|cs|rb|php|swift|scala|c|cc|cpp|h|hpp|proto|graphql|vue|svelte)$  # source code in a source tree is never a secret: packages/cli/src/credentials/credentials.service.ts is a module, not a key (#74). Requires a source-root segment (src/ lib/ app/ packages/ tests/ ...), so secrets/keys.py at a repo root still denies; never inside a dot-directory, never a dotfile (.env.ts), never a key/env stem with a code suffix (server.key.md)
 
 # --- Secret-bearing paths: never read or written by the model ---
 deny-path: (^|/)\.env(\.[A-Za-z0-9._-]+)?$                                      # .env and variants hold live credentials
@@ -57,6 +65,8 @@ ask-write-path: (^|/)\.claude/settings(\.local)?\.json$                         
 ask-write-path: (^|/)\.claude/hooks(/|$)                                        # Claude Code is changing hook scripts that enforce your safety gates
 ask-write-path: (^|/)\.claude/plugins/                                          # Claude Code is changing installed plugin files (including this guard's own rules) - confirm you asked for this
 ask-write-path: (^|/)\.pre-commit-config\.ya?ml$                                # Claude Code is changing the checks that run before every commit
+ask-write-path: (^|/)ccds-guard-rules\.txt[. ]*$                                   # Claude Code is changing the operator's own guard rules (the file that can exempt paths) - confirm you asked for this. Matched by filename so `cd ~/.claude && ... > ccds-guard-rules.txt` and Windows trailing-dot aliases are seen too
+ask-write-path: (^|/)ccds-guard\.disabled[. ]*$                                    # Claude Code is writing the guard opt-out marker that makes doctor treat a disabled guard as intended - confirm you asked for this
 
 # --- Dangerous commands: blocked outright ---
 deny-command: \bgit\b[^\n;|&]*\bpush\b[^\n;|&]*(\s--force(?!-with-lease|-if-includes)\b|\s-[a-z]*f[a-z]*\b)  # force-push rewrites shared history; use --force-with-lease if you truly need it
@@ -69,6 +79,9 @@ deny-command: \bwget\b[^\n;|&]*--no-check-certificate\b                         
 deny-command: \bsslverify\s*[= ]\s*false\b                                      # disabling git TLS verification lets anyone intercept the traffic
 deny-command: \bstrict-ssl\b[^\n;|&]*\bfalse\b                                  # disabling npm TLS verification lets anyone intercept the traffic
 deny-command: \b(PYTHONHTTPSVERIFY=0|NODE_TLS_REJECT_UNAUTHORIZED=0)\b          # disabling TLS verification lets anyone intercept the traffic
+
+# --- Guard self-removal: the model switching off its own gates asks first ---
+ask-command: \bclaude\s+plugin\s+(disable|uninstall|remove)\b[^\n;|&]*\bccds-(guard|loops)\b  # Claude Code is disabling or removing a ccds enforcement plugin (its own safety gates) - confirm you asked for this
 
 # --- Package installs: ask, because models hallucinate package names ---
 # Attackers register hallucinated names (slopsquatting). Flags may appear

--- a/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
@@ -9,8 +9,9 @@ One script, two matchers (see hooks.json):
                                         package-install ask (slopsquatting)
   Read|Write|Edit|NotebookEdit|Grep  -> secret-path deny, config-tamper ask
 
-Rules are DATA (guard-rules.txt beside this script, five categories); editing
-the table tunes the guard without touching code. Checks that need path
+Rules are DATA (guard-rules.txt beside this script, five categories, plus the
+operator's ~/.claude/ccds-guard-rules.txt loaded after it — CCDS_GUARD_USER_RULES
+relocates it); editing the tables tunes the guard without touching code. Checks that need path
 resolution a regex cannot express live in CODE (lessons from three multi-model
 review rounds, ADR-0012 addendum):
   - recursive force-delete outside the project: targets are resolved (quotes,
@@ -85,6 +86,15 @@ import subprocess
 import sys
 import tempfile
 
+# Operator rules: same format, loaded AFTER the shipped table so a plugin
+# update never overwrites them. Lives under ~/.claude and is tamper-watched
+# (ask-write-path) because an allow-path line can exempt a secret file — the
+# model must not be able to add one silently. CCDS_GUARD_USER_RULES is the
+# test seam / relocation knob; it is read from the hook's own environment
+# (Claude Code's process), which a `VAR=x cmd` prefix inside a Bash tool call
+# cannot reach — only the session's launch environment can set it.
+USER_RULES_FILE = os.environ.get("CCDS_GUARD_USER_RULES", "").strip() or \
+    os.path.join(os.path.expanduser("~"), ".claude", "ccds-guard-rules.txt")
 RULES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "guard-rules.txt")
 
@@ -183,15 +193,53 @@ ALLOW: <short reason>   or   DENY: <short reason>
 
 
 def _load_rules():
-    """Return {category: [(compiled_regex, label), ...]}.
-    Unparseable lines/patterns are skipped, never fatal."""
+    """Return {category: [(compiled_regex, label), ...]} from the shipped
+    table plus the operator's file (if any). Operator deny-path rules are ALSO
+    kept in "deny-path-first", checked before any allow-path exemption, so an
+    operator can tighten what the shipped table exempts. A missing operator
+    file is the normal case; a symlinked one is ignored, loudly."""
     rules = {c: [] for c in CATEGORIES}
+    rules["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, rules)
+    # The operator file is tamper-watched by PATH. A symlink at that path
+    # would move the effective content to a target the watch never sees
+    # (review finding): creating the link asks once, every later write to the
+    # target would not. So a symlinked operator file is ignored, loudly.
+    if os.path.islink(USER_RULES_FILE):
+        sys.stderr.write("ccds-guard: %s is a symlink and was ignored — the "
+                         "operator rules file must be a regular file.\n"
+                         % USER_RULES_FILE)
+    else:
+        _load_rules_file(USER_RULES_FILE, rules, operator=True)
+    # Whatever path the operator file resolves to (CCDS_GUARD_USER_RULES may
+    # relocate it), writes there are tamper-watched, not just the default name.
     try:
-        with open(RULES_FILE, encoding="utf-8") as f:
+        rules["ask-write-path"].append((
+            re.compile(re.escape(_norm(USER_RULES_FILE)) + r"[. ]*$", re.IGNORECASE),
+            "Claude Code is changing the operator's own guard rules - confirm you asked for this"))
+    except re.error:
+        pass
+    return rules
+
+
+def _load_rules_file(path, rules, operator=False):
+    """Parse one rules file into `rules`. Shipped-table problems are silent by
+    contract (a bad pattern disables itself, never the guard); operator-file
+    problems are reported on stderr with file:line, because a rule the
+    operator wrote and thinks is active must not fail silently. An EMPTY body
+    is skipped everywhere: `allow-path:` with nothing after it would compile
+    to a regex that matches every path (review finding)."""
+    try:
+        with open(path, encoding="utf-8") as f:
             lines = f.readlines()
     except (OSError, UnicodeDecodeError):
-        return rules
-    for raw in lines:
+        return
+
+    def complain(n, why):
+        if operator:
+            sys.stderr.write("ccds-guard: %s:%d ignored — %s\n" % (path, n, why))
+
+    for n, raw in enumerate(lines, 1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
@@ -203,13 +251,20 @@ def _load_rules():
                 if " # " in body:
                     body, label = body.split(" # ", 1)
                     body, label = body.strip(), label.strip()
+                if not body:
+                    complain(n, "empty pattern (would match every path)")
+                    break
                 try:
-                    rules[cat].append((re.compile(body, re.IGNORECASE),
-                                       label or body))
-                except re.error:
-                    pass  # a bad pattern disables itself, never the guard
+                    entry = (re.compile(body, re.IGNORECASE), label or body)
+                except re.error as exc:
+                    complain(n, "invalid regex (%s)" % exc)
+                    break
+                rules[cat].append(entry)
+                if operator and cat == "deny-path":
+                    rules["deny-path-first"].append(entry)
                 break
-    return rules
+        else:
+            complain(n, "unknown rule category")
 
 
 def _split_cmd(cmd):
@@ -377,8 +432,9 @@ def _ask(reasons, payload, tool, detail, tamper=False):
         "Verdict: %s\nGuard reason(s): %s\nFlagged input: %s\n"
         "Use a safer form (bare lockfile restores pass untouched), or leave "
         "the exact command for the operator to run themselves. Persistent "
-        "false positive? The operator can tune guard-rules.txt or set "
-        "CCDS_GUARD_ADJUDICATOR_CMD." % (why, "; ".join(reasons), detail))
+        "false positive? The operator can add an allow-path in "
+        "~/.claude/ccds-guard-rules.txt or set CCDS_GUARD_ADJUDICATOR_CMD."
+        % (why, "; ".join(reasons), detail))
 
 
 def _deny(msg):
@@ -546,10 +602,14 @@ def _guard_bash(cmd, payload, rules):
         cmd_word = posixpath.basename(_norm(toks[i])) if i < len(toks) else ""
         text_only = cmd_word in TEXT_COMMANDS
         for tok in _tokens_for_scan(seg):
-            if _match_any(rules["allow-path"], tok):
-                continue
-            if not secret_hit and not text_only \
-                    and _match_any(rules["deny-path"], tok):
+            # allow-path exempts from the SECRET scan only (the table's
+            # contract). The tamper watch must still see an exempt token:
+            # hook scripts are .py/.sh files, and the source-code exemption
+            # would otherwise let `sed -i ... .claude/hooks/x.py` pass silently.
+            exempt = _match_any(rules["allow-path"], tok)
+            if not secret_hit and not text_only and (
+                    _match_any(rules["deny-path-first"], tok)
+                    or (not exempt and _match_any(rules["deny-path"], tok))):
                 secret_hit = True
             if not tamper_hit and _match_any(rules["ask-write-path"], tok):
                 tamper_hit = True
@@ -632,9 +692,9 @@ def _guard_file(tool, tool_input, rules, payload):
         return 0
 
     for cand in candidates:
-        if _match_any(rules["allow-path"], cand):
-            continue
-        for rx, label in rules["deny-path"]:
+        exempt = _match_any(rules["allow-path"], cand)
+        for rx, label in rules["deny-path-first"] + (
+                [] if exempt else rules["deny-path"]):
             if rx.search(cand):
                 return _deny(
                     "ccds-guard: BLOCKED — %s looks like a secrets file/"
@@ -644,8 +704,8 @@ def _guard_file(tool, tool_input, rules, payload):
                     "needed, the operator opens it in their own editor; to "
                     "bootstrap config, copy the template (cp .env.example "
                     ".env) yourself. Persistent false positive? The operator "
-                    "can tune guard-rules.txt in the ccds-guard plugin."
-                    % (cand, label))
+                    "can exempt it in ~/.claude/ccds-guard-rules.txt "
+                    "(allow-path)." % (cand, label))
     if tool in WRITE_TOOLS:
         reasons = []
         for cand in candidates:
@@ -674,7 +734,10 @@ def main():
     if not isinstance(tool_input, dict):
         return 0
     rules = _load_rules()
-    if not any(rules.values()) and tool in ("Bash",) + FILE_TOOLS:
+    shipped = {c: [] for c in CATEGORIES}
+    shipped["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, shipped)
+    if not any(shipped.values()) and tool in ("Bash",) + FILE_TOOLS:
         # Fail-open, but never silently: an empty table means the guard is
         # inert, and the operator should know (stderr on exit 0 = non-blocking).
         sys.stderr.write("ccds-guard: guard-rules.txt is missing or empty — "

--- a/plugins/ccds-guard/hooks/guard-rules.txt
+++ b/plugins/ccds-guard/hooks/guard-rules.txt
@@ -24,6 +24,13 @@
 # NOT in this table (lives in pretooluse-guard.py as path logic, because a
 # regex cannot resolve paths): recursive force-delete outside the project.
 #
+# Operator additions live in ~/.claude/ccds-guard-rules.txt (same five
+# categories; loaded after this file, never replaced by a plugin update, and
+# tamper-watched like settings). Typical use: declare the credential files your
+# own skills are meant to read, so they stop being adjudicated on every call:
+#   allow-path: (^|/)\.claude/credentials/   # keys my skills read by design
+# Override the location with CCDS_GUARD_USER_RULES (a test seam).
+#
 # Charter: protective only. This guard exists so that projects built by people
 # who configure nothing still refuse to leak secrets, run curl|bash, or install
 # hallucinated packages. It is a teaching backstop layered on Claude Code's
@@ -35,6 +42,7 @@
 allow-path: \.env\.(example|sample|template|dist)$                              # env templates are meant to be edited
 allow-path: (^|/)tests?/fixtures?/                                              # test fixtures named like secrets
 allow-path: \.pub$                                                              # public keys are not secrets
+allow-path: ^(?=.*(?:^|/)(?:src|lib|app|apps|packages|pkg|internal|cmd|tests?|spec|__tests__|e2e|examples?)/)(?!.*(?:^|/)\.[^/]+/)(?:.*/)?(?!\.)(?![^/]*\.(?:key|pem|p12|pfx|jks|keystore|env|tfstate)\.)(?!id_(?:rsa|dsa|ecdsa|ed25519)\b)[^/]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|cs|rb|php|swift|scala|c|cc|cpp|h|hpp|proto|graphql|vue|svelte)$  # source code in a source tree is never a secret: packages/cli/src/credentials/credentials.service.ts is a module, not a key (#74). Requires a source-root segment (src/ lib/ app/ packages/ tests/ ...), so secrets/keys.py at a repo root still denies; never inside a dot-directory, never a dotfile (.env.ts), never a key/env stem with a code suffix (server.key.md)
 
 # --- Secret-bearing paths: never read or written by the model ---
 deny-path: (^|/)\.env(\.[A-Za-z0-9._-]+)?$                                      # .env and variants hold live credentials
@@ -57,6 +65,8 @@ ask-write-path: (^|/)\.claude/settings(\.local)?\.json$                         
 ask-write-path: (^|/)\.claude/hooks(/|$)                                        # Claude Code is changing hook scripts that enforce your safety gates
 ask-write-path: (^|/)\.claude/plugins/                                          # Claude Code is changing installed plugin files (including this guard's own rules) - confirm you asked for this
 ask-write-path: (^|/)\.pre-commit-config\.ya?ml$                                # Claude Code is changing the checks that run before every commit
+ask-write-path: (^|/)ccds-guard-rules\.txt[. ]*$                                   # Claude Code is changing the operator's own guard rules (the file that can exempt paths) - confirm you asked for this. Matched by filename so `cd ~/.claude && ... > ccds-guard-rules.txt` and Windows trailing-dot aliases are seen too
+ask-write-path: (^|/)ccds-guard\.disabled[. ]*$                                    # Claude Code is writing the guard opt-out marker that makes doctor treat a disabled guard as intended - confirm you asked for this
 
 # --- Dangerous commands: blocked outright ---
 deny-command: \bgit\b[^\n;|&]*\bpush\b[^\n;|&]*(\s--force(?!-with-lease|-if-includes)\b|\s-[a-z]*f[a-z]*\b)  # force-push rewrites shared history; use --force-with-lease if you truly need it
@@ -69,6 +79,9 @@ deny-command: \bwget\b[^\n;|&]*--no-check-certificate\b                         
 deny-command: \bsslverify\s*[= ]\s*false\b                                      # disabling git TLS verification lets anyone intercept the traffic
 deny-command: \bstrict-ssl\b[^\n;|&]*\bfalse\b                                  # disabling npm TLS verification lets anyone intercept the traffic
 deny-command: \b(PYTHONHTTPSVERIFY=0|NODE_TLS_REJECT_UNAUTHORIZED=0)\b          # disabling TLS verification lets anyone intercept the traffic
+
+# --- Guard self-removal: the model switching off its own gates asks first ---
+ask-command: \bclaude\s+plugin\s+(disable|uninstall|remove)\b[^\n;|&]*\bccds-(guard|loops)\b  # Claude Code is disabling or removing a ccds enforcement plugin (its own safety gates) - confirm you asked for this
 
 # --- Package installs: ask, because models hallucinate package names ---
 # Attackers register hallucinated names (slopsquatting). Flags may appear

--- a/plugins/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugins/ccds-guard/hooks/pretooluse-guard.py
@@ -9,8 +9,9 @@ One script, two matchers (see hooks.json):
                                         package-install ask (slopsquatting)
   Read|Write|Edit|NotebookEdit|Grep  -> secret-path deny, config-tamper ask
 
-Rules are DATA (guard-rules.txt beside this script, five categories); editing
-the table tunes the guard without touching code. Checks that need path
+Rules are DATA (guard-rules.txt beside this script, five categories, plus the
+operator's ~/.claude/ccds-guard-rules.txt loaded after it — CCDS_GUARD_USER_RULES
+relocates it); editing the tables tunes the guard without touching code. Checks that need path
 resolution a regex cannot express live in CODE (lessons from three multi-model
 review rounds, ADR-0012 addendum):
   - recursive force-delete outside the project: targets are resolved (quotes,
@@ -85,6 +86,15 @@ import subprocess
 import sys
 import tempfile
 
+# Operator rules: same format, loaded AFTER the shipped table so a plugin
+# update never overwrites them. Lives under ~/.claude and is tamper-watched
+# (ask-write-path) because an allow-path line can exempt a secret file — the
+# model must not be able to add one silently. CCDS_GUARD_USER_RULES is the
+# test seam / relocation knob; it is read from the hook's own environment
+# (Claude Code's process), which a `VAR=x cmd` prefix inside a Bash tool call
+# cannot reach — only the session's launch environment can set it.
+USER_RULES_FILE = os.environ.get("CCDS_GUARD_USER_RULES", "").strip() or \
+    os.path.join(os.path.expanduser("~"), ".claude", "ccds-guard-rules.txt")
 RULES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "guard-rules.txt")
 
@@ -183,15 +193,53 @@ ALLOW: <short reason>   or   DENY: <short reason>
 
 
 def _load_rules():
-    """Return {category: [(compiled_regex, label), ...]}.
-    Unparseable lines/patterns are skipped, never fatal."""
+    """Return {category: [(compiled_regex, label), ...]} from the shipped
+    table plus the operator's file (if any). Operator deny-path rules are ALSO
+    kept in "deny-path-first", checked before any allow-path exemption, so an
+    operator can tighten what the shipped table exempts. A missing operator
+    file is the normal case; a symlinked one is ignored, loudly."""
     rules = {c: [] for c in CATEGORIES}
+    rules["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, rules)
+    # The operator file is tamper-watched by PATH. A symlink at that path
+    # would move the effective content to a target the watch never sees
+    # (review finding): creating the link asks once, every later write to the
+    # target would not. So a symlinked operator file is ignored, loudly.
+    if os.path.islink(USER_RULES_FILE):
+        sys.stderr.write("ccds-guard: %s is a symlink and was ignored — the "
+                         "operator rules file must be a regular file.\n"
+                         % USER_RULES_FILE)
+    else:
+        _load_rules_file(USER_RULES_FILE, rules, operator=True)
+    # Whatever path the operator file resolves to (CCDS_GUARD_USER_RULES may
+    # relocate it), writes there are tamper-watched, not just the default name.
     try:
-        with open(RULES_FILE, encoding="utf-8") as f:
+        rules["ask-write-path"].append((
+            re.compile(re.escape(_norm(USER_RULES_FILE)) + r"[. ]*$", re.IGNORECASE),
+            "Claude Code is changing the operator's own guard rules - confirm you asked for this"))
+    except re.error:
+        pass
+    return rules
+
+
+def _load_rules_file(path, rules, operator=False):
+    """Parse one rules file into `rules`. Shipped-table problems are silent by
+    contract (a bad pattern disables itself, never the guard); operator-file
+    problems are reported on stderr with file:line, because a rule the
+    operator wrote and thinks is active must not fail silently. An EMPTY body
+    is skipped everywhere: `allow-path:` with nothing after it would compile
+    to a regex that matches every path (review finding)."""
+    try:
+        with open(path, encoding="utf-8") as f:
             lines = f.readlines()
     except (OSError, UnicodeDecodeError):
-        return rules
-    for raw in lines:
+        return
+
+    def complain(n, why):
+        if operator:
+            sys.stderr.write("ccds-guard: %s:%d ignored — %s\n" % (path, n, why))
+
+    for n, raw in enumerate(lines, 1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
@@ -203,13 +251,20 @@ def _load_rules():
                 if " # " in body:
                     body, label = body.split(" # ", 1)
                     body, label = body.strip(), label.strip()
+                if not body:
+                    complain(n, "empty pattern (would match every path)")
+                    break
                 try:
-                    rules[cat].append((re.compile(body, re.IGNORECASE),
-                                       label or body))
-                except re.error:
-                    pass  # a bad pattern disables itself, never the guard
+                    entry = (re.compile(body, re.IGNORECASE), label or body)
+                except re.error as exc:
+                    complain(n, "invalid regex (%s)" % exc)
+                    break
+                rules[cat].append(entry)
+                if operator and cat == "deny-path":
+                    rules["deny-path-first"].append(entry)
                 break
-    return rules
+        else:
+            complain(n, "unknown rule category")
 
 
 def _split_cmd(cmd):
@@ -377,8 +432,9 @@ def _ask(reasons, payload, tool, detail, tamper=False):
         "Verdict: %s\nGuard reason(s): %s\nFlagged input: %s\n"
         "Use a safer form (bare lockfile restores pass untouched), or leave "
         "the exact command for the operator to run themselves. Persistent "
-        "false positive? The operator can tune guard-rules.txt or set "
-        "CCDS_GUARD_ADJUDICATOR_CMD." % (why, "; ".join(reasons), detail))
+        "false positive? The operator can add an allow-path in "
+        "~/.claude/ccds-guard-rules.txt or set CCDS_GUARD_ADJUDICATOR_CMD."
+        % (why, "; ".join(reasons), detail))
 
 
 def _deny(msg):
@@ -546,10 +602,14 @@ def _guard_bash(cmd, payload, rules):
         cmd_word = posixpath.basename(_norm(toks[i])) if i < len(toks) else ""
         text_only = cmd_word in TEXT_COMMANDS
         for tok in _tokens_for_scan(seg):
-            if _match_any(rules["allow-path"], tok):
-                continue
-            if not secret_hit and not text_only \
-                    and _match_any(rules["deny-path"], tok):
+            # allow-path exempts from the SECRET scan only (the table's
+            # contract). The tamper watch must still see an exempt token:
+            # hook scripts are .py/.sh files, and the source-code exemption
+            # would otherwise let `sed -i ... .claude/hooks/x.py` pass silently.
+            exempt = _match_any(rules["allow-path"], tok)
+            if not secret_hit and not text_only and (
+                    _match_any(rules["deny-path-first"], tok)
+                    or (not exempt and _match_any(rules["deny-path"], tok))):
                 secret_hit = True
             if not tamper_hit and _match_any(rules["ask-write-path"], tok):
                 tamper_hit = True
@@ -632,9 +692,9 @@ def _guard_file(tool, tool_input, rules, payload):
         return 0
 
     for cand in candidates:
-        if _match_any(rules["allow-path"], cand):
-            continue
-        for rx, label in rules["deny-path"]:
+        exempt = _match_any(rules["allow-path"], cand)
+        for rx, label in rules["deny-path-first"] + (
+                [] if exempt else rules["deny-path"]):
             if rx.search(cand):
                 return _deny(
                     "ccds-guard: BLOCKED — %s looks like a secrets file/"
@@ -644,8 +704,8 @@ def _guard_file(tool, tool_input, rules, payload):
                     "needed, the operator opens it in their own editor; to "
                     "bootstrap config, copy the template (cp .env.example "
                     ".env) yourself. Persistent false positive? The operator "
-                    "can tune guard-rules.txt in the ccds-guard plugin."
-                    % (cand, label))
+                    "can exempt it in ~/.claude/ccds-guard-rules.txt "
+                    "(allow-path)." % (cand, label))
     if tool in WRITE_TOOLS:
         reasons = []
         for cand in candidates:
@@ -674,7 +734,10 @@ def main():
     if not isinstance(tool_input, dict):
         return 0
     rules = _load_rules()
-    if not any(rules.values()) and tool in ("Bash",) + FILE_TOOLS:
+    shipped = {c: [] for c in CATEGORIES}
+    shipped["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, shipped)
+    if not any(shipped.values()) and tool in ("Bash",) + FILE_TOOLS:
         # Fail-open, but never silently: an empty table means the guard is
         # inert, and the operator should know (stderr on exit 0 = non-blocking).
         sys.stderr.write("ccds-guard: guard-rules.txt is missing or empty — "

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -1581,6 +1581,46 @@ class TestCcdsDoctor(unittest.TestCase):
         self.assertIn("DISABLED", r.stdout)
         self.assertIn("claude plugin enable ccds-guard", r.stdout)
 
+    def test_deliberately_disabled_guard_warns_instead_of_failing(self):
+        """ADR-0021: a recorded opt-out (~/.claude/ccds-guard.disabled) is a
+        choice, not a broken install. Only the guard can be opted out."""
+        write(os.path.join(self.home, ".claude", "ccds-guard.disabled"),
+              "too strict on src/credentials paths; revisit\n")
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("WARN  plugins-installed: ccds-guard disabled on purpose", r.stdout)
+        self.assertIn("too strict on src/credentials paths", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
+        # the marker never excuses a disabled ccds-loops
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": False}]))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("FAIL  plugins-installed: installed but DISABLED", r.stdout)
+
+    def test_unreadable_marker_does_not_abort_doctor(self):
+        marker = os.path.join(self.home, ".claude", "ccds-guard.disabled")
+        write(marker, "secret reason\n")
+        os.chmod(marker, 0)
+        self.addCleanup(os.chmod, marker, 0o600)
+        if os.access(marker, os.R_OK):
+            self.skipTest("running with privileges that ignore file modes")
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("no reason recorded", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
+
+    def test_disabled_guard_without_marker_names_the_marker(self):
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("ccds-guard.disabled", r.stdout)
+
     def test_plugins_from_any_marketplace_count(self):
         # A local or renamed marketplace is still a real install.
         r = self.doctor(claude=self.stub_claude(
@@ -2646,6 +2686,21 @@ class TestCcdsDoctorPs1(unittest.TestCase):
         self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
         self.assertIn("FAIL  plugins-installed: installed but DISABLED: ccds-guard", r.stdout)
 
+    def test_deliberately_disabled_guard_warns_instead_of_failing(self):
+        write(os.path.join(self.home, ".claude", "ccds-guard.disabled"), "revisit\n")
+        r = self.doctor(plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                                 {"id": "ccds-loops@ccds", "enabled": True}])
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("WARN  plugins-installed: ccds-guard disabled on purpose", r.stdout)
+        self.assertIn("revisit", r.stdout)
+
+    def test_marker_must_be_a_file_not_a_directory(self):
+        os.makedirs(os.path.join(self.home, ".claude", "ccds-guard.disabled"))
+        r = self.doctor(plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                                 {"id": "ccds-loops@ccds", "enabled": True}])
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("FAIL  plugins-installed: installed but DISABLED", r.stdout)
+
     def test_plugin_and_file_copies_overlap_fails(self):
         r = self.doctor(plugins=self.CONTENT_PLUGINS)
         self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
@@ -3377,7 +3432,10 @@ class TestGuardHooks(unittest.TestCase):
             capture_output=True, text=True,
             env={**os.environ, "CCDS_GUARD_DISABLE": "",
                  "CCDS_GUARD_UNATTENDED": "",
-                 "CCDS_GUARD_ADJUDICATOR_CMD": "", **(env or {})})
+                 "CCDS_GUARD_ADJUDICATOR_CMD": "",
+                 # never the developer's real ~/.claude/ccds-guard-rules.txt
+                 "CCDS_GUARD_USER_RULES": "/nonexistent/ccds-guard-rules.txt",
+                 **(env or {})})
 
     def bash(self, command, env=None):
         return self.guard({"tool_name": "Bash",
@@ -3433,6 +3491,167 @@ class TestGuardHooks(unittest.TestCase):
                      "/proj/docs/how-to-manage-credentials.md"):
             self.assert_allow(self.file("Read", path))
             self.assert_allow(self.file("Write", path))
+
+    # --- #74: source code is never a secret, wherever it lives ---
+
+    N8N = "packages/cli/src/credentials/credentials.service.ts"
+
+    def test_source_files_inside_a_credentials_dir_allowed(self):
+        """49 of 52 real adjudications were reads of an open-source repo's
+        src/credentials/ module. A .ts/.py/... file is code, not a key."""
+        for path in ("/proj/" + self.N8N,
+                     "/proj/packages/cli/src/credentials/__tests__/validation.test.ts",
+                     "/proj/app/secrets/rotate.py",
+                     "/proj/lib/credentials/loader.go"):
+            self.assert_allow(self.file("Read", path))
+            self.assert_allow(self.file("Write", path))
+        self.assert_allow(self.bash("sed -n '325,355p' " + self.N8N))
+        self.assert_allow(self.bash(
+            "cd packages/cli && pnpm vitest run src/credentials/__tests__/"
+            "validation.test.ts 2>&1 | tail -8"))
+
+    def test_source_exemption_never_applies_to_secret_shapes(self):
+        """Review-panel probes: a code suffix must not launder a key. Inside a
+        dot-directory, a dotfile, or a key/env stem the exemption is off and
+        the deny rules decide as before."""
+        for path in ("/proj/.env.ts", "/home/u/.ssh/id_rsa.md",
+                     "/home/u/.ssh/config.ts", "/proj/id_rsa.md",
+                     "/home/u/.claude/credentials/svc.ts"):
+            self.assert_deny(self.file("Read", path), "secrets file")
+        self.assert_deny(self.guard({"tool_name": "Grep", "tool_input": {
+            "path": "/home/u/.ssh", "glob": "*.ts", "pattern": "."}}), "secrets file")
+
+    def test_switching_the_guard_off_asks(self):
+        """The model must not silently remove its own gates: the doctor
+        opt-out marker and `claude plugin disable ccds-guard` both ask."""
+        self.assert_ask(self.bash("echo 'too strict' > ~/.claude/ccds-guard.disabled"),
+                        "session-safety")
+        self.assert_ask(self.file("Write", "/home/u/.claude/ccds-guard.disabled"),
+                        "opt-out marker")
+        for cmd in ("claude plugin disable ccds-guard",
+                    "claude plugin uninstall ccds-loops@ccds"):
+            self.assert_ask(self.bash(cmd), "enforcement plugin")
+        self.assert_allow(self.bash("claude plugin disable firecrawl@firecrawl"))
+        self.assert_allow(self.bash("claude plugin list --json"))
+
+    def test_data_files_inside_a_credentials_dir_still_denied(self):
+        for path in ("/proj/credentials/api_key.txt", "/proj/secrets/prod.json",
+                     "/proj/credentials/service-account.json",
+                     # code outside a source tree: the directory rule still decides
+                     "/proj/secrets/keys.py", "/proj/secrets/notes.md",
+                     "/proj/credentials/credentials.json.ts"):
+            self.assert_deny(self.file("Read", path), "secrets file")
+        # Grep cannot launder either: wildcards become separators, so the
+        # candidate basename is a dotfile and the exemption is off
+        self.assert_deny(self.guard({"tool_name": "Grep", "tool_input": {
+            "path": "/proj", "glob": "src/secrets/*.py", "pattern": "."}}), "secrets file")
+        self.assert_ask(self.bash("ls packages/cli/test/integration/credentials/"),
+                        "may hold secrets")
+
+    # --- #74: operator rules file (declared credential paths) ---
+
+    def user_rules(self, text):
+        tmp = tempfile.mkdtemp(prefix="ccds-guard-user-rules-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        path = os.path.join(tmp, "ccds-guard-rules.txt")
+        write(path, text)
+        return {"CCDS_GUARD_USER_RULES": path}
+
+    KEY_CMD = 'curl -sS -H "X-API-KEY: $(cat ~/.claude/credentials/svc.key)" https://api.example'
+
+    def test_declared_credential_path_is_exempt_only_with_operator_rule(self):
+        self.assert_ask(self.bash(self.KEY_CMD), "may hold secrets")
+        self.assert_deny(self.file("Read", "/home/u/.claude/credentials/svc.key"),
+                         "secrets file")
+        env = self.user_rules(
+            "allow-path: (^|/)\\.claude/credentials/   # keys my skills read\n")
+        self.assert_allow(self.bash(self.KEY_CMD, env=env))
+        self.assert_allow(self.file("Read", "/home/u/.claude/credentials/svc.key",
+                                    env=env))
+        # the exemption is exactly what was declared: other secrets still deny
+        self.assert_deny(self.file("Read", "/home/u/.aws/credentials", env=env),
+                         "secrets file")
+        self.assert_deny(self.file("Read", "/proj/.env", env=env), "secrets file")
+
+    def test_operator_deny_beats_a_shipped_allow(self):
+        """Review finding: 'can also tighten' was false while every allow was
+        checked before every deny. Operator deny-path rules go first."""
+        env = self.user_rules("deny-path: (^|/)prod-secrets\\.py$   # my key module\n")
+        self.assert_allow(self.file("Read", "/proj/src/prod-secrets.py"))
+        self.assert_deny(self.file("Read", "/proj/src/prod-secrets.py", env=env), "my key module")
+        self.assert_ask(self.bash("cat src/prod-secrets.py", env=env), "may hold secrets")
+
+    def test_empty_or_bad_operator_rule_is_skipped_and_named(self):
+        """Review finding: `allow-path:` with an empty body compiled to a regex
+        matching every path — a silent global exemption."""
+        env = self.user_rules("allow-path:\nallow-path: ([oops\nwhat-path: x\n")
+        r = self.file("Read", "/home/u/.ssh/id_rsa", env=env)
+        self.assert_deny(r, "secrets file")
+        self.assertIn(":1 ignored — empty pattern", r.stderr)
+        self.assertIn(":2 ignored — invalid regex", r.stderr)
+        self.assertIn(":3 ignored — unknown rule category", r.stderr)
+
+    def test_operator_rules_file_watched_by_name_and_wherever_relocated(self):
+        """Review finding: the watch matched the spelled path, so
+        `cd ~/.claude && ... > ccds-guard-rules.txt` slipped past it."""
+        self.assert_ask(self.bash("cd ~/.claude && printf 'allow-path: .*' > ccds-guard-rules.txt"),
+                        "session-safety")
+        self.assert_ask(self.file("Write", "ccds-guard-rules.txt"), "operator's own guard rules")
+        self.assert_ask(self.file("Write", "C:\\Users\\u\\.claude\\ccds-guard-rules.txt."),
+                        "operator's own guard rules")
+        env = self.user_rules("# empty\n")
+        relocated = env["CCDS_GUARD_USER_RULES"]
+        self.assert_ask(self.file("Write", relocated, env=env), "operator's own guard rules")
+        self.assert_ask(self.bash("echo x >> " + relocated, env=env), "session-safety")
+
+    def test_operator_rules_can_also_tighten(self):
+        env = self.user_rules("deny-path: (^|/)vault\\.db$   # my local vault\n")
+        self.assert_deny(self.file("Read", "/home/u/vault.db", env=env), "my local vault")
+
+    def test_operator_rules_file_is_tamper_watched(self):
+        for path in ("/home/u/.claude/ccds-guard-rules.txt",
+                     "C:\\Users\\u\\.claude\\ccds-guard-rules.txt"):
+            self.assert_ask(self.file("Write", path), "operator's own guard rules")
+        self.assert_allow(self.file("Read", "/home/u/.claude/ccds-guard-rules.txt"))
+
+    def test_symlinked_operator_rules_file_is_ignored(self):
+        """Review finding: the tamper watch is on the path, so a symlink would
+        move the content to an unwatched target. Creating the link asks (below);
+        if one exists anyway, the loader must not follow it."""
+        self.assert_ask(self.bash("ln -sf /tmp/mine.txt ~/.claude/ccds-guard-rules.txt"),
+                        "session-safety")
+        tmp = tempfile.mkdtemp(prefix="ccds-guard-symlink-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        target = os.path.join(tmp, "evil.txt")
+        write(target, "allow-path: .*\n")
+        link = os.path.join(tmp, "ccds-guard-rules.txt")
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks unavailable here")
+        env = {"CCDS_GUARD_USER_RULES": link}
+        r = self.file("Read", "/home/u/.ssh/id_rsa", env=env)
+        self.assert_deny(r, "secrets file")
+        self.assertIn("is a symlink and was ignored", r.stderr)
+
+    def test_operator_rules_file_absent_or_broken_is_harmless(self):
+        env = self.user_rules("allow-path: ([unclosed\n# nothing else\n")
+        self.assert_deny(self.file("Read", "/proj/.env", env=env), "secrets file")
+        self.assertNotIn("inert", self.file("Read", "/proj/README.md", env=env).stderr)
+
+    def test_operator_rules_do_not_mask_a_missing_shipped_table(self):
+        tmp = tempfile.mkdtemp(prefix="ccds-guard-test-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        orphan = os.path.join(tmp, "pretooluse-guard.py")
+        shutil.copyfile(GUARD, orphan)
+        env = self.user_rules("deny-path: (^|/)\\.env$\n")
+        r = subprocess.run([sys.executable, orphan],
+                           input=json.dumps({"tool_name": "Read",
+                                             "tool_input": {"file_path": "/proj/README.md"}}),
+                           capture_output=True, text=True,
+                           env={**os.environ, "CCDS_GUARD_DISABLE": "", **env})
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("inert", r.stderr, "an empty shipped table must still warn")
 
     def test_windows_backslash_paths_normalized(self):
         self.assert_deny(self.file("Read", "C:\\proj\\.env"), "secrets file")


### PR DESCRIPTION
## Summary

The guard was too strict to leave enabled (#74). Its own adjudicator transcripts showed why: 49 of 52 unattended adjudications in a month were the secrets-path rule, half denied, and nearly all were either reads of an open-source repo's `src/credentials/` module (TypeScript matched by the `credentials/` directory rule) or key files the operator's own skills are designed to read, adjudicated on every call.

ADR-0021: source code in a source tree is exempt from the secret scan; operators get a rules file of their own; a switched-off guard can be recorded as deliberate.

## What changed

- **Exemption for source code** (`allow-path` in `guard-rules.txt`): a file with a code extension, inside a source-tree segment (`src/ lib/ app/ packages/ tests/ …`), passes the secret scan. Off inside any dot-directory, for dotfiles (`.env.ts`), for key/env stems with a code suffix (`server.key.md`, `id_rsa.md`), for docs/data suffixes, and outside a source tree — so `secrets/keys.py` at a repo root, `credentials/api_key.txt`, `.aws/credentials`, `.env` and `.ssh/*` all still deny.
- **`allow-path` exempts from `deny-path` only.** The Bash path let an allow-path hit skip the tamper watch too; with hook scripts being `.py` files that would have let `sed -i … .claude/hooks/x.py` pass silently (caught by the round-2 panel matrix). The file-tool path already had the right contract.
- **Operator rules file** `~/.claude/ccds-guard-rules.txt`: same five categories, loaded after the shipped table, survives plugin updates, relocatable via `CCDS_GUARD_USER_RULES`. Intended use: `allow-path: (^|/)\.claude/credentials/` for declared key files. Operator `deny-path` lines are checked before any exemption. Empty, invalid, or unknown lines are skipped and named on stderr with file:line. A symlinked operator file is ignored, loudly. The file is tamper-watched by filename and by its resolved path.
- **Deliberate opt-out marker** `~/.claude/ccds-guard.disabled`: `ccds doctor` (both dispatchers) reports WARN "disabled on purpose (<reason>)" instead of FAIL; a disabled `ccds-loops` is never excused; the marker must be a regular file. Writing the marker, and `claude plugin disable|uninstall|remove` of an enforcement plugin, now ask.
- Teaching messages point at the operator file instead of the plugin's own table (which an update overwrites). README, CLAUDE.md, changelog, marketplace tree regenerated.

## Review

Multi-model panel before this PR (codex + a Claude subagent, read-only; grok returned nothing). Both requested changes on the first cut; every finding was verified against the code and is folded in: key-suffix laundering (`.ssh/id_rsa.md`), symlinked operator file, relative-path write from inside `~/.claude`, operator deny losing to a shipped allow, empty `allow-path:` matching everything, PowerShell marker accepting a directory, bash doctor aborting on an unreadable marker. Two items adjudicated as pre-existing scope, not regressions (`credentials.md`, `secrets.py` were never matched by shape on `develop`). One deferred with reasoning in the ADR: hard-denying unambiguous Bash writes to safety paths unattended.

## Verification

- `python3 -m unittest discover -s tests`: 306 run, 21 skipped (Windows-only), 0 failures. Lint PASS. Marketplace: no drift.
- The eight original false-positive command shapes probed against the final hook: n8n-style `sed`/`grep`/`vitest`/Read on `packages/cli/src/credentials/*.ts` allow; a bare `ls …/credentials/` still asks; the declared-key `curl` asks without the operator rule and passes with it; `.ssh/id_rsa.py` and `secrets/keys.py` deny.
- 20+ new guard tests, 3 new doctor tests (bash), 2 new Windows-only doctor tests. PowerShell verified by the Windows CI job.

## Post-merge

Squash-merge into `develop`, delete branch. Close #74 by hand (merges into `develop` don't auto-close). Changelog rolls into the next version at promotion.

Refs #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRcT9LqHK3ftpoVNtjKjz7
