### PR TITLE
docs: retitle changelog [Unreleased] as v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## [Unreleased]
+## v0.19.0 — 2026-09-06 — The guard stops fighting you, and the roster stops loading twice
+
+Two things were quietly wrong for everyone. The security guard flagged
+ordinary source code as secrets — 49 of 52 unattended adjudications in a
+month were one rule matching the word `credentials` in a path, and half of
+them were denied — so people switched it off. And anyone who installed both
+the marketplace plugins and the file installer had every agent loaded twice,
+with the stale file copy winning and `ccds doctor` saying PASS. This release
+fixes both, gives operators their own guard rules file for the key files their
+skills legitimately read, lets a deliberate guard opt-out be recorded instead
+of reported as broken, and closes a doctor blind spot that reported a disabled
+guard as enabled. It also adopts a `develop` integration branch (`main` stays
+the default because the plugin marketplace installs from it) and finally gives
+the 19 agents the display colors they were meant to have.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
Rolls the Unreleased entries on `develop` (#69 branch model, #71 dual-install detection + #70 fix, #72 agent alignment, #75 guard fix) into `## v0.19.0 — 2026-09-06` with a stakeholder intro, so the promotion PR and the `v0.19.0` tag match the changelog.

## Verification
Changelog-only change; full suite still passes (306 run, 21 skipped).

## Post-merge
Squash into `develop`; then the promotion PR `develop` → `main` (merge commit, never squash) and tag `v0.19.0` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRcT9LqHK3ftpoVNtjKjz7