### PR TITLE
release: promote develop to main for v0.19.0

### DIFF
--- a/.claude/agents/ai-architect.md
+++ b/.claude/agents/ai-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ai-architect
 model: opus
-color: "#6366f1"
+color: blue
 description: AI / LLM application domain specialist. Use proactively on AI / LLM work — model selection, serving topology, RAG-vs-finetune-vs-prompt, eval strategy, cost/latency budgets, and data policy. Owns AI architecture and composes the ai-* implementation skills.
 ---
 

--- a/.claude/agents/dataplat-architect.md
+++ b/.claude/agents/dataplat-architect.md
@@ -1,7 +1,7 @@
 ---
 name: dataplat-architect
 model: opus
-color: "#0f766e"
+color: cyan
 description: Data Platform domain specialist. Use proactively on data-platform work — warehouse/lakehouse topology, batch vs streaming, partitioning and storage format, governance, ingestion, quality, and serving. Owns data-platform architecture and composes the dataplat-* implementation skills.
 ---
 

--- a/.claude/agents/deploy-checklist.md
+++ b/.claude/agents/deploy-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: deploy-checklist
 model: haiku
-color: "#ff5a1f"
+color: orange
 disallowedTools: Write, Edit, NotebookEdit
 description: Deployment readiness and pre-production checklist specialist. Use proactively before any production deployment, environment promotion, release cut, or go/no-go assessment.
 ---

--- a/.claude/agents/desktop-architect.md
+++ b/.claude/agents/desktop-architect.md
@@ -1,7 +1,7 @@
 ---
 name: desktop-architect
 model: opus
-color: "#92400e"
+color: orange
 description: Desktop App domain specialist. Use proactively on desktop work — runtime choice, process/window model, IPC topology, OS integration, autoupdate, code signing, installers, and shell integration. Owns desktop architecture and composes the desktop-* implementation skills.
 ---
 

--- a/.claude/agents/devtool-architect.md
+++ b/.claude/agents/devtool-architect.md
@@ -1,7 +1,7 @@
 ---
 name: devtool-architect
 model: opus
-color: "#475569"
+color: blue
 description: DevTool / CLI / Library domain specialist. Use proactively on public-surface work — API and CLI surface design, versioning, distribution, extensibility, compatibility, docs, packaging, and telemetry. Owns devtool architecture and composes the devtool-* implementation skills.
 ---
 

--- a/.claude/agents/ecom-architect.md
+++ b/.claude/agents/ecom-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ecom-architect
 model: opus
-color: "#db2777"
+color: pink
 description: E-commerce domain specialist. Use proactively on storefront/checkout/OMS work — catalog vs cart vs order boundary, payment strategy, inventory reservation, tax/shipping, promotions, search, and peak-event scale. Owns e-commerce architecture and composes the ecom-* implementation skills.
 ---
 

--- a/.claude/agents/embed-architect.md
+++ b/.claude/agents/embed-architect.md
@@ -1,7 +1,7 @@
 ---
 name: embed-architect
 model: opus
-color: "#78350f"
+color: orange
 description: Embedded / IoT domain specialist. Use proactively on embedded / firmware / IoT work — SoC/MCU choice, RTOS vs bare-metal, memory/flash layout, secure boot chain, A/B partitioning, fleet OTA topology, and provisioning/attestation. Owns embedded architecture and composes the embed-* implementation skills.
 ---
 

--- a/.claude/agents/ext-architect.md
+++ b/.claude/agents/ext-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ext-architect
 model: opus
-color: "#4338ca"
+color: blue
 description: Browser extension domain specialist. Use proactively on browser-extension work — manifest version (MV3), permissions model, background/service-worker/content-script split, cross-browser strategy, store-review posture, and native-host bridges. Owns browser-extension architecture and composes the ext-* implementation skills.
 ---
 

--- a/.claude/agents/fintech-architect.md
+++ b/.claude/agents/fintech-architect.md
@@ -1,7 +1,7 @@
 ---
 name: fintech-architect
 model: opus
-color: "#365314"
+color: green
 description: Fintech domain specialist. Use proactively on regulated-money work — ledger topology, custody, KYC/AML and licensing, money-movement primitives, reconciliation, audit retention, and risk. Owns fintech architecture and composes the fintech-* implementation skills.
 ---
 

--- a/.claude/agents/game-architect.md
+++ b/.claude/agents/game-architect.md
@@ -1,7 +1,7 @@
 ---
 name: game-architect
 model: opus
-color: "#ea580c"
+color: orange
 description: Game domain specialist. Use proactively on game work — engine selection, core game loop, state architecture, asset pipeline, save/load topology, and platform-target strategy. Owns game architecture and composes the game-* implementation skills.
 ---
 

--- a/.claude/agents/infra-architect.md
+++ b/.claude/agents/infra-architect.md
@@ -1,7 +1,7 @@
 ---
 name: infra-architect
 model: opus
-color: "#334155"
+color: blue
 description: Infrastructure / dev-platform domain specialist. Use proactively on infra / platform work — cloud topology, network segmentation, environments, IaC strategy, secrets topology, and platform tenancy. Owns infrastructure architecture and composes the infra-* implementation skills.
 ---
 

--- a/.claude/agents/media-architect.md
+++ b/.claude/agents/media-architect.md
@@ -1,7 +1,7 @@
 ---
 name: media-architect
 model: opus
-color: "#0369a1"
+color: cyan
 description: Media / streaming domain specialist. Use proactively on media / streaming work — ingest → process → store → deliver pipeline, codec/container strategy, VOD vs live topology, DRM posture, CDN strategy, and QoE. Owns media architecture and composes the media-* implementation skills.
 ---
 

--- a/.claude/agents/mobile-architect.md
+++ b/.claude/agents/mobile-architect.md
@@ -1,7 +1,7 @@
 ---
 name: mobile-architect
 model: opus
-color: "#2563eb"
+color: blue
 description: Mobile domain specialist. Use proactively on iOS / Android work — framework choice, offline posture, background-execution strategy, release topology, and privacy posture. Owns mobile architecture and composes the mobile-* implementation skills.
 ---
 

--- a/.claude/agents/orch-architect.md
+++ b/.claude/agents/orch-architect.md
@@ -1,7 +1,7 @@
 ---
 name: orch-architect
 model: opus
-color: "#be123c"
+color: red
 description: Agent / orchestration domain specialist. Use proactively on agent / orchestration work — agent topology, tool-use contract, memory model, planning/looping control, sandbox boundaries, and eval strategy. Owns orchestration architecture and composes the orch-* implementation skills.
 ---
 

--- a/.claude/agents/plan-architect.md
+++ b/.claude/agents/plan-architect.md
@@ -1,7 +1,7 @@
 ---
 name: plan-architect
 model: opus
-color: "#1a56db"
+color: blue
 description: Universal system design and architecture planning specialist. Use proactively when defining component boundaries, data flows, integration patterns, or making major structural decisions before or during implementation.
 ---
 
@@ -35,7 +35,7 @@ You do NOT own:
 
 ## Approach
 
-1. **Understand constraints first** — ask about scale requirements, team size, deployment target, and non-functional requirements before proposing a design
+1. **Pin the constraints first** — scale requirements, team size, deployment target, and non-functional requirements. Use what the task and the repo give you; where they are silent, state the assumption you are designing under and proceed. List only the open questions whose answers would change the design, for the orchestrator to take back to the user — you cannot ask them yourself
 2. **Prefer simplicity** — recommend the least complex architecture that satisfies requirements; avoid over-engineering
 3. **Make trade-offs explicit** — present 2–3 options with clear pros/cons rather than a single opinionated answer when the choice is genuinely context-dependent
 4. **Design for change** — favor designs that isolate likely change points behind abstractions

--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-code-reviewer
 model: sonnet
-color: "#7e3af2"
+color: purple
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - code-review-checklist

--- a/.claude/agents/saas-architect.md
+++ b/.claude/agents/saas-architect.md
@@ -1,7 +1,7 @@
 ---
 name: saas-architect
 model: opus
-color: "#0ea5e9"
+color: cyan
 description: SaaS domain specialist. Use proactively on multi-tenant / productivity web-app work — tenancy model, data isolation, billing topology, entitlements, auth/SSO, realtime collab, and horizontal-scale decisions. Owns SaaS architecture and composes the saas-* implementation skills.
 ---
 
@@ -46,9 +46,12 @@ them yourself):
 
 ## Approach
 
-1. **Clarify constraints first** — B2B or B2C; tenant count and size distribution (the
+1. **Pin the constraints first** — B2B or B2C; tenant count and size distribution (the
    largest 10% dominates); compliance scope (SOC 2, HIPAA, PCI, GDPR); residency;
-   self-service vs sales-led; seats per tenant.
+   self-service vs sales-led; seats per tenant. Take them from the task and the repo;
+   where those are silent, state the assumption you are designing under and proceed,
+   and list only the open questions whose answers would change the topology for the
+   orchestrator to take back to the user — you cannot ask them yourself.
 2. **Start from the hardest-to-reverse decision** — tenancy model and identity topology
    shape everything downstream. Lock them first.
 3. **Present trade-offs explicitly** — 2–3 viable topologies with pros, cons, operational

--- a/.claude/agents/secure-auditor.md
+++ b/.claude/agents/secure-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: secure-auditor
 model: opus
-color: "#e3a008"
+color: yellow
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - security-checklist

--- a/.claude/agents/test-writer-runner.md
+++ b/.claude/agents/test-writer-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-writer-runner
 model: sonnet
-color: "#057a55"
+color: green
 description: Test writing and execution specialist. Use proactively after implementation is complete, after a PR review resolves issues, or when test coverage for a module or feature needs improving.
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,30 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read
 
 jobs:
+  promotion-only:
+    name: main accepts only develop
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-promotion PRs into main (ADR-0019)
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::PRs into main must have develop as their head branch (ADR-0019). Retarget this PR at develop: gh pr edit --base develop"
+            exit 1
+          fi
+          echo "promotion PR develop -> main: ok"
+
   verify-agents-nix:
     name: Verify agents (Linux)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ---
 
-## [Unreleased]
+## v0.19.0 — 2026-09-06 — The guard stops fighting you, and the roster stops loading twice
+
+Two things were quietly wrong for everyone. The security guard flagged
+ordinary source code as secrets — 49 of 52 unattended adjudications in a
+month were one rule matching the word `credentials` in a path, and half of
+them were denied — so people switched it off. And anyone who installed both
+the marketplace plugins and the file installer had every agent loaded twice,
+with the stale file copy winning and `ccds doctor` saying PASS. This release
+fixes both, gives operators their own guard rules file for the key files their
+skills legitimately read, lets a deliberate guard opt-out be recorded instead
+of reported as broken, and closes a doctor blind spot that reported a disabled
+guard as enabled. It also adopts a `develop` integration branch (`main` stays
+the default because the plugin marketplace installs from it) and finally gives
+the 19 agents the display colors they were meant to have.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ## [Unreleased]
 
+### Added
+
+- **`ccds doctor` now catches the double-loaded roster, and setup no longer
+  creates it** (ADR-0020). The 19 agents and cross-cutting skills reach Claude
+  Code either from the ccds plugins or from file copies in `~/.claude`; having
+  both means every agent is in the roster twice, with the stale file copy owning
+  the bare name. A new `plugin-file-overlap` check fails in that state and prints
+  the exact removal command (both dispatchers, first behavioral tests for the
+  PowerShell doctor). `ccds setup`, `ccds.ps1 setup` and `Install-Playbook.ps1`
+  skip the file copies when a content plugin is enabled and name any stale
+  copies instead of deleting them. `agents-installed` / `skills-installed`
+  report the plugin as the source when `ccds-core` is enabled.
+
 ### Fixed
+
+- **`ccds doctor` reported a DISABLED `ccds-guard` as enabled** (#70). The bash
+  check split `claude plugin list --json` into objects and looked for
+  `"enabled": false` on the same line as the plugin id — but the real CLI
+  pretty-prints one field per line, so the disabled branch could never match on
+  real output. The test stub emitted flat JSON, which is why the suite passed.
+  Newlines are now collapsed before splitting, the stub pretty-prints like the
+  CLI, and a regression test covers the disabled case on both platforms.
 
 - **`build-release.ps1` could build a structurally broken release ZIP without
   a single warning.** Entry names are produced by trimming the stage path off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent `color:` values are now the eight names Claude Code accepts** (`red`,
+  `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, `cyan`). All 19 agents
+  carried hex values, which the sub-agents reference does not list, so the field
+  was silently ignored and every ccds agent rendered in the default color. A new
+  `agent-colors` lint check keeps it that way.
+- **`plan-architect` and `saas-architect` no longer "ask about constraints
+  first".** A subagent cannot converse with the user; that step returned a
+  question as the whole result and wasted the dispatch. They now take constraints
+  from the task and the repo, state the assumptions they design under where those
+  are silent, and hand back only the questions whose answers would change the
+  design — the shape the Claude 5 prompting guidance recommends for autonomous
+  work.
+
 ### Added
 
 - **`ccds doctor` now catches the double-loaded roster, and setup no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Infrastructure
 
+- **The repo now has a `develop` integration branch; `main` is release-only and
+  stays the GitHub default** (ADR-0019). Feature PRs target `develop`
+  (`gh pr create --base develop`); `main` only receives `develop` → `main`
+  promotion PRs, merged without squashing and tagged. `main` has to remain the
+  default branch because `/plugin marketplace add` installs from the default
+  branch — flipping it would have shipped unreleased code to every marketplace
+  user. CI now runs on both branches, and a new `promotion-only` check fails
+  any PR into `main` that does not come from `develop`.
 - **Both release builders are now run for real in the test suite, and what they
   produce is asserted** (ADR-0017 amendment). The `release-parity` lint added
   in v0.18.0 proves the two builders' copy *lists* agree; nothing proved either

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ New sessions should read this file first to get up to speed before doing anythin
 
 ### Added
 
+- **The guard takes operator rules and a deliberate opt-out** (ADR-0021).
+  `~/.claude/ccds-guard-rules.txt` accepts the same five rule categories as the
+  shipped table, loads after it, survives plugin updates, and is tamper-watched
+  — its intended use is `allow-path: (^|/)\.claude/credentials/` to declare the
+  key files your own skills read, so they stop being adjudicated on every call.
+  `~/.claude/ccds-guard.disabled` (first line = reason) makes `ccds doctor`
+  report a switched-off guard as WARN "disabled on purpose" instead of FAIL.
+  Switching the guard off now asks first: writing that marker, and
+  `claude plugin disable|uninstall|remove` of an enforcement plugin, are
+  tamper-watched like settings writes.
+
 - **`ccds doctor` now catches the double-loaded roster, and setup no longer
   creates it** (ADR-0020). The 19 agents and cross-cutting skills reach Claude
   Code either from the ccds plugins or from file copies in `~/.claude`; having
@@ -36,6 +47,22 @@ New sessions should read this file first to get up to speed before doing anythin
   report the plugin as the source when `ccds-core` is enabled.
 
 ### Fixed
+
+- **The guard flagged source code as secrets** (#74). Evidence from a month of
+  unattended adjudications: 49 of 52 were the secrets-path rule, and half were
+  denied — nearly all reads of an open-source repo's `src/credentials/` module
+  (TypeScript, matched by the `credentials/` directory rule) or key files the
+  operator's own skills are designed to read. Source-code files inside a
+  source tree (`src/`, `lib/`, `packages/`, `tests/` …) are now exempt from
+  the secret scan, while data files in a `credentials/` or `secrets/`
+  directory, code outside a source tree, dotfiles, anything under a
+  dot-directory, and key stems with a code suffix (`server.key.md`) still
+  block. Reviewed by a three-model panel before merge; its findings are folded
+  in (operator deny rules beat shipped exemptions, empty rules are rejected,
+  the watches match by filename, a symlinked operator file is ignored). Found on the way: in a
+  Bash command an `allow-path` hit also skipped the tamper watch, so with the
+  new exemption `sed -i … .claude/hooks/x.py` would have passed silently; the
+  Bash path now exempts from the secret scan only, matching the file-tool path.
 
 - **`ccds doctor` reported a DISABLED `ccds-guard` as enabled** (#70). The bash
   check split `claude plugin list --json` into objects and looked for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,9 @@ postinst, `ccds setup`, `ccds sync`'s first run, and the installers all funnel t
 (ADR-0016). Put outlet-wide install behavior there, never in an installer.
 `ccds-loops` carries the process-enforcement hooks (ADR-0011) and
 `ccds-guard` the zero-config security guard (secret-path denies, dangerous-command
-blocks, install ask-gate, config tamper watch; rules in `hooks/guard-rules.txt`, kill
-switch `CCDS_GUARD_DISABLE=1`; in unattended/auto-accept sessions ask-gates are decided
+blocks, install ask-gate, config tamper watch; rules in `hooks/guard-rules.txt`,
+operator additions in `~/.claude/ccds-guard-rules.txt` (ADR-0021), kill switch
+`CCDS_GUARD_DISABLE=1`, deliberate opt-out marker `~/.claude/ccds-guard.disabled`; in unattended/auto-accept sessions ask-gates are decided
 by a fresh-context LLM adjudicator instead of a prompt, except safety-config writes,
 which deny outright — ADR-0015). That adjudicator sets the project's **minimum Claude
 Code version, v2.1.169** (the release that added `--safe-mode`); its three isolation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,15 @@ skills — no domain agent; skills-only, like `common-`).
 
 ## Conventions
 
+- **Branch model (ADR-0019):** `develop` is the integration branch — cut every
+  feature/fix/docs branch from it and open the PR against it with an explicit
+  `gh pr create --base develop`. `main` is the release branch **and stays the GitHub
+  default branch**: `/plugin marketplace add ggrace519/claude-code-dev-studio` clones
+  and updates from the repository's default branch, so whatever `main` holds is what
+  every marketplace user installs. Promotion is a `develop` → `main` PR, merged as a
+  merge commit or fast-forward (never squash), then tagged on `main`. CI runs on both
+  branches, and the `promotion-only` job rejects any PR into `main` whose head is not
+  `develop`.
 - **Decisions are logged.** Every significant architectural/security/process decision is
   an ADR in `DECISIONS.md`. The shared `playbook-conventions` skill carries the ADR
   template and the output/handoff format — agents pull it rather than restating it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,10 +157,11 @@ skills — no domain agent; skills-only, like `common-`).
   `PATH`; `TestReleaseZipPs1` runs `build-release.ps1` unmodified on Windows).
 - **The suite runs on both platforms** (ADR-0018): `python3 -m unittest discover -s
   tests` on Linux, and the same command under Windows Python in CI. Sessions here run
-  in WSL on a Windows box, so both are reachable locally — `python.exe -m unittest
-  discover -s tests` runs the Windows half against the same checkout. Platform-specific
-  classes guard on `sys.platform`; never "cover" a platform by running one hand-picked
-  class on it.
+  on native Debian (since 2026-08-14; the WSL-on-Windows setup ADR-0018 describes is
+  gone), so the Windows half — `TestInstallPlaybookPs1`, `TestReleaseZipPs1`,
+  `TestCcdsDoctorPs1` — is verified by the `windows-latest` CI job, not locally.
+  Platform-specific classes guard on `sys.platform`; never "cover" a platform by
+  running one hand-picked class on it.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ its `<pack>-*` skills in a single coherent context. See `DECISIONS.md` ADR-0007.
 
 | Layer | Location | Loaded | Notes |
 |---|---|---|---|
-| 19 agents | `~/.claude/agents/` | always (session start) | 14 domain + 5 core; ~850 tokens of descriptions |
+| 19 agents | plugins (`ccds-core` + packs) **or** `~/.claude/agents/` — never both (ADR-0020) | always (session start) | 14 domain + 5 core; ~850 tokens of descriptions |
 | Cross-cutting skills | `~/.claude/skills/` | descriptions always; body JIT | `playbook-conventions`, `api-design`, `ux-design`, `security-checklist`, `code-review-checklist`, `inventive-engineer`, `common-*`, `loop-*` |
 | Domain skills | `~/.claude/playbook/skills/` → `.claude/skills/` | per project (JIT) | `<pack>-*`; staged by `ccds sync` (via the `sync-agents` skill) |
 | Gate templates | `~/.claude/playbook/templates/` → project files | per project (with sync) | settings denies, CLAUDE.md standards, pre-commit, CI — stack-matched via `stack-matrix.json`, never-destroy (ADR-0013); skip with `--no-gates` |

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1944,3 +1944,117 @@ run; naming the command is enough and reversible.
 ### Supersedes
 
 None.
+
+---
+
+## ADR-0021: The Guard Exempts Source Code and Takes Operator Rules
+
+**Date:** 2026-09-06
+**Status:** Accepted
+**Phase:** Hardening
+**Deciders:** Greg Grace
+
+### Context
+
+The guard was too strict to leave on: the maintainer disabled it (#74). The
+adjudicator's own transcripts showed why — 49 of 52 unattended adjudications
+in a month were the secrets-path rule, and the judge denied half of them. Two
+patterns accounted for nearly all hits: reads of an open-source repo's
+`src/credentials/` module (TypeScript files matched by the `credentials/`
+directory rule that ADR-0012's review round had deliberately restored), and
+key files the operator's own skills are designed to read, adjudicated on
+every single call because nothing let the operator declare them.
+
+A third, smaller issue: `ccds doctor` reports a disabled guard as FAIL by
+design (ADR-0016), which is right for an accidental state and wrong for a
+recorded decision.
+
+### Decision
+
+1. **Source code is exempt from the secret scan wherever it lives.** A new
+   `allow-path` for source extensions (`.ts .py .go .rs .java .md …`) means
+   `credentials/credentials.service.ts` passes while `credentials/api_key.txt`
+   and `credentials/service-account.json` still deny. The `credentials/` and
+   `secrets/` directory rules stay — narrowing them to dot-directories was
+   considered and rejected because it would have let data files in a repo's
+   `credentials/` through.
+2. **`allow-path` exempts from `deny-path` only.** The Bash path had let an
+   allow-path hit skip the tamper watch too; with hook scripts being `.py`
+   files, the new exemption made `sed -i … .claude/hooks/x.py` pass silently
+   until the panel matrix caught it. The file-tool path already had the
+   right contract; the Bash path now matches it.
+3. **Operator rules file** `~/.claude/ccds-guard-rules.txt`: same five
+   categories, loaded after the shipped table, never overwritten by a plugin
+   update, relocatable via `CCDS_GUARD_USER_RULES` (test seam). Declaring
+   `allow-path: (^|/)\.claude/credentials/` is the intended use; it can also
+   tighten. The file is tamper-watched (`ask-write-path`), so the model
+   cannot add an exemption silently — unattended, that write denies outright
+   like every other safety-config write. Operator rules never mask an empty
+   shipped table (the inert warning keys on the shipped file alone).
+4. **Deliberate opt-out marker** `~/.claude/ccds-guard.disabled`: with it
+   present and only `ccds-guard` disabled, doctor reports WARN "disabled on
+   purpose (<first line>)" instead of FAIL, in both dispatchers. A disabled
+   `ccds-loops` is never excused. Writing the marker asks (tamper watch), and
+   so does `claude plugin disable|uninstall|remove` of an enforcement plugin
+   — a gap the review probes found: the CLI edits settings.json out of the
+   guard's sight, so the command text itself is the only place to catch it.
+5. **The exemption cannot launder a key.** Review probes showed the first cut
+   let `.ssh/id_rsa.md`, `.ssh/config.ts` and `.env.ts` through. The
+   exemption is now off inside any dot-directory, for any dotfile, and for
+   key/env stems with a code suffix (`server.key.md`, `id_rsa.md`). Files the
+   shipped table never matched by shape (`credentials.md`, `backend.env.ts`)
+   remain out of scope, as before: the guard classifies by shape, not content.
+6. **A symlinked operator file is ignored, loudly.** The tamper watch is on
+   the path; a symlink would move the effective content to a target the watch
+   never sees (creating the link asks once, later writes to the target would
+   not — review finding). The loader refuses a symlink at the operator path
+   and says so on stderr; a symlinked `~/.claude` *directory* (dotfiles
+   managers) is still fine, since only the file itself is checked.
+
+7. **Review-panel refinements** (codex + a Claude reviewer, both read-only,
+   both REQUEST CHANGES on the first cut; grok returned nothing): the
+   exemption additionally requires a source-tree segment (`src/ lib/ app/
+   packages/ tests/ …`), so `secrets/keys.py` at a repo root denies as
+   before while `packages/cli/src/credentials/x.ts` passes; docs/data
+   suffixes (`.md .rst .sql`) are not exempt; operator `deny-path` rules are
+   checked before any exemption, so "can also tighten" is true; an empty rule
+   body (`allow-path:` alone would match every path), an invalid regex, or an
+   unknown category in the operator file is skipped and named on stderr with
+   file:line; the two tamper watches match by filename (and by the resolved
+   `CCDS_GUARD_USER_RULES` path), so `cd ~/.claude && … > ccds-guard-rules.txt`
+   and Windows trailing-dot aliases ask; the doctor marker must be a regular
+   file (PowerShell `-PathType Leaf`) and an unreadable one no longer aborts
+   the bash doctor under `pipefail`.
+
+### Rationale
+
+Telling the adjudicator about declared paths was the alternative for (3);
+exempting them before the scan is simpler and cheaper, and keeps the judge's
+"on its face" contract intact. Extension-based exemption over
+directory-narrowing (1) keeps the panel's earlier decision where it was
+right (data files in `credentials/`) and removes it only where the evidence
+showed it wrong (code). The allow-path contract fix (2) is a correctness
+change independent of the evidence and would have been needed anyway.
+
+### Consequences
+
+- Of the 49 real hits, every source read and every declared-key call clears;
+  a bare `ls …/credentials/` still asks (one hit), and reads of
+  `~/.aws/credentials`, `.env`, `.ssh` are unchanged.
+- The teaching messages now point at the operator file, not the plugin's
+  own rules table (which an update overwrites).
+- Follow-on: a `ccds guard` subcommand to add/list operator rules is
+  possible; not needed for the fix.
+- Follow-on (review finding, deliberately not in this change): in the Bash
+  path an unambiguous WRITE to a safety path (`> file`, `>>`, `tee`) is still
+  adjudicated unattended rather than denied outright like a file-tool write,
+  because a name in a command line does not prove a write (ADR-0015 comment).
+  Classifying redirection targets and `tee` arguments as tamper writes is a
+  precise improvement worth its own change and tests.
+- Known limitation, unchanged: shell quoting/concatenation
+  (`ccds-guard-rules'.txt'`) defeats every regex-over-string rule in the table
+  (ADR-0012 threat model, pinned by `test_known_limitation_quoting_bypasses_pinned`).
+
+### Supersedes
+
+None (amends ADR-0012's rule table and ADR-0016's doctor contract).

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1796,3 +1796,77 @@ existing rather than trusting one developer's box:
 
 ### Supersedes
 None.
+
+---
+
+## ADR-0019: `develop` Integrates, `main` Releases and Stays the Default Branch
+
+**Date:** 2026-09-06
+**Status:** Accepted
+**Phase:** Deployment
+**Deciders:** Greg Grace
+
+### Context
+
+Until now the repo had one long-lived branch. Every feature PR targeted `main`,
+so `main` was simultaneously the integration branch and the branch that
+`/plugin marketplace add ggrace519/claude-code-dev-studio` installs from. Any
+merged-but-unreleased change was immediately live for every marketplace user.
+
+The standing convention across Greg's repos is a two-branch model: `develop`
+for integration, `main` for what is released, with `develop` set as the GitHub
+default branch so PRs, clones, and the UI target it. Applying that here hit a
+conflict specific to this repo: **the default branch is a distribution
+channel.** The Claude Code plugin-marketplaces documentation states that a
+marketplace source's `ref` "defaults to repository default branch", and that a
+marketplace added without a ref updates from the default branch. The local
+evidence agrees — the marketplace clone on this machine
+(`~/.claude/plugins/marketplaces/ccds`) is a shallow clone whose only fetch
+refspec is `+refs/heads/main:refs/remotes/origin/main`, i.e. whatever the
+default branch was at add time. Making `develop` the default would have put
+every new install, and existing installs on their next `marketplace update`,
+onto unreleased code.
+
+### Decision
+
+1. **`develop` is the integration branch.** Every feature/fix/docs branch is
+   cut from it and its PR targets it. Because `develop` is *not* the default
+   branch, the PR base must be passed explicitly: `gh pr create --base develop`.
+2. **`main` is the release branch and remains the GitHub default branch.**
+   Only promotion PRs (`develop` as head, `main` as base) land on it, merged as
+   a merge commit or fast-forward — never squash, which would diverge the two
+   branches and make every later promotion conflict. Releases are tagged on
+   `main`.
+3. **CI covers both.** `ci.yml` triggers on pushes and PRs to `main` *and*
+   `develop`. A `promotion-only` job fails any PR into `main` whose head branch
+   is not `develop`, so a mis-targeted feature PR is caught by a red check
+   rather than by someone noticing.
+4. **`develop` is never deleted** and must always be promotable — nothing
+   known-broken lands on it; unfinished work stays on a stacked branch.
+
+### Rationale
+
+Pinning the marketplace source to `@main` everywhere it is written down was
+considered and rejected: it fixes only the invocations this repo controls,
+while the unpinned form already exists in earlier changelog entries, in
+`known_marketplaces.json` on every existing install, and anywhere the
+one-liner has been copied. Keeping `main` as the default makes the unpinned
+form correct by construction. The cost — one `--base develop` flag on PR
+creation — is small and is backstopped by the CI guard.
+
+### Consequences
+
+- Changelog entries accumulate under `## [Unreleased]` on `develop`; the
+  promotion PR rolls them into the dated version heading that matches the tag.
+- The raw-URL installer one-liners (`.../main/install-playbook.sh`,
+  `.../main/Install-Playbook.ps1`) and the marketplace source stay exactly as
+  documented — they already name `main` and now mean "released".
+- Stacked PRs still get no CI (a known limitation noted in v0.17.0 notes);
+  the base branch for stacks is the parent branch, not `develop`.
+- Follow-on: if the marketplace source is ever made pinnable in the
+  installers (`owner/repo@main`), that is an optional hardening, not a
+  requirement of this model.
+
+### Supersedes
+
+None.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1870,3 +1870,77 @@ creation — is small and is backstopped by the CI guard.
 ### Supersedes
 
 None.
+
+---
+
+## ADR-0020: The Always-On Roster Has One Source — Plugins or File Copies, Never Both
+
+**Date:** 2026-09-06
+**Status:** Accepted
+**Phase:** Deployment
+**Deciders:** Greg Grace
+
+### Context
+
+ccds ships the same 19 agents and 18 cross-cutting skills by two routes: the
+plugin marketplace (`ccds-core` + one plugin per archetype pack) and the file
+installers, which copy them into `~/.claude/agents/` and `~/.claude/skills/`.
+The README presented the ZIP route as "additionally" providing the CLI and
+library, and nothing stopped a user from having both. Claude Code loads both:
+every agent then appears twice in the roster (`plan-architect` and
+`ccds-core:plan-architect`), the router sees two identical descriptions, the
+file copy owns the bare name, and the ~850 tokens of agent descriptions plus
+the skill listing are paid twice. The file copies also go stale the moment the
+plugins update, because only the plugins auto-update.
+
+This was found on the maintainer's own machine, where a v0.11.0 file install
+had sat under current marketplace plugins for weeks — and `ccds doctor` said
+PASS, because it checked each route in isolation. The same investigation found
+#70: the bash doctor's disabled-plugin branch could never match the real
+`claude plugin list --json`, which pretty-prints one field per line, so a
+disabled `ccds-guard` was reported as enabled.
+
+### Decision
+
+1. **One source.** The always-on agents and cross-cutting skills come from the
+   ccds content plugins *or* from file copies, never both. The enforcement
+   plugins (`ccds-guard`, `ccds-loops`) are orthogonal: hooks ship only via
+   plugins (ADR-0012) and every route installs them.
+2. **Setup gates the copies.** `ccds-user-setup.sh`, `ccds.ps1 setup` and
+   `Install-Playbook.ps1` probe `claude plugin list --json` (read-only; skipped
+   under `--skip-plugins`, which means "never touch the CLI", and under
+   `--dry-run`). If any content plugin is enabled, steps 1/1b are skipped with
+   a one-line explanation, and stale copies are named with the exact removal
+   command. Setup never deletes a user's files.
+3. **Doctor sees both routes.** `agents-installed` and `skills-installed`
+   report the plugin as the source when `ccds-core` is enabled, and their FAIL
+   remedies name both fixes. A new `plugin-file-overlap` check FAILs when a
+   content plugin is enabled and ccds-owned copies (names from `catalog.json`)
+   are present, printing the removal command; it WARNs when the CLI cannot be
+   read. Both dispatchers, same 12-check contract.
+4. **Parsers collapse newlines first** (bash `tr -d '\n\r'`, PowerShell
+   `-join` before `ConvertFrom-Json`), and the test stubs pretty-print their
+   JSON so the suite exercises the real shape. Fixes #70.
+
+### Rationale
+
+Removing the file route entirely was considered: the CLI and per-project
+`ccds sync` still need the library on disk, and .deb/.rpm users have no
+marketplace step, so the file route stays. Making setup delete stale copies was
+rejected: the installers must never remove files they did not write in this
+run; naming the command is enough and reversible.
+
+### Consequences
+
+- A file-route user who later installs `ccds-core@ccds` gets a doctor FAIL
+  with the removal command, not a silent double roster.
+- The `~/.claude/CLAUDE.md` ccds block no longer claims the agents "live in
+  `~/.claude/agents/`"; it names both routes.
+- First behavioral coverage of `ccds.ps1 doctor` (Windows CI job).
+- Follow-on: `ccds doctor` could compare the file-install version against the
+  marketplace commit to flag a stale file route even when no plugin is
+  enabled; not done here.
+
+### Supersedes
+
+None.

--- a/Install-Playbook.ps1
+++ b/Install-Playbook.ps1
@@ -151,6 +151,61 @@ $Script:MarketplaceSource = if ($env:CCDS_MARKETPLACE_SOURCE) {
 } else { "$Script:Owner/$Script:Repo" }
 $Script:ClaudeCmd = if ($env:CCDS_CLAUDE_CMD) { $env:CCDS_CLAUDE_CMD } else { 'claude' }
 
+# ADR-0020: the always-on agents and cross-cutting skills reach Claude Code by
+# ONE of two routes -- the ccds content plugins (ccds-core + the archetype
+# packs) or the file copies this installer writes. Both at once loads every
+# agent twice. Returns the enabled content-plugin names (empty when none, or
+# when the CLI is absent/unreadable -- then the file route is taken and
+# `ccds doctor` reports any overlap). Read-only probe.
+function Get-EnabledContentPlugins {
+    $names = @()
+    if (-not (Get-Command $Script:ClaudeCmd -ErrorAction SilentlyContinue)) { return $names }
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        # Join first: the real CLI pretty-prints one field per line.
+        $raw = @(& $Script:ClaudeCmd plugin list --json 2>$null) -join "`n"
+        if (-not $raw.Trim()) { return $names }
+        foreach ($pl in @($raw | ConvertFrom-Json)) {
+            if ($null -eq $pl -or -not $pl.enabled) { continue }
+            if ("$($pl.id)" -match '^(ccds-[a-z]+)@') {
+                $n = $Matches[1]
+                if ($n -ne 'ccds-guard' -and $n -ne 'ccds-loops') { $names += $n }
+            }
+        }
+    } catch {
+        return @()
+    } finally {
+        $ErrorActionPreference = $prevEap
+    }
+    return @($names | Sort-Object -Unique)
+}
+
+# Stale file copies next to enabled plugins: say so with the exact removal
+# command, but never delete a user's files from the installer.
+function Show-StaleFileCopies {
+    param([string]$Prefix)
+    $agentsDir = Join-Path $env:USERPROFILE '.claude\agents'
+    $skillsDir = Join-Path $env:USERPROFILE '.claude\skills'
+    $srcDir    = Join-Path $Prefix 'agents'
+    $staleAgents = @()
+    if (Test-Path $srcDir) {
+        $staleAgents = @(Get-ChildItem -LiteralPath $srcDir -Filter *.md -File -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path -LiteralPath (Join-Path $agentsDir $_.Name) } | ForEach-Object { $_.Name })
+    }
+    $staleSkills = @($Script:GlobalSkills | Where-Object { Test-Path -LiteralPath (Join-Path $skillsDir "$_\SKILL.md") })
+    if ($staleAgents.Count -eq 0 -and $staleSkills.Count -eq 0) { return }
+    Write-WarnMsg "File copies from an earlier install are still present and are loaded in ADDITION to the plugins:"
+    Write-WarnMsg "  $($staleAgents.Count) agent file(s) in $agentsDir, $($staleSkills.Count) cross-cutting skill(s) in $skillsDir"
+    Write-WarnMsg "Remove them (the plugins keep working):"
+    if ($staleAgents.Count -gt 0) {
+        Write-WarnMsg ("  Remove-Item -Force " + (($staleAgents | ForEach-Object { "'" + (Join-Path $agentsDir $_) + "'" }) -join ', '))
+    }
+    if ($staleSkills.Count -gt 0) {
+        Write-WarnMsg ("  Remove-Item -Recurse -Force " + (($staleSkills | ForEach-Object { "'" + (Join-Path $skillsDir $_) + "'" }) -join ', '))
+    }
+}
+
 function Get-CcdsProfilePath {
     if ($env:CCDS_PS_PROFILE) { return $env:CCDS_PS_PROFILE }
     return $PROFILE.CurrentUserAllHosts
@@ -780,13 +835,23 @@ try {
         (Get-Content $installedVersionFile -Raw).Trim()
     } else { $resolvedTag }
 
-    # Copy all 19 always-on agents to ~/.claude/agents/ (always-loaded by Claude Code)
-    Write-Step "Installing always-on agents to $(Join-Path $env:USERPROFILE '.claude\agents')"
-    Install-AlwaysOnAgents -Prefix $Prefix -DryRun:$DryRun
+    # ADR-0020: plugins OR file copies, never both. -SkipPlugins means "never
+    # touch the claude CLI", so the probe is skipped with it too.
+    $contentPlugins = @()
+    if (-not $SkipPlugins) { $contentPlugins = @(Get-EnabledContentPlugins) }
+    if ($contentPlugins.Count -gt 0) {
+        Write-Step "Always-on agents and cross-cutting skills"
+        Write-OkMsg "Supplied by enabled plugin(s): $($contentPlugins -join ' ') -- skipping the file copies so Claude Code does not load the roster twice"
+        Show-StaleFileCopies -Prefix $Prefix
+    } else {
+        # Copy all 19 always-on agents to ~/.claude/agents/ (always-loaded by Claude Code)
+        Write-Step "Installing always-on agents to $(Join-Path $env:USERPROFILE '.claude\agents')"
+        Install-AlwaysOnAgents -Prefix $Prefix -DryRun:$DryRun
 
-    # Copy cross-cutting (global) skills to ~/.claude/skills/
-    Write-Step "Installing cross-cutting skills to $(Join-Path $env:USERPROFILE '.claude\skills')"
-    Install-GlobalSkills -Prefix $Prefix -DryRun:$DryRun
+        # Copy cross-cutting (global) skills to ~/.claude/skills/
+        Write-Step "Installing cross-cutting skills to $(Join-Path $env:USERPROFILE '.claude\skills')"
+        Install-GlobalSkills -Prefix $Prefix -DryRun:$DryRun
+    }
 
     # Inject/update ccds pointer block in ~/.claude/CLAUDE.md
     Write-Step "Updating ccds block in $(Join-Path $env:USERPROFILE '.claude\CLAUDE.md')"
@@ -865,7 +930,11 @@ try {
         Write-Host "Future shells : PATH update persists automatically." -ForegroundColor Yellow
     }
     Write-Host ""
-    Write-Host "Agents  : 19 always-on -> $(Join-Path $env:USERPROFILE '.claude\agents') (14 domain + 5 core)"
+    if ($contentPlugins.Count -gt 0) {
+        Write-Host "Agents  : 19 always-on from plugins ($($contentPlugins -join ' '))"
+    } else {
+        Write-Host "Agents  : 19 always-on -> $(Join-Path $env:USERPROFILE '.claude\agents') (14 domain + 5 core)"
+    }
     Write-Host "Skills  : $(Join-Path $Prefix 'skills') (domain skills, JIT per project; cross-cutting -> $(Join-Path $env:USERPROFILE '.claude\skills'))"
     Write-Host "CLAUDE  : $(Join-Path $env:USERPROFILE '.claude\CLAUDE.md') (ccds pointer block injected)"
     Write-Host "Plugins : $pluginsStatus"

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Optional, opt-in tab-completion for the Claude Code CLI itself — independent o
 - Agents live in a **flat** `.claude/agents/` directory; skills are `skills/<name>/SKILL.md` (one dir per skill). Claude Code does not recurse `.claude/agents/`. See ADR-0001 / ADR-0007.
 - Release ZIPs are named `ccds-<tag>.zip` with a matching `ccds-<tag>.zip.sha256` sidecar. Installers verify SHA256 before extracting.
 - The `~/.claude/CLAUDE.md` ccds block is delimited by `# >>> ccds >>>` / `# <<< ccds <<<` markers. The installer is idempotent — re-running updates the block in place. See ADR-0006 / ADR-0007.
+- Contributions branch from **`develop`** and PRs target it (`gh pr create --base develop`). `main` is release-only and stays the default branch because `/plugin marketplace add` installs from the default branch. See ADR-0019.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,13 @@ source by `scripts/build-marketplace.py` and gated for freshness in CI.
 
 The ZIP installer below remains fully supported — it additionally provides the
 `ccds` CLI, the global `~/.claude/playbook/` library, and per-project skill
-staging via `ccds sync`.
+staging via `ccds sync`. The two routes are **alternatives for the always-on
+agents and cross-cutting skills, not layers** (ADR-0020): with `ccds-core` or a
+pack plugin enabled, Claude Code already loads that roster, so `ccds setup` and
+the installers skip the `~/.claude/agents` / `~/.claude/skills` copies, and
+`ccds doctor` fails with the exact removal command if both are ever present
+(every agent would be in the roster twice). Using both the CLI and the plugins
+is fine — the enforcement plugins are installed by every route.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,16 @@ updates, and enable/disable — no installer, no PATH, no restart dance.
 The guard stops model mistakes and casual prompt injection — it is a teaching
 backstop on top of Claude Code's permission modes, not a sandbox. Never run
 with permissions bypassed (`--dangerously-skip-permissions`) outside an
-isolated container, guard or no guard. Kill switch: `CCDS_GUARD_DISABLE=1`;
-tune rules in the plugin's `hooks/guard-rules.txt`. The hooks need `python3`
+isolated container, guard or no guard. Kill switch: `CCDS_GUARD_DISABLE=1`.
+Tune it without editing the plugin: `~/.claude/ccds-guard-rules.txt` takes the
+same five rule categories and loads after the shipped table (ADR-0021) — the
+usual entry is `allow-path: (^|/)\.claude/credentials/` to declare the key
+files your own skills are meant to read, so they stop being adjudicated on
+every call; the file is tamper-watched like settings, and its `deny-path`
+lines beat any shipped exemption. Source code inside a source tree is exempt
+from the secret scan (`src/credentials/foo.ts` is a module, not a key). If you switch the guard off on purpose, record why in
+`~/.claude/ccds-guard.disabled` and `ccds doctor` reports it as a choice
+(WARN) rather than a broken install. The hooks need `python3`
 on PATH (macOS/Linux/WSL have it; on native Windows install Python 3 or the
 guard is inert).
 

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -365,12 +365,44 @@ function Invoke-SetupCommand {
     $skillsDst   = Join-Path $claudeHome 'skills'
     $claudeMd    = Join-Path $claudeHome 'CLAUDE.md'
 
-    # Step 1 -- always-on agents
-    Write-Host "==> Installing always-on agents to $agentsDst" -ForegroundColor Cyan
+    # Step 0 -- which route supplies the always-on roster? (ADR-0020) The
+    # roster reaches Claude Code by the ccds content plugins OR by the file
+    # copies below, never both: both at once loads every agent twice. Read-only
+    # probe; skipped under -SkipPlugins (never touch the CLI) and -DryRun.
+    $contentPlugins = @()
+    if (-not $Opts.SkipPlugins -and -not $Opts.DryRun) {
+        Resolve-ContentPlugins
+        if ($Script:ContentPluginsKnown) { $contentPlugins = @($Script:ContentPlugins) }
+    }
     $srcAgents = @()
     if (Test-Path -LiteralPath $agentsSrc) {
         $srcAgents = @(Get-ChildItem -LiteralPath $agentsSrc -Filter *.md -File -ErrorAction SilentlyContinue)
     }
+    $skillList = Get-GlobalSkillList
+    if ($contentPlugins.Count -gt 0) {
+        Write-Host "==> Always-on agents and cross-cutting skills" -ForegroundColor Cyan
+        Write-Host "OK  Supplied by enabled plugin(s): $($contentPlugins -join ' ') -- skipping the file copies so Claude Code does not load the roster twice" -ForegroundColor Green
+        # Stale copies next to enabled plugins: name them with the exact
+        # removal command, but never delete a user's files from setup.
+        $staleAgents = @($srcAgents | Where-Object { Test-Path -LiteralPath (Join-Path $agentsDst $_.Name) } | ForEach-Object { $_.Name })
+        $staleSkills = @()
+        if ($skillList) {
+            $staleSkills = @($skillList.Names | Where-Object { Test-Path -LiteralPath (Join-Path $skillsDst "$_\SKILL.md") })
+        }
+        if ($staleAgents.Count -gt 0 -or $staleSkills.Count -gt 0) {
+            Write-Host "!!  File copies from an earlier setup are still present and are loaded in ADDITION to the plugins:" -ForegroundColor Yellow
+            Write-Host "!!    $($staleAgents.Count) agent file(s) in $agentsDst, $($staleSkills.Count) cross-cutting skill(s) in $skillsDst" -ForegroundColor Yellow
+            Write-Host "!!  Remove them (the plugins keep working):" -ForegroundColor Yellow
+            if ($staleAgents.Count -gt 0) {
+                Write-Host ("!!    Remove-Item -Force " + (($staleAgents | ForEach-Object { "'" + (Join-Path $agentsDst $_) + "'" }) -join ', ')) -ForegroundColor Yellow
+            }
+            if ($staleSkills.Count -gt 0) {
+                Write-Host ("!!    Remove-Item -Recurse -Force " + (($staleSkills | ForEach-Object { "'" + (Join-Path $skillsDst $_) + "'" }) -join ', ')) -ForegroundColor Yellow
+            }
+        }
+    } else {
+    # Step 1 -- always-on agents
+    Write-Host "==> Installing always-on agents to $agentsDst" -ForegroundColor Cyan
     if ($Opts.DryRun) {
         Write-Host "    DRY RUN -- would copy $($srcAgents.Count) always-on agents to $agentsDst"
     } else {
@@ -387,7 +419,6 @@ function Invoke-SetupCommand {
 
     # Step 2 -- cross-cutting (global) skills
     Write-Host "==> Installing cross-cutting skills to $skillsDst" -ForegroundColor Cyan
-    $skillList = Get-GlobalSkillList
     if (-not $skillList) {
         Write-Error "cannot determine the global skill list (no parsable Install-Playbook.ps1 or scripts\ccds-user-setup.sh under $installRoot)" -ErrorAction Continue
         exit 2
@@ -413,6 +444,7 @@ function Invoke-SetupCommand {
         }
         Write-Host "OK  Copied $copied/$($skillList.Names.Count) cross-cutting skills to $skillsDst" -ForegroundColor Green
     }
+    } # end file route (Step 0 gate)
 
     # Step 3 -- ccds pointer block in ~/.claude/CLAUDE.md (idempotent)
     Write-Host "==> Updating ccds block in $claudeMd" -ForegroundColor Cyan
@@ -509,13 +541,20 @@ function Invoke-SetupCommand {
     } else {
         Write-Host ""
         Write-Host "User setup complete." -ForegroundColor Green
+        if ($contentPlugins.Count -gt 0) {
+            Write-Host "Agents      : from plugins ($($contentPlugins -join ' '))"
+            Write-Host "Skills      : from plugins ($($contentPlugins -join ' '))"
+        } else {
+            Write-Host "Agents      : $agentsDst (19 always-on)"
+            Write-Host "Skills      : $skillsDst ($(if ($skillList) { $skillList.Names.Count } else { '?' }) cross-cutting)"
+        }
         Write-Host "Plugins     : $pluginStatus"
     }
 }
 
 # ---------------------------------------------------------------------------
 # Command: doctor -- proactive environment health checks.
-# PowerShell twin of bin/ccds.sh cmd_doctor: same 11 checks, same output
+# PowerShell twin of bin/ccds.sh cmd_doctor: same 12 checks, same output
 # contract (one 'OK|WARN|FAIL  name: detail' line per check + indented remedy
 # on WARN/FAIL, summary block, exit 0 = no FAIL / 1 = FAIL found).
 #
@@ -617,17 +656,25 @@ function Test-DoctorVersion {
 
 function Test-DoctorAgents {
     $dir = Join-Path $env:USERPROFILE '.claude\agents'
+    if (Test-CorePluginEnabled) {
+        Write-DoctorLine OK 'agents-installed' "supplied by the enabled ccds-core plugin (no file copies needed in $dir)"
+        return
+    }
     if (Test-Path -LiteralPath (Join-Path $dir 'plan-architect.md')) {
         $n = @(Get-ChildItem -LiteralPath $dir -Filter *.md -File -ErrorAction SilentlyContinue).Count
         Write-DoctorLine OK 'agents-installed' "core sentinel plan-architect.md present ($n agent file(s) in $dir)"
     } else {
         Write-DoctorLine FAIL 'agents-installed' `
-            "plan-architect.md missing from $dir -- the always-on agents are not installed" `
-            "run 'ccds setup'"
+            "plan-architect.md missing from $dir and the ccds-core plugin is not enabled -- the always-on agents are not installed" `
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     }
 }
 
 function Test-DoctorSkills {
+    if (Test-CorePluginEnabled) {
+        Write-DoctorLine OK 'skills-installed' "supplied by the enabled ccds-core plugin (no file copies needed in $(Join-Path $env:USERPROFILE '.claude\skills'))"
+        return
+    }
     $skillList = Get-GlobalSkillList
     if (-not $skillList) {
         Write-DoctorLine WARN 'skills-installed' `
@@ -648,8 +695,65 @@ function Test-DoctorSkills {
     } else {
         Write-DoctorLine FAIL 'skills-installed' `
             "$($missing.Count)/$($skillList.Names.Count) cross-cutting skills missing from ${skillsDir}: $($missing -join ' ')" `
-            "run 'ccds setup'"
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     }
+}
+
+function Test-DoctorPluginFileOverlap {
+    # The always-on agents and cross-cutting skills reach Claude Code by ONE of
+    # two routes: the ccds content plugins, or file copies written by setup.
+    # Both at once means every agent is in the roster twice (two identical
+    # descriptions for the router, the stale file copy owns the bare name) and
+    # the descriptions cost context twice. Twin of bin/ccds.sh.
+    Resolve-ContentPlugins
+    if (-not $Script:ContentPluginsKnown) {
+        Write-DoctorLine WARN 'plugin-file-overlap' `
+            "cannot check: claude CLI not on PATH or 'claude plugin list --json' unreadable" `
+            "install Claude Code / run 'claude plugin list', then re-run 'ccds doctor'"
+        return
+    }
+    $agentsDir = Join-Path $env:USERPROFILE '.claude\agents'
+    $skillsDir = Join-Path $env:USERPROFILE '.claude\skills'
+    # ccds-owned agent names come from catalog.json (authoritative, shipped in
+    # every layout); the package's agents\ dir is the fallback for an old tree.
+    $owned = @()
+    $catalog = Join-Path $installRoot 'catalog.json'
+    if (Test-Path -LiteralPath $catalog) {
+        try {
+            $entries = @([System.IO.File]::ReadAllText($catalog) | ConvertFrom-Json)
+            $owned = @($entries | Where-Object { $_.kind -eq 'agent' } | ForEach-Object { "$($_.name).md" })
+        } catch { $owned = @() }
+    }
+    if ($owned.Count -eq 0) {
+        $src = Join-Path $installRoot 'agents'
+        if (-not (Test-Path -LiteralPath $src)) { $src = Join-Path $installRoot '.claude\agents' }
+        if (Test-Path -LiteralPath $src) {
+            $owned = @(Get-ChildItem -LiteralPath $src -Filter *.md -File -ErrorAction SilentlyContinue | ForEach-Object { $_.Name })
+        }
+    }
+    $agentFiles = @($owned | Where-Object { Test-Path -LiteralPath (Join-Path $agentsDir $_) })
+    $skillList = Get-GlobalSkillList
+    $skillNames = if ($skillList) { @($skillList.Names) } else { @() }
+    $skillDirs = @($skillNames | Where-Object { Test-Path -LiteralPath (Join-Path $skillsDir "$_\SKILL.md") })
+    if ($Script:ContentPlugins.Count -eq 0) {
+        Write-DoctorLine OK 'plugin-file-overlap' 'no ccds content plugin enabled; agents and skills come from the file copies only'
+        return
+    }
+    $pluginNames = $Script:ContentPlugins -join ' '
+    if ($agentFiles.Count -eq 0 -and $skillDirs.Count -eq 0) {
+        Write-DoctorLine OK 'plugin-file-overlap' "plugins ($pluginNames) supply the agents and skills; no file copies present"
+        return
+    }
+    $cmds = @()
+    if ($agentFiles.Count -gt 0) {
+        $cmds += 'Remove-Item -Force ' + (($agentFiles | ForEach-Object { "'" + (Join-Path $agentsDir $_) + "'" }) -join ', ')
+    }
+    if ($skillDirs.Count -gt 0) {
+        $cmds += 'Remove-Item -Recurse -Force ' + (($skillDirs | ForEach-Object { "'" + (Join-Path $skillsDir $_) + "'" }) -join ', ')
+    }
+    Write-DoctorLine FAIL 'plugin-file-overlap' `
+        "loaded twice: plugin(s) $pluginNames are enabled AND $($agentFiles.Count) agent file(s) + $($skillDirs.Count) cross-cutting skill(s) from a file install (version $(Get-InstalledVersion)) sit in $(Join-Path $env:USERPROFILE '.claude') -- Claude Code loads both copies, and the file copies (which own the bare names) go stale the moment the plugins update" `
+        ("remove the file copies (the plugins keep working): " + ($cmds -join '; '))
 }
 
 function Test-DoctorBom {
@@ -788,6 +892,47 @@ function Get-ClaudeCommand {
     return 'claude'
 }
 
+# Content plugins are the ccds-* plugins that ship agents and skills (ccds-core
+# + the archetype packs) -- every ccds plugin except the hooks-only enforcement
+# pair. When one is enabled, Claude Code already loads that roster from the
+# plugin, so file copies in ~/.claude/{agents,skills} are a SECOND load.
+# Twin of bin/ccds.sh content_plugins_enabled. Sets two script variables:
+#   $Script:ContentPluginsKnown  $false when the CLI is absent / unreadable
+#   $Script:ContentPlugins       enabled content-plugin names (may be empty)
+# Probed once per run.
+$Script:ContentPluginsProbed = $false
+$Script:ContentPluginsKnown  = $false
+$Script:ContentPlugins       = @()
+
+function Resolve-ContentPlugins {
+    if ($Script:ContentPluginsProbed) { return }
+    $Script:ContentPluginsProbed = $true
+    $claudeCmd = Get-ClaudeCommand
+    if (-not (Get-Command $claudeCmd -ErrorAction SilentlyContinue)) { return }
+    $plugins = $null
+    try {
+        # Join first: the real CLI pretty-prints one field per line, and a
+        # line-by-line pipe into ConvertFrom-Json parses each line alone.
+        $raw = @(& $claudeCmd plugin list --json 2>$null) -join "`n"
+        if ($raw.Trim()) { $plugins = @($raw | ConvertFrom-Json) } else { $plugins = @() }
+    } catch { return }
+    $names = @()
+    foreach ($pl in $plugins) {
+        if ($null -eq $pl -or -not $pl.enabled) { continue }
+        if ("$($pl.id)" -match '^(ccds-[a-z]+)@') {
+            $n = $Matches[1]
+            if ($n -ne 'ccds-guard' -and $n -ne 'ccds-loops') { $names += $n }
+        }
+    }
+    $Script:ContentPluginsKnown = $true
+    $Script:ContentPlugins = @($names | Sort-Object -Unique)
+}
+
+function Test-CorePluginEnabled {
+    Resolve-ContentPlugins
+    return ($Script:ContentPluginsKnown -and ($Script:ContentPlugins -contains 'ccds-core'))
+}
+
 function Test-DoctorClaudeCli {
     # WARN, not FAIL: an older CLI does not break ccds -- the guard's deny and
     # ask tiers work unchanged. It silently costs the unattended adjudicator.
@@ -830,8 +975,9 @@ function Test-DoctorPlugins {
     }
     $plugins = $null
     try {
-        $raw = & $claudeCmd plugin list --json 2>$null
-        $plugins = @($raw | ConvertFrom-Json)
+        # Join first: the real CLI pretty-prints one field per line (see #70).
+        $raw = @(& $claudeCmd plugin list --json 2>$null) -join "`n"
+        $plugins = if ($raw.Trim()) { @($raw | ConvertFrom-Json) } else { @() }
     } catch { }
     if ($null -eq $plugins) {
         Write-DoctorLine 'WARN' 'plugins-installed' `
@@ -876,6 +1022,7 @@ function Invoke-DoctorCommand {
         @{ Name = 'path-and-duals'  ; Fn = ${function:Test-DoctorPathDuals} }
         @{ Name = 'claude-cli'      ; Fn = ${function:Test-DoctorClaudeCli} }
         @{ Name = 'plugins-installed'; Fn = ${function:Test-DoctorPlugins} }
+        @{ Name = 'plugin-file-overlap'; Fn = ${function:Test-DoctorPluginFileOverlap} }
     )
 
     Write-Host "ccds doctor -- environment checks (version $(Get-InstalledVersion), $layoutKind layout)"

--- a/bin/ccds.ps1
+++ b/bin/ccds.ps1
@@ -999,9 +999,22 @@ function Test-DoctorPlugins {
         return
     }
     if ($disabled.Count -gt 0) {
+        # A deliberate opt-out is not a broken install: the operator records
+        # the reason in ~/.claude/ccds-guard.disabled and doctor downgrades the
+        # guard line to WARN (ADR-0021). Only ccds-guard can be opted out.
+        $marker = Join-Path $env:USERPROFILE '.claude\ccds-guard.disabled'
+        if ($disabled.Count -eq 1 -and $disabled[0] -eq 'ccds-guard' -and (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            $why = ''
+            try { $why = @(Get-Content -LiteralPath $marker -TotalCount 1 -ErrorAction Stop)[0] } catch { }
+            if (-not $why) { $why = 'no reason recorded' }
+            Write-DoctorLine 'WARN' 'plugins-installed' `
+                "ccds-guard disabled on purpose (${marker}: $why); ccds-loops installed and enabled" `
+                "when the guard is revisited: claude plugin enable ccds-guard; Remove-Item '$marker'"
+            return
+        }
         Write-DoctorLine 'FAIL' 'plugins-installed' `
             "installed but DISABLED: $($disabled -join ' ') -- a disabled guard protects nothing" `
-            "claude plugin enable $($disabled[0])"
+            "claude plugin enable $($disabled[0]) (or, if deliberate: Set-Content '$marker' 'reason' so doctor reports it as a choice)"
         return
     }
     Write-DoctorLine 'OK' 'plugins-installed' 'ccds-guard ccds-loops installed and enabled'

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -264,6 +264,48 @@ MIN_CLAUDE_VERSION="2.1.169"
 CLAUDE_CMD="${CCDS_CLAUDE_CMD:-claude}"
 ENFORCEMENT_PLUGINS=(ccds-guard ccds-loops)
 
+# Content plugins are the ccds-* plugins that ship agents and skills: ccds-core
+# and the archetype packs -- every ccds plugin except the hooks-only enforcement
+# pair above. When one is enabled, Claude Code already loads those agents and
+# skills from the plugin, so copies in ~/.claude/agents and ~/.claude/skills are
+# a SECOND load of the same roster. Echoes the enabled content-plugin names
+# (space-separated, possibly empty), or the literal "unknown" when the claude
+# CLI is absent or `claude plugin list --json` cannot be read. Cached per run.
+content_plugins_enabled() {
+    if [[ -z "${CONTENT_PLUGINS_CACHE+x}" ]]; then
+        local json
+        if ! command -v "$CLAUDE_CMD" >/dev/null 2>&1 \
+            || ! json="$("$CLAUDE_CMD" plugin list --json 2>/dev/null)"; then
+            CONTENT_PLUGINS_CACHE="unknown"
+        else
+            # The real CLI pretty-prints one field per line, so collapse newlines
+            # FIRST, then split into one object per line; keep the enabled ones,
+            # pull the "<name>@" id prefix, drop the hooks-only pair.
+            CONTENT_PLUGINS_CACHE="$(printf '%s' "$json" | tr -d '\n\r' | tr '{' '\n' \
+                | grep '"enabled"[[:space:]]*:[[:space:]]*true' \
+                | grep -o '"id"[[:space:]]*:[[:space:]]*"ccds-[a-z]*@' \
+                | sed -e 's/.*"\(ccds-[a-z]*\)@/\1/' \
+                | grep -v -x -e ccds-guard -e ccds-loops \
+                | sort -u | tr '\n' ' ' | sed -e 's/ $//' || true)"
+        fi
+    fi
+    printf '%s' "$CONTENT_PLUGINS_CACHE"
+}
+
+core_plugin_enabled() {  # true when ccds-core (the 5 core agents + cross-cutting skills) is enabled
+    case " $(content_plugins_enabled) " in *" ccds-core "*) return 0 ;; esac
+    return 1
+}
+
+# The authoritative GLOBAL_SKILLS list, read from the setup script at runtime --
+# never a second hardcoded copy that can drift. Prints one name per line;
+# prints nothing when the script is missing or the block cannot be parsed.
+global_skill_names() {
+    [[ -f "$SETUP_SCRIPT" ]] || return 0
+    sed -n '/^GLOBAL_SKILLS=(/,/^)/p' "$SETUP_SCRIPT" \
+        | sed -e '1d' -e '$d' -e 's/#.*$//' -e 's/[[:space:]]//g' | grep -v '^$' || true
+}
+
 # Numeric compare of dotted versions without sort -V (absent on some minimal
 # images). Echoes "older", "same" or "newer" for $1 relative to $2.
 version_cmp() {
@@ -332,7 +374,7 @@ doc_check_plugins() {
         # Match the plugin id from any marketplace: "<name>@<marketplace>".
         if ! printf '%s' "$json" | grep -q "\"id\"[[:space:]]*:[[:space:]]*\"${p}@"; then
             missing+=("$p")
-        elif printf '%s' "$json" \
+        elif printf '%s' "$json" | tr -d '\n\r' \
             | tr '{' '\n' | grep "\"${p}@" | grep -q '"enabled"[[:space:]]*:[[:space:]]*false'; then
             disabled+=("$p")
         fi
@@ -405,20 +447,26 @@ doc_check_version() {
 
 doc_check_agents() {
     local dir="$HOME/.claude/agents"
+    if core_plugin_enabled; then
+        doc_line OK agents-installed "supplied by the enabled ccds-core plugin (no file copies needed in $dir)"
+        return
+    fi
     if [[ -f "$dir/plan-architect.md" ]]; then
         local n
         n="$(find "$dir" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
         doc_line OK agents-installed "core sentinel plan-architect.md present ($n agent file(s) in $dir)"
     else
         doc_line FAIL agents-installed \
-            "plan-architect.md missing from $dir -- the always-on agents are not installed" \
-            "run 'ccds setup'"
+            "plan-architect.md missing from $dir and the ccds-core plugin is not enabled -- the always-on agents are not installed" \
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     fi
 }
 
 doc_check_skills() {
-    # Read the authoritative GLOBAL_SKILLS list from the setup script at
-    # runtime -- never a second hardcoded copy that can drift.
+    if core_plugin_enabled; then
+        doc_line OK skills-installed "supplied by the enabled ccds-core plugin (no file copies needed in $HOME/.claude/skills)"
+        return
+    fi
     if [[ ! -f "$SETUP_SCRIPT" ]]; then
         doc_line WARN skills-installed \
             "cannot determine expected skill list ($SETUP_SCRIPT not found)" \
@@ -426,8 +474,7 @@ doc_check_skills() {
         return
     fi
     local -a expected=()
-    mapfile -t expected < <(sed -n '/^GLOBAL_SKILLS=(/,/^)/p' "$SETUP_SCRIPT" \
-        | sed -e '1d' -e '$d' -e 's/#.*$//' -e 's/[[:space:]]//g' | grep -v '^$' || true)
+    mapfile -t expected < <(global_skill_names)
     if (( ${#expected[@]} == 0 )); then
         doc_line WARN skills-installed \
             "could not extract GLOBAL_SKILLS from $SETUP_SCRIPT" \
@@ -444,8 +491,64 @@ doc_check_skills() {
     else
         doc_line FAIL skills-installed \
             "${#missing[@]}/${#expected[@]} cross-cutting skills missing from $HOME/.claude/skills: ${missing[*]}" \
-            "run 'ccds setup'"
+            "run 'ccds setup' (or: claude plugin install ccds-core@ccds --scope user)"
     fi
+}
+
+doc_check_plugin_file_overlap() {
+    # The always-on agents and cross-cutting skills reach Claude Code by ONE of
+    # two routes: the ccds content plugins, or file copies written by setup.
+    # Both at once means every agent is in the roster twice (the router sees
+    # two identical descriptions and the stale file copy owns the bare name)
+    # and the descriptions cost context twice. Each route alone is fine.
+    local plugins
+    plugins="$(content_plugins_enabled)"
+    if [[ "$plugins" == "unknown" ]]; then
+        doc_line WARN plugin-file-overlap \
+            "cannot check: claude CLI not on PATH or 'claude plugin list --json' unreadable" \
+            "install Claude Code / run 'claude plugin list', then re-run 'ccds doctor'"
+        return
+    fi
+    # ccds-owned agent names come from catalog.json (authoritative, shipped in
+    # every layout); the package's agents/ dir is the fallback for an old tree.
+    local name
+    local -a owned=() agent_files=() skill_dirs=()
+    if [[ -f "$INSTALL_ROOT/catalog.json" ]]; then
+        mapfile -t owned < <(tr -d '\n\r' < "$INSTALL_ROOT/catalog.json" | tr '{' '\n' \
+            | grep '"kind"[[:space:]]*:[[:space:]]*"agent"' \
+            | grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | sed -e 's/.*"\([^"]*\)"$/\1.md/' || true)
+    fi
+    if (( ${#owned[@]} == 0 )); then
+        local agents_src="$INSTALL_ROOT/agents" f
+        [[ -d "$agents_src" ]] || agents_src="$INSTALL_ROOT/.claude/agents"
+        for f in "$agents_src"/*.md; do [[ -f "$f" ]] && owned+=("$(basename "$f")"); done
+    fi
+    for name in "${owned[@]}"; do
+        [[ -f "$HOME/.claude/agents/$name" ]] && agent_files+=("$name")
+    done
+    while IFS= read -r name; do
+        [[ -n "$name" && -f "$HOME/.claude/skills/$name/SKILL.md" ]] && skill_dirs+=("$name")
+    done < <(global_skill_names)
+    if [[ -z "$plugins" ]]; then
+        doc_line OK plugin-file-overlap "no ccds content plugin enabled; agents and skills come from the file copies only"
+        return
+    fi
+    if (( ${#agent_files[@]} == 0 && ${#skill_dirs[@]} == 0 )); then
+        doc_line OK plugin-file-overlap "plugins ($plugins) supply the agents and skills; no file copies present"
+        return
+    fi
+    local -a cmds=()
+    if (( ${#agent_files[@]} > 0 )); then
+        cmds+=("rm -f $(printf "$HOME/.claude/agents/%s " "${agent_files[@]}" | sed -e 's/ $//')")
+    fi
+    if (( ${#skill_dirs[@]} > 0 )); then
+        cmds+=("rm -rf $(printf "$HOME/.claude/skills/%s " "${skill_dirs[@]}" | sed -e 's/ $//')")
+    fi
+    local remedy="remove the file copies (the plugins keep working): $(IFS='&'; printf '%s' "${cmds[*]}" | sed -e 's/&/ \&\& /g')"
+    doc_line FAIL plugin-file-overlap \
+        "loaded twice: plugin(s) $plugins are enabled AND ${#agent_files[@]} agent file(s) + ${#skill_dirs[@]} cross-cutting skill(s) from a file install (version $(installed_version)) sit in $HOME/.claude -- Claude Code loads both copies, and the file copies (which own the bare names) go stale the moment the plugins update" \
+        "$remedy"
 }
 
 doc_check_bom() {
@@ -550,6 +653,7 @@ cmd_doctor() {
         "path-and-duals:doc_check_path_duals"
         "claude-cli:doc_check_claude_cli"
         "plugins-installed:doc_check_plugins"
+        "plugin-file-overlap:doc_check_plugin_file_overlap"
     )
 
     echo "ccds doctor -- environment checks (version $(installed_version), $LAYOUT_KIND layout)"

--- a/bin/ccds.sh
+++ b/bin/ccds.sh
@@ -386,9 +386,22 @@ doc_check_plugins() {
         return
     fi
     if (( ${#disabled[@]} > 0 )); then
+        # A deliberate opt-out is not a broken install: the operator records
+        # the reason in ~/.claude/ccds-guard.disabled and doctor downgrades the
+        # guard line to WARN (ADR-0021). Only ccds-guard can be opted out; a
+        # disabled ccds-loops is still an incomplete install.
+        local marker="$HOME/.claude/ccds-guard.disabled"
+        if [[ "${disabled[*]}" == "ccds-guard" && -f "$marker" ]]; then
+            local why
+            why="$(head -n 1 "$marker" 2>/dev/null | tr -d '\r' || true)"
+            doc_line WARN plugins-installed \
+                "ccds-guard disabled on purpose (${marker}: ${why:-no reason recorded}); ccds-loops installed and enabled" \
+                "when the guard is revisited: claude plugin enable ccds-guard && rm $marker"
+            return
+        fi
         doc_line FAIL plugins-installed \
             "installed but DISABLED: ${disabled[*]} -- a disabled guard protects nothing" \
-            "claude plugin enable ${disabled[0]}"
+            "claude plugin enable ${disabled[0]} (or, if deliberate: echo 'reason' > $HOME/.claude/ccds-guard.disabled so doctor reports it as a choice)"
         return
     fi
     doc_line OK plugins-installed "${ENFORCEMENT_PLUGINS[*]} installed and enabled"

--- a/plugin-extras/ccds-guard/hooks/guard-rules.txt
+++ b/plugin-extras/ccds-guard/hooks/guard-rules.txt
@@ -24,6 +24,13 @@
 # NOT in this table (lives in pretooluse-guard.py as path logic, because a
 # regex cannot resolve paths): recursive force-delete outside the project.
 #
+# Operator additions live in ~/.claude/ccds-guard-rules.txt (same five
+# categories; loaded after this file, never replaced by a plugin update, and
+# tamper-watched like settings). Typical use: declare the credential files your
+# own skills are meant to read, so they stop being adjudicated on every call:
+#   allow-path: (^|/)\.claude/credentials/   # keys my skills read by design
+# Override the location with CCDS_GUARD_USER_RULES (a test seam).
+#
 # Charter: protective only. This guard exists so that projects built by people
 # who configure nothing still refuse to leak secrets, run curl|bash, or install
 # hallucinated packages. It is a teaching backstop layered on Claude Code's
@@ -35,6 +42,7 @@
 allow-path: \.env\.(example|sample|template|dist)$                              # env templates are meant to be edited
 allow-path: (^|/)tests?/fixtures?/                                              # test fixtures named like secrets
 allow-path: \.pub$                                                              # public keys are not secrets
+allow-path: ^(?=.*(?:^|/)(?:src|lib|app|apps|packages|pkg|internal|cmd|tests?|spec|__tests__|e2e|examples?)/)(?!.*(?:^|/)\.[^/]+/)(?:.*/)?(?!\.)(?![^/]*\.(?:key|pem|p12|pfx|jks|keystore|env|tfstate)\.)(?!id_(?:rsa|dsa|ecdsa|ed25519)\b)[^/]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|cs|rb|php|swift|scala|c|cc|cpp|h|hpp|proto|graphql|vue|svelte)$  # source code in a source tree is never a secret: packages/cli/src/credentials/credentials.service.ts is a module, not a key (#74). Requires a source-root segment (src/ lib/ app/ packages/ tests/ ...), so secrets/keys.py at a repo root still denies; never inside a dot-directory, never a dotfile (.env.ts), never a key/env stem with a code suffix (server.key.md)
 
 # --- Secret-bearing paths: never read or written by the model ---
 deny-path: (^|/)\.env(\.[A-Za-z0-9._-]+)?$                                      # .env and variants hold live credentials
@@ -57,6 +65,8 @@ ask-write-path: (^|/)\.claude/settings(\.local)?\.json$                         
 ask-write-path: (^|/)\.claude/hooks(/|$)                                        # Claude Code is changing hook scripts that enforce your safety gates
 ask-write-path: (^|/)\.claude/plugins/                                          # Claude Code is changing installed plugin files (including this guard's own rules) - confirm you asked for this
 ask-write-path: (^|/)\.pre-commit-config\.ya?ml$                                # Claude Code is changing the checks that run before every commit
+ask-write-path: (^|/)ccds-guard-rules\.txt[. ]*$                                   # Claude Code is changing the operator's own guard rules (the file that can exempt paths) - confirm you asked for this. Matched by filename so `cd ~/.claude && ... > ccds-guard-rules.txt` and Windows trailing-dot aliases are seen too
+ask-write-path: (^|/)ccds-guard\.disabled[. ]*$                                    # Claude Code is writing the guard opt-out marker that makes doctor treat a disabled guard as intended - confirm you asked for this
 
 # --- Dangerous commands: blocked outright ---
 deny-command: \bgit\b[^\n;|&]*\bpush\b[^\n;|&]*(\s--force(?!-with-lease|-if-includes)\b|\s-[a-z]*f[a-z]*\b)  # force-push rewrites shared history; use --force-with-lease if you truly need it
@@ -69,6 +79,9 @@ deny-command: \bwget\b[^\n;|&]*--no-check-certificate\b                         
 deny-command: \bsslverify\s*[= ]\s*false\b                                      # disabling git TLS verification lets anyone intercept the traffic
 deny-command: \bstrict-ssl\b[^\n;|&]*\bfalse\b                                  # disabling npm TLS verification lets anyone intercept the traffic
 deny-command: \b(PYTHONHTTPSVERIFY=0|NODE_TLS_REJECT_UNAUTHORIZED=0)\b          # disabling TLS verification lets anyone intercept the traffic
+
+# --- Guard self-removal: the model switching off its own gates asks first ---
+ask-command: \bclaude\s+plugin\s+(disable|uninstall|remove)\b[^\n;|&]*\bccds-(guard|loops)\b  # Claude Code is disabling or removing a ccds enforcement plugin (its own safety gates) - confirm you asked for this
 
 # --- Package installs: ask, because models hallucinate package names ---
 # Attackers register hallucinated names (slopsquatting). Flags may appear

--- a/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugin-extras/ccds-guard/hooks/pretooluse-guard.py
@@ -9,8 +9,9 @@ One script, two matchers (see hooks.json):
                                         package-install ask (slopsquatting)
   Read|Write|Edit|NotebookEdit|Grep  -> secret-path deny, config-tamper ask
 
-Rules are DATA (guard-rules.txt beside this script, five categories); editing
-the table tunes the guard without touching code. Checks that need path
+Rules are DATA (guard-rules.txt beside this script, five categories, plus the
+operator's ~/.claude/ccds-guard-rules.txt loaded after it — CCDS_GUARD_USER_RULES
+relocates it); editing the tables tunes the guard without touching code. Checks that need path
 resolution a regex cannot express live in CODE (lessons from three multi-model
 review rounds, ADR-0012 addendum):
   - recursive force-delete outside the project: targets are resolved (quotes,
@@ -85,6 +86,15 @@ import subprocess
 import sys
 import tempfile
 
+# Operator rules: same format, loaded AFTER the shipped table so a plugin
+# update never overwrites them. Lives under ~/.claude and is tamper-watched
+# (ask-write-path) because an allow-path line can exempt a secret file — the
+# model must not be able to add one silently. CCDS_GUARD_USER_RULES is the
+# test seam / relocation knob; it is read from the hook's own environment
+# (Claude Code's process), which a `VAR=x cmd` prefix inside a Bash tool call
+# cannot reach — only the session's launch environment can set it.
+USER_RULES_FILE = os.environ.get("CCDS_GUARD_USER_RULES", "").strip() or \
+    os.path.join(os.path.expanduser("~"), ".claude", "ccds-guard-rules.txt")
 RULES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "guard-rules.txt")
 
@@ -183,15 +193,53 @@ ALLOW: <short reason>   or   DENY: <short reason>
 
 
 def _load_rules():
-    """Return {category: [(compiled_regex, label), ...]}.
-    Unparseable lines/patterns are skipped, never fatal."""
+    """Return {category: [(compiled_regex, label), ...]} from the shipped
+    table plus the operator's file (if any). Operator deny-path rules are ALSO
+    kept in "deny-path-first", checked before any allow-path exemption, so an
+    operator can tighten what the shipped table exempts. A missing operator
+    file is the normal case; a symlinked one is ignored, loudly."""
     rules = {c: [] for c in CATEGORIES}
+    rules["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, rules)
+    # The operator file is tamper-watched by PATH. A symlink at that path
+    # would move the effective content to a target the watch never sees
+    # (review finding): creating the link asks once, every later write to the
+    # target would not. So a symlinked operator file is ignored, loudly.
+    if os.path.islink(USER_RULES_FILE):
+        sys.stderr.write("ccds-guard: %s is a symlink and was ignored — the "
+                         "operator rules file must be a regular file.\n"
+                         % USER_RULES_FILE)
+    else:
+        _load_rules_file(USER_RULES_FILE, rules, operator=True)
+    # Whatever path the operator file resolves to (CCDS_GUARD_USER_RULES may
+    # relocate it), writes there are tamper-watched, not just the default name.
     try:
-        with open(RULES_FILE, encoding="utf-8") as f:
+        rules["ask-write-path"].append((
+            re.compile(re.escape(_norm(USER_RULES_FILE)) + r"[. ]*$", re.IGNORECASE),
+            "Claude Code is changing the operator's own guard rules - confirm you asked for this"))
+    except re.error:
+        pass
+    return rules
+
+
+def _load_rules_file(path, rules, operator=False):
+    """Parse one rules file into `rules`. Shipped-table problems are silent by
+    contract (a bad pattern disables itself, never the guard); operator-file
+    problems are reported on stderr with file:line, because a rule the
+    operator wrote and thinks is active must not fail silently. An EMPTY body
+    is skipped everywhere: `allow-path:` with nothing after it would compile
+    to a regex that matches every path (review finding)."""
+    try:
+        with open(path, encoding="utf-8") as f:
             lines = f.readlines()
     except (OSError, UnicodeDecodeError):
-        return rules
-    for raw in lines:
+        return
+
+    def complain(n, why):
+        if operator:
+            sys.stderr.write("ccds-guard: %s:%d ignored — %s\n" % (path, n, why))
+
+    for n, raw in enumerate(lines, 1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
@@ -203,13 +251,20 @@ def _load_rules():
                 if " # " in body:
                     body, label = body.split(" # ", 1)
                     body, label = body.strip(), label.strip()
+                if not body:
+                    complain(n, "empty pattern (would match every path)")
+                    break
                 try:
-                    rules[cat].append((re.compile(body, re.IGNORECASE),
-                                       label or body))
-                except re.error:
-                    pass  # a bad pattern disables itself, never the guard
+                    entry = (re.compile(body, re.IGNORECASE), label or body)
+                except re.error as exc:
+                    complain(n, "invalid regex (%s)" % exc)
+                    break
+                rules[cat].append(entry)
+                if operator and cat == "deny-path":
+                    rules["deny-path-first"].append(entry)
                 break
-    return rules
+        else:
+            complain(n, "unknown rule category")
 
 
 def _split_cmd(cmd):
@@ -377,8 +432,9 @@ def _ask(reasons, payload, tool, detail, tamper=False):
         "Verdict: %s\nGuard reason(s): %s\nFlagged input: %s\n"
         "Use a safer form (bare lockfile restores pass untouched), or leave "
         "the exact command for the operator to run themselves. Persistent "
-        "false positive? The operator can tune guard-rules.txt or set "
-        "CCDS_GUARD_ADJUDICATOR_CMD." % (why, "; ".join(reasons), detail))
+        "false positive? The operator can add an allow-path in "
+        "~/.claude/ccds-guard-rules.txt or set CCDS_GUARD_ADJUDICATOR_CMD."
+        % (why, "; ".join(reasons), detail))
 
 
 def _deny(msg):
@@ -546,10 +602,14 @@ def _guard_bash(cmd, payload, rules):
         cmd_word = posixpath.basename(_norm(toks[i])) if i < len(toks) else ""
         text_only = cmd_word in TEXT_COMMANDS
         for tok in _tokens_for_scan(seg):
-            if _match_any(rules["allow-path"], tok):
-                continue
-            if not secret_hit and not text_only \
-                    and _match_any(rules["deny-path"], tok):
+            # allow-path exempts from the SECRET scan only (the table's
+            # contract). The tamper watch must still see an exempt token:
+            # hook scripts are .py/.sh files, and the source-code exemption
+            # would otherwise let `sed -i ... .claude/hooks/x.py` pass silently.
+            exempt = _match_any(rules["allow-path"], tok)
+            if not secret_hit and not text_only and (
+                    _match_any(rules["deny-path-first"], tok)
+                    or (not exempt and _match_any(rules["deny-path"], tok))):
                 secret_hit = True
             if not tamper_hit and _match_any(rules["ask-write-path"], tok):
                 tamper_hit = True
@@ -632,9 +692,9 @@ def _guard_file(tool, tool_input, rules, payload):
         return 0
 
     for cand in candidates:
-        if _match_any(rules["allow-path"], cand):
-            continue
-        for rx, label in rules["deny-path"]:
+        exempt = _match_any(rules["allow-path"], cand)
+        for rx, label in rules["deny-path-first"] + (
+                [] if exempt else rules["deny-path"]):
             if rx.search(cand):
                 return _deny(
                     "ccds-guard: BLOCKED — %s looks like a secrets file/"
@@ -644,8 +704,8 @@ def _guard_file(tool, tool_input, rules, payload):
                     "needed, the operator opens it in their own editor; to "
                     "bootstrap config, copy the template (cp .env.example "
                     ".env) yourself. Persistent false positive? The operator "
-                    "can tune guard-rules.txt in the ccds-guard plugin."
-                    % (cand, label))
+                    "can exempt it in ~/.claude/ccds-guard-rules.txt "
+                    "(allow-path)." % (cand, label))
     if tool in WRITE_TOOLS:
         reasons = []
         for cand in candidates:
@@ -674,7 +734,10 @@ def main():
     if not isinstance(tool_input, dict):
         return 0
     rules = _load_rules()
-    if not any(rules.values()) and tool in ("Bash",) + FILE_TOOLS:
+    shipped = {c: [] for c in CATEGORIES}
+    shipped["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, shipped)
+    if not any(shipped.values()) and tool in ("Bash",) + FILE_TOOLS:
         # Fail-open, but never silently: an empty table means the guard is
         # inert, and the operator should know (stderr on exit 0 = non-blocking).
         sys.stderr.write("ccds-guard: guard-rules.txt is missing or empty — "

--- a/plugins/ccds-ai/agents/ai-architect.md
+++ b/plugins/ccds-ai/agents/ai-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ai-architect
 model: opus
-color: "#6366f1"
+color: blue
 description: AI / LLM application domain specialist. Use proactively on AI / LLM work — model selection, serving topology, RAG-vs-finetune-vs-prompt, eval strategy, cost/latency budgets, and data policy. Owns AI architecture and composes the ai-* implementation skills.
 ---
 

--- a/plugins/ccds-core/agents/deploy-checklist.md
+++ b/plugins/ccds-core/agents/deploy-checklist.md
@@ -1,7 +1,7 @@
 ---
 name: deploy-checklist
 model: haiku
-color: "#ff5a1f"
+color: orange
 disallowedTools: Write, Edit, NotebookEdit
 description: Deployment readiness and pre-production checklist specialist. Use proactively before any production deployment, environment promotion, release cut, or go/no-go assessment.
 ---

--- a/plugins/ccds-core/agents/plan-architect.md
+++ b/plugins/ccds-core/agents/plan-architect.md
@@ -1,7 +1,7 @@
 ---
 name: plan-architect
 model: opus
-color: "#1a56db"
+color: blue
 description: Universal system design and architecture planning specialist. Use proactively when defining component boundaries, data flows, integration patterns, or making major structural decisions before or during implementation.
 ---
 
@@ -35,7 +35,7 @@ You do NOT own:
 
 ## Approach
 
-1. **Understand constraints first** — ask about scale requirements, team size, deployment target, and non-functional requirements before proposing a design
+1. **Pin the constraints first** — scale requirements, team size, deployment target, and non-functional requirements. Use what the task and the repo give you; where they are silent, state the assumption you are designing under and proceed. List only the open questions whose answers would change the design, for the orchestrator to take back to the user — you cannot ask them yourself
 2. **Prefer simplicity** — recommend the least complex architecture that satisfies requirements; avoid over-engineering
 3. **Make trade-offs explicit** — present 2–3 options with clear pros/cons rather than a single opinionated answer when the choice is genuinely context-dependent
 4. **Design for change** — favor designs that isolate likely change points behind abstractions

--- a/plugins/ccds-core/agents/pr-code-reviewer.md
+++ b/plugins/ccds-core/agents/pr-code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: pr-code-reviewer
 model: sonnet
-color: "#7e3af2"
+color: purple
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - code-review-checklist

--- a/plugins/ccds-core/agents/secure-auditor.md
+++ b/plugins/ccds-core/agents/secure-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: secure-auditor
 model: opus
-color: "#e3a008"
+color: yellow
 disallowedTools: Write, Edit, NotebookEdit
 skills:
   - security-checklist

--- a/plugins/ccds-core/agents/test-writer-runner.md
+++ b/plugins/ccds-core/agents/test-writer-runner.md
@@ -1,7 +1,7 @@
 ---
 name: test-writer-runner
 model: sonnet
-color: "#057a55"
+color: green
 description: Test writing and execution specialist. Use proactively after implementation is complete, after a PR review resolves issues, or when test coverage for a module or feature needs improving.
 ---
 

--- a/plugins/ccds-dataplat/agents/dataplat-architect.md
+++ b/plugins/ccds-dataplat/agents/dataplat-architect.md
@@ -1,7 +1,7 @@
 ---
 name: dataplat-architect
 model: opus
-color: "#0f766e"
+color: cyan
 description: Data Platform domain specialist. Use proactively on data-platform work — warehouse/lakehouse topology, batch vs streaming, partitioning and storage format, governance, ingestion, quality, and serving. Owns data-platform architecture and composes the dataplat-* implementation skills.
 ---
 

--- a/plugins/ccds-desktop/agents/desktop-architect.md
+++ b/plugins/ccds-desktop/agents/desktop-architect.md
@@ -1,7 +1,7 @@
 ---
 name: desktop-architect
 model: opus
-color: "#92400e"
+color: orange
 description: Desktop App domain specialist. Use proactively on desktop work — runtime choice, process/window model, IPC topology, OS integration, autoupdate, code signing, installers, and shell integration. Owns desktop architecture and composes the desktop-* implementation skills.
 ---
 

--- a/plugins/ccds-devtool/agents/devtool-architect.md
+++ b/plugins/ccds-devtool/agents/devtool-architect.md
@@ -1,7 +1,7 @@
 ---
 name: devtool-architect
 model: opus
-color: "#475569"
+color: blue
 description: DevTool / CLI / Library domain specialist. Use proactively on public-surface work — API and CLI surface design, versioning, distribution, extensibility, compatibility, docs, packaging, and telemetry. Owns devtool architecture and composes the devtool-* implementation skills.
 ---
 

--- a/plugins/ccds-ecom/agents/ecom-architect.md
+++ b/plugins/ccds-ecom/agents/ecom-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ecom-architect
 model: opus
-color: "#db2777"
+color: pink
 description: E-commerce domain specialist. Use proactively on storefront/checkout/OMS work — catalog vs cart vs order boundary, payment strategy, inventory reservation, tax/shipping, promotions, search, and peak-event scale. Owns e-commerce architecture and composes the ecom-* implementation skills.
 ---
 

--- a/plugins/ccds-embed/agents/embed-architect.md
+++ b/plugins/ccds-embed/agents/embed-architect.md
@@ -1,7 +1,7 @@
 ---
 name: embed-architect
 model: opus
-color: "#78350f"
+color: orange
 description: Embedded / IoT domain specialist. Use proactively on embedded / firmware / IoT work — SoC/MCU choice, RTOS vs bare-metal, memory/flash layout, secure boot chain, A/B partitioning, fleet OTA topology, and provisioning/attestation. Owns embedded architecture and composes the embed-* implementation skills.
 ---
 

--- a/plugins/ccds-ext/agents/ext-architect.md
+++ b/plugins/ccds-ext/agents/ext-architect.md
@@ -1,7 +1,7 @@
 ---
 name: ext-architect
 model: opus
-color: "#4338ca"
+color: blue
 description: Browser extension domain specialist. Use proactively on browser-extension work — manifest version (MV3), permissions model, background/service-worker/content-script split, cross-browser strategy, store-review posture, and native-host bridges. Owns browser-extension architecture and composes the ext-* implementation skills.
 ---
 

--- a/plugins/ccds-fintech/agents/fintech-architect.md
+++ b/plugins/ccds-fintech/agents/fintech-architect.md
@@ -1,7 +1,7 @@
 ---
 name: fintech-architect
 model: opus
-color: "#365314"
+color: green
 description: Fintech domain specialist. Use proactively on regulated-money work — ledger topology, custody, KYC/AML and licensing, money-movement primitives, reconciliation, audit retention, and risk. Owns fintech architecture and composes the fintech-* implementation skills.
 ---
 

--- a/plugins/ccds-game/agents/game-architect.md
+++ b/plugins/ccds-game/agents/game-architect.md
@@ -1,7 +1,7 @@
 ---
 name: game-architect
 model: opus
-color: "#ea580c"
+color: orange
 description: Game domain specialist. Use proactively on game work — engine selection, core game loop, state architecture, asset pipeline, save/load topology, and platform-target strategy. Owns game architecture and composes the game-* implementation skills.
 ---
 

--- a/plugins/ccds-guard/hooks/guard-rules.txt
+++ b/plugins/ccds-guard/hooks/guard-rules.txt
@@ -24,6 +24,13 @@
 # NOT in this table (lives in pretooluse-guard.py as path logic, because a
 # regex cannot resolve paths): recursive force-delete outside the project.
 #
+# Operator additions live in ~/.claude/ccds-guard-rules.txt (same five
+# categories; loaded after this file, never replaced by a plugin update, and
+# tamper-watched like settings). Typical use: declare the credential files your
+# own skills are meant to read, so they stop being adjudicated on every call:
+#   allow-path: (^|/)\.claude/credentials/   # keys my skills read by design
+# Override the location with CCDS_GUARD_USER_RULES (a test seam).
+#
 # Charter: protective only. This guard exists so that projects built by people
 # who configure nothing still refuse to leak secrets, run curl|bash, or install
 # hallucinated packages. It is a teaching backstop layered on Claude Code's
@@ -35,6 +42,7 @@
 allow-path: \.env\.(example|sample|template|dist)$                              # env templates are meant to be edited
 allow-path: (^|/)tests?/fixtures?/                                              # test fixtures named like secrets
 allow-path: \.pub$                                                              # public keys are not secrets
+allow-path: ^(?=.*(?:^|/)(?:src|lib|app|apps|packages|pkg|internal|cmd|tests?|spec|__tests__|e2e|examples?)/)(?!.*(?:^|/)\.[^/]+/)(?:.*/)?(?!\.)(?![^/]*\.(?:key|pem|p12|pfx|jks|keystore|env|tfstate)\.)(?!id_(?:rsa|dsa|ecdsa|ed25519)\b)[^/]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|cs|rb|php|swift|scala|c|cc|cpp|h|hpp|proto|graphql|vue|svelte)$  # source code in a source tree is never a secret: packages/cli/src/credentials/credentials.service.ts is a module, not a key (#74). Requires a source-root segment (src/ lib/ app/ packages/ tests/ ...), so secrets/keys.py at a repo root still denies; never inside a dot-directory, never a dotfile (.env.ts), never a key/env stem with a code suffix (server.key.md)
 
 # --- Secret-bearing paths: never read or written by the model ---
 deny-path: (^|/)\.env(\.[A-Za-z0-9._-]+)?$                                      # .env and variants hold live credentials
@@ -57,6 +65,8 @@ ask-write-path: (^|/)\.claude/settings(\.local)?\.json$                         
 ask-write-path: (^|/)\.claude/hooks(/|$)                                        # Claude Code is changing hook scripts that enforce your safety gates
 ask-write-path: (^|/)\.claude/plugins/                                          # Claude Code is changing installed plugin files (including this guard's own rules) - confirm you asked for this
 ask-write-path: (^|/)\.pre-commit-config\.ya?ml$                                # Claude Code is changing the checks that run before every commit
+ask-write-path: (^|/)ccds-guard-rules\.txt[. ]*$                                   # Claude Code is changing the operator's own guard rules (the file that can exempt paths) - confirm you asked for this. Matched by filename so `cd ~/.claude && ... > ccds-guard-rules.txt` and Windows trailing-dot aliases are seen too
+ask-write-path: (^|/)ccds-guard\.disabled[. ]*$                                    # Claude Code is writing the guard opt-out marker that makes doctor treat a disabled guard as intended - confirm you asked for this
 
 # --- Dangerous commands: blocked outright ---
 deny-command: \bgit\b[^\n;|&]*\bpush\b[^\n;|&]*(\s--force(?!-with-lease|-if-includes)\b|\s-[a-z]*f[a-z]*\b)  # force-push rewrites shared history; use --force-with-lease if you truly need it
@@ -69,6 +79,9 @@ deny-command: \bwget\b[^\n;|&]*--no-check-certificate\b                         
 deny-command: \bsslverify\s*[= ]\s*false\b                                      # disabling git TLS verification lets anyone intercept the traffic
 deny-command: \bstrict-ssl\b[^\n;|&]*\bfalse\b                                  # disabling npm TLS verification lets anyone intercept the traffic
 deny-command: \b(PYTHONHTTPSVERIFY=0|NODE_TLS_REJECT_UNAUTHORIZED=0)\b          # disabling TLS verification lets anyone intercept the traffic
+
+# --- Guard self-removal: the model switching off its own gates asks first ---
+ask-command: \bclaude\s+plugin\s+(disable|uninstall|remove)\b[^\n;|&]*\bccds-(guard|loops)\b  # Claude Code is disabling or removing a ccds enforcement plugin (its own safety gates) - confirm you asked for this
 
 # --- Package installs: ask, because models hallucinate package names ---
 # Attackers register hallucinated names (slopsquatting). Flags may appear

--- a/plugins/ccds-guard/hooks/pretooluse-guard.py
+++ b/plugins/ccds-guard/hooks/pretooluse-guard.py
@@ -9,8 +9,9 @@ One script, two matchers (see hooks.json):
                                         package-install ask (slopsquatting)
   Read|Write|Edit|NotebookEdit|Grep  -> secret-path deny, config-tamper ask
 
-Rules are DATA (guard-rules.txt beside this script, five categories); editing
-the table tunes the guard without touching code. Checks that need path
+Rules are DATA (guard-rules.txt beside this script, five categories, plus the
+operator's ~/.claude/ccds-guard-rules.txt loaded after it — CCDS_GUARD_USER_RULES
+relocates it); editing the tables tunes the guard without touching code. Checks that need path
 resolution a regex cannot express live in CODE (lessons from three multi-model
 review rounds, ADR-0012 addendum):
   - recursive force-delete outside the project: targets are resolved (quotes,
@@ -85,6 +86,15 @@ import subprocess
 import sys
 import tempfile
 
+# Operator rules: same format, loaded AFTER the shipped table so a plugin
+# update never overwrites them. Lives under ~/.claude and is tamper-watched
+# (ask-write-path) because an allow-path line can exempt a secret file — the
+# model must not be able to add one silently. CCDS_GUARD_USER_RULES is the
+# test seam / relocation knob; it is read from the hook's own environment
+# (Claude Code's process), which a `VAR=x cmd` prefix inside a Bash tool call
+# cannot reach — only the session's launch environment can set it.
+USER_RULES_FILE = os.environ.get("CCDS_GUARD_USER_RULES", "").strip() or \
+    os.path.join(os.path.expanduser("~"), ".claude", "ccds-guard-rules.txt")
 RULES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "guard-rules.txt")
 
@@ -183,15 +193,53 @@ ALLOW: <short reason>   or   DENY: <short reason>
 
 
 def _load_rules():
-    """Return {category: [(compiled_regex, label), ...]}.
-    Unparseable lines/patterns are skipped, never fatal."""
+    """Return {category: [(compiled_regex, label), ...]} from the shipped
+    table plus the operator's file (if any). Operator deny-path rules are ALSO
+    kept in "deny-path-first", checked before any allow-path exemption, so an
+    operator can tighten what the shipped table exempts. A missing operator
+    file is the normal case; a symlinked one is ignored, loudly."""
     rules = {c: [] for c in CATEGORIES}
+    rules["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, rules)
+    # The operator file is tamper-watched by PATH. A symlink at that path
+    # would move the effective content to a target the watch never sees
+    # (review finding): creating the link asks once, every later write to the
+    # target would not. So a symlinked operator file is ignored, loudly.
+    if os.path.islink(USER_RULES_FILE):
+        sys.stderr.write("ccds-guard: %s is a symlink and was ignored — the "
+                         "operator rules file must be a regular file.\n"
+                         % USER_RULES_FILE)
+    else:
+        _load_rules_file(USER_RULES_FILE, rules, operator=True)
+    # Whatever path the operator file resolves to (CCDS_GUARD_USER_RULES may
+    # relocate it), writes there are tamper-watched, not just the default name.
     try:
-        with open(RULES_FILE, encoding="utf-8") as f:
+        rules["ask-write-path"].append((
+            re.compile(re.escape(_norm(USER_RULES_FILE)) + r"[. ]*$", re.IGNORECASE),
+            "Claude Code is changing the operator's own guard rules - confirm you asked for this"))
+    except re.error:
+        pass
+    return rules
+
+
+def _load_rules_file(path, rules, operator=False):
+    """Parse one rules file into `rules`. Shipped-table problems are silent by
+    contract (a bad pattern disables itself, never the guard); operator-file
+    problems are reported on stderr with file:line, because a rule the
+    operator wrote and thinks is active must not fail silently. An EMPTY body
+    is skipped everywhere: `allow-path:` with nothing after it would compile
+    to a regex that matches every path (review finding)."""
+    try:
+        with open(path, encoding="utf-8") as f:
             lines = f.readlines()
     except (OSError, UnicodeDecodeError):
-        return rules
-    for raw in lines:
+        return
+
+    def complain(n, why):
+        if operator:
+            sys.stderr.write("ccds-guard: %s:%d ignored — %s\n" % (path, n, why))
+
+    for n, raw in enumerate(lines, 1):
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
@@ -203,13 +251,20 @@ def _load_rules():
                 if " # " in body:
                     body, label = body.split(" # ", 1)
                     body, label = body.strip(), label.strip()
+                if not body:
+                    complain(n, "empty pattern (would match every path)")
+                    break
                 try:
-                    rules[cat].append((re.compile(body, re.IGNORECASE),
-                                       label or body))
-                except re.error:
-                    pass  # a bad pattern disables itself, never the guard
+                    entry = (re.compile(body, re.IGNORECASE), label or body)
+                except re.error as exc:
+                    complain(n, "invalid regex (%s)" % exc)
+                    break
+                rules[cat].append(entry)
+                if operator and cat == "deny-path":
+                    rules["deny-path-first"].append(entry)
                 break
-    return rules
+        else:
+            complain(n, "unknown rule category")
 
 
 def _split_cmd(cmd):
@@ -377,8 +432,9 @@ def _ask(reasons, payload, tool, detail, tamper=False):
         "Verdict: %s\nGuard reason(s): %s\nFlagged input: %s\n"
         "Use a safer form (bare lockfile restores pass untouched), or leave "
         "the exact command for the operator to run themselves. Persistent "
-        "false positive? The operator can tune guard-rules.txt or set "
-        "CCDS_GUARD_ADJUDICATOR_CMD." % (why, "; ".join(reasons), detail))
+        "false positive? The operator can add an allow-path in "
+        "~/.claude/ccds-guard-rules.txt or set CCDS_GUARD_ADJUDICATOR_CMD."
+        % (why, "; ".join(reasons), detail))
 
 
 def _deny(msg):
@@ -546,10 +602,14 @@ def _guard_bash(cmd, payload, rules):
         cmd_word = posixpath.basename(_norm(toks[i])) if i < len(toks) else ""
         text_only = cmd_word in TEXT_COMMANDS
         for tok in _tokens_for_scan(seg):
-            if _match_any(rules["allow-path"], tok):
-                continue
-            if not secret_hit and not text_only \
-                    and _match_any(rules["deny-path"], tok):
+            # allow-path exempts from the SECRET scan only (the table's
+            # contract). The tamper watch must still see an exempt token:
+            # hook scripts are .py/.sh files, and the source-code exemption
+            # would otherwise let `sed -i ... .claude/hooks/x.py` pass silently.
+            exempt = _match_any(rules["allow-path"], tok)
+            if not secret_hit and not text_only and (
+                    _match_any(rules["deny-path-first"], tok)
+                    or (not exempt and _match_any(rules["deny-path"], tok))):
                 secret_hit = True
             if not tamper_hit and _match_any(rules["ask-write-path"], tok):
                 tamper_hit = True
@@ -632,9 +692,9 @@ def _guard_file(tool, tool_input, rules, payload):
         return 0
 
     for cand in candidates:
-        if _match_any(rules["allow-path"], cand):
-            continue
-        for rx, label in rules["deny-path"]:
+        exempt = _match_any(rules["allow-path"], cand)
+        for rx, label in rules["deny-path-first"] + (
+                [] if exempt else rules["deny-path"]):
             if rx.search(cand):
                 return _deny(
                     "ccds-guard: BLOCKED — %s looks like a secrets file/"
@@ -644,8 +704,8 @@ def _guard_file(tool, tool_input, rules, payload):
                     "needed, the operator opens it in their own editor; to "
                     "bootstrap config, copy the template (cp .env.example "
                     ".env) yourself. Persistent false positive? The operator "
-                    "can tune guard-rules.txt in the ccds-guard plugin."
-                    % (cand, label))
+                    "can exempt it in ~/.claude/ccds-guard-rules.txt "
+                    "(allow-path)." % (cand, label))
     if tool in WRITE_TOOLS:
         reasons = []
         for cand in candidates:
@@ -674,7 +734,10 @@ def main():
     if not isinstance(tool_input, dict):
         return 0
     rules = _load_rules()
-    if not any(rules.values()) and tool in ("Bash",) + FILE_TOOLS:
+    shipped = {c: [] for c in CATEGORIES}
+    shipped["deny-path-first"] = []
+    _load_rules_file(RULES_FILE, shipped)
+    if not any(shipped.values()) and tool in ("Bash",) + FILE_TOOLS:
         # Fail-open, but never silently: an empty table means the guard is
         # inert, and the operator should know (stderr on exit 0 = non-blocking).
         sys.stderr.write("ccds-guard: guard-rules.txt is missing or empty — "

--- a/plugins/ccds-infra/agents/infra-architect.md
+++ b/plugins/ccds-infra/agents/infra-architect.md
@@ -1,7 +1,7 @@
 ---
 name: infra-architect
 model: opus
-color: "#334155"
+color: blue
 description: Infrastructure / dev-platform domain specialist. Use proactively on infra / platform work — cloud topology, network segmentation, environments, IaC strategy, secrets topology, and platform tenancy. Owns infrastructure architecture and composes the infra-* implementation skills.
 ---
 

--- a/plugins/ccds-media/agents/media-architect.md
+++ b/plugins/ccds-media/agents/media-architect.md
@@ -1,7 +1,7 @@
 ---
 name: media-architect
 model: opus
-color: "#0369a1"
+color: cyan
 description: Media / streaming domain specialist. Use proactively on media / streaming work — ingest → process → store → deliver pipeline, codec/container strategy, VOD vs live topology, DRM posture, CDN strategy, and QoE. Owns media architecture and composes the media-* implementation skills.
 ---
 

--- a/plugins/ccds-mobile/agents/mobile-architect.md
+++ b/plugins/ccds-mobile/agents/mobile-architect.md
@@ -1,7 +1,7 @@
 ---
 name: mobile-architect
 model: opus
-color: "#2563eb"
+color: blue
 description: Mobile domain specialist. Use proactively on iOS / Android work — framework choice, offline posture, background-execution strategy, release topology, and privacy posture. Owns mobile architecture and composes the mobile-* implementation skills.
 ---
 

--- a/plugins/ccds-orch/agents/orch-architect.md
+++ b/plugins/ccds-orch/agents/orch-architect.md
@@ -1,7 +1,7 @@
 ---
 name: orch-architect
 model: opus
-color: "#be123c"
+color: red
 description: Agent / orchestration domain specialist. Use proactively on agent / orchestration work — agent topology, tool-use contract, memory model, planning/looping control, sandbox boundaries, and eval strategy. Owns orchestration architecture and composes the orch-* implementation skills.
 ---
 

--- a/plugins/ccds-saas/agents/saas-architect.md
+++ b/plugins/ccds-saas/agents/saas-architect.md
@@ -1,7 +1,7 @@
 ---
 name: saas-architect
 model: opus
-color: "#0ea5e9"
+color: cyan
 description: SaaS domain specialist. Use proactively on multi-tenant / productivity web-app work — tenancy model, data isolation, billing topology, entitlements, auth/SSO, realtime collab, and horizontal-scale decisions. Owns SaaS architecture and composes the saas-* implementation skills.
 ---
 
@@ -46,9 +46,12 @@ them yourself):
 
 ## Approach
 
-1. **Clarify constraints first** — B2B or B2C; tenant count and size distribution (the
+1. **Pin the constraints first** — B2B or B2C; tenant count and size distribution (the
    largest 10% dominates); compliance scope (SOC 2, HIPAA, PCI, GDPR); residency;
-   self-service vs sales-led; seats per tenant.
+   self-service vs sales-led; seats per tenant. Take them from the task and the repo;
+   where those are silent, state the assumption you are designing under and proceed,
+   and list only the open questions whose answers would change the topology for the
+   orchestrator to take back to the user — you cannot ask them yourself.
 2. **Start from the hardest-to-reverse decision** — tenancy model and identity topology
    shape everything downstream. Lock them first.
 3. **Present trade-offs explicitly** — 2–3 viable topologies with pros, cons, operational

--- a/scripts/ccds-user-setup.sh
+++ b/scripts/ccds-user-setup.sh
@@ -2,6 +2,8 @@
 # ccds-user-setup.sh
 # ------------------
 # Performs per-user Claude Code Dev Studio setup (ADR-0007):
+#   0. Detects enabled ccds content plugins; if any, steps 1-1b are skipped
+#      (the plugins already supply that roster -- ADR-0020)
 #   1. Copies all 19 always-on agents to ~/.claude/agents/
 #   2. Copies the cross-cutting (global) skills to ~/.claude/skills/
 #   3. Injects / updates the ccds pointer block in ~/.claude/CLAUDE.md
@@ -276,13 +278,76 @@ install_plugins() {
 }
 
 # ---------------------------------------------------------------------------
+# Step 0 — Which route supplies the always-on roster?  (ADR-0020)
+#
+# The 19 agents and the cross-cutting skills reach Claude Code by ONE of two
+# routes: the ccds content plugins (ccds-core + the archetype packs, installed
+# from the marketplace) or the file copies steps 1/1b write. Both at once puts
+# every agent in the roster twice -- the router sees two identical
+# descriptions, the stale file copy owns the bare name, and the descriptions
+# cost context twice. So when a content plugin is enabled, the copies are
+# skipped. Detection is a read-only `claude plugin list --json`; it is not run
+# under --skip-plugins (never touch the CLI) or --dry-run (no calls at all).
+# `ccds doctor` reports the overlap either way.
+# ---------------------------------------------------------------------------
+CONTENT_PLUGINS=""
+
+detect_content_plugins() {
+    (( SKIP_PLUGINS || DRY_RUN )) && return 0
+    command -v "$CLAUDE_CMD" >/dev/null 2>&1 || return 0
+    local json
+    json="$("$CLAUDE_CMD" plugin list --json </dev/null 2>/dev/null)" || return 0
+    # The CLI pretty-prints one field per line: collapse newlines FIRST, then
+    # split into one object per line, keep enabled ones, take the "<name>@" id
+    # prefix, and drop the hooks-only enforcement pair.
+    CONTENT_PLUGINS="$(printf '%s' "$json" | tr -d '\n\r' | tr '{' '\n' \
+        | grep '"enabled"[[:space:]]*:[[:space:]]*true' \
+        | grep -o '"id"[[:space:]]*:[[:space:]]*"ccds-[a-z]*@' \
+        | sed -e 's/.*"\(ccds-[a-z]*\)@/\1/' \
+        | grep -v -x -e ccds-guard -e ccds-loops \
+        | sort -u | tr '\n' ' ' | sed -e 's/ $//' || true)"
+}
+
+# Stale file copies next to enabled plugins: say so, with the exact removal
+# command, but never delete a user's files from setup.
+warn_stale_file_copies() {
+    local -a agent_files=() skill_dirs=()
+    local src name
+    for src in "$INSTALL_ROOT"/agents/*.md; do
+        [[ -f "$src" ]] || continue
+        name="$(basename "$src")"
+        [[ -f "$HOME/.claude/agents/$name" ]] && agent_files+=("$name")
+    done
+    for name in "${GLOBAL_SKILLS[@]}"; do
+        [[ -f "$HOME/.claude/skills/$name/SKILL.md" ]] && skill_dirs+=("$name")
+    done
+    (( ${#agent_files[@]} == 0 && ${#skill_dirs[@]} == 0 )) && return 0
+    log_warn "File copies from an earlier setup are still present and are loaded in ADDITION to the plugins:"
+    log_warn "  ${#agent_files[@]} agent file(s) in $HOME/.claude/agents, ${#skill_dirs[@]} cross-cutting skill(s) in $HOME/.claude/skills"
+    log_warn "Remove them (the plugins keep working):"
+    if (( ${#agent_files[@]} > 0 )); then
+        log_warn "  rm -f $(printf "$HOME/.claude/agents/%s " "${agent_files[@]}")"
+    fi
+    if (( ${#skill_dirs[@]} > 0 )); then
+        log_warn "  rm -rf $(printf "$HOME/.claude/skills/%s " "${skill_dirs[@]}")"
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
-log_step "Installing always-on agents to $HOME/.claude/agents"
-install_agents
+detect_content_plugins
+if [[ -n "$CONTENT_PLUGINS" ]]; then
+    log_step "Always-on agents and cross-cutting skills"
+    log_ok "Supplied by enabled plugin(s): $CONTENT_PLUGINS -- skipping the file copies so Claude Code does not load the roster twice"
+    warn_stale_file_copies
+else
+    log_step "Installing always-on agents to $HOME/.claude/agents"
+    install_agents
 
-log_step "Installing cross-cutting skills to $HOME/.claude/skills"
-install_global_skills
+    log_step "Installing cross-cutting skills to $HOME/.claude/skills"
+    install_global_skills
+fi
 
 log_step "Updating ccds block in $HOME/.claude/CLAUDE.md"
 set_claude_playbook_block
@@ -294,8 +359,13 @@ if (( DRY_RUN )); then
     printf '\n%sDRY RUN -- no changes made.%s\n' "$C_YELLOW" "$C_RESET"
 else
     printf '\n%sUser setup complete.%s\n' "$C_GREEN" "$C_RESET"
-    printf 'Agents      : %s/.claude/agents/ (19 always-on)\n' "$HOME"
-    printf 'Skills      : %s/.claude/skills/ (%d cross-cutting)\n' "$HOME" "${#GLOBAL_SKILLS[@]}"
+    if [[ -n "$CONTENT_PLUGINS" ]]; then
+        printf 'Agents      : from plugins (%s)\n' "$CONTENT_PLUGINS"
+        printf 'Skills      : from plugins (%s)\n' "$CONTENT_PLUGINS"
+    else
+        printf 'Agents      : %s/.claude/agents/ (19 always-on)\n' "$HOME"
+        printf 'Skills      : %s/.claude/skills/ (%d cross-cutting)\n' "$HOME" "${#GLOBAL_SKILLS[@]}"
+    fi
     printf 'ccds block  : %s/.claude/CLAUDE.md\n' "$HOME"
     printf 'Plugins     : %s\n' "$PLUGINS_STATUS"
 fi

--- a/scripts/jit-claude.md
+++ b/scripts/jit-claude.md
@@ -7,12 +7,13 @@
 ## Claude Code Dev Studio
 
 Installed at `~/.claude/playbook/`. **19 agents** (14 domain agents + 5 core
-generalists) live in `~/.claude/agents/` and are always loaded. Each domain agent
+generalists) are always loaded — supplied either by the ccds plugins (`ccds-core`
++ the archetype packs) or by copies in `~/.claude/agents/`, never both. Each domain agent
 composes its `<pack>-*` **skills** — the just-in-time layer (`~/.claude/playbook/skills/`,
 indexed in `catalog.json`). Cross-cutting skills (`playbook-conventions`, `api-design`,
 `ux-design`, `security-checklist`, `code-review-checklist`, `inventive-engineer`,
-`common-*`, and the `loop-*` agent-loop process skills) are installed in
-`~/.claude/skills/` and always available.
+`common-*`, and the `loop-*` agent-loop process skills) come from the same
+route (plugins, or copies in `~/.claude/skills/`) and are always available.
 
 To activate a project's domain skills (on `/init`, a new task, "sync agents", or when a
 domain agent needs a `<pack>-*` skill not yet in `.claude/skills/`), use the

--- a/scripts/lint-playbook.py
+++ b/scripts/lint-playbook.py
@@ -404,6 +404,21 @@ def _zip_payload(src):
     return {m.group(2).replace("\\", "/") for m in PS_COPY_RE.finditer(src)}
 
 
+AGENT_COLORS = ("red", "blue", "green", "yellow", "purple", "orange", "pink", "cyan")
+
+
+def check_agent_colors():
+    """The subagent `color` field accepts exactly eight names (sub-agents doc:
+    "Accepts red, blue, green, yellow, purple, orange, pink, or cyan"). Every
+    agent shipped hex values for months; Claude Code ignored them silently."""
+    for fname in agent_files():
+        fm = frontmatter(read(os.path.join(AGENTS_DIR, fname)))
+        value = field(fm, "color") if fm else ""
+        if value and value not in AGENT_COLORS:
+            err("agent-colors", f"{fname}: color '{value}' is not one of "
+                f"{', '.join(AGENT_COLORS)} -- Claude Code ignores it")
+
+
 def check_release_parity():
     sh_path = os.path.join(REPO_ROOT, "build-release.sh")
     ps_path = os.path.join(REPO_ROOT, "build-release.ps1")
@@ -444,6 +459,7 @@ def main():
     check_process_skills()
     check_cli_parity()
     check_release_parity()
+    check_agent_colors()
     check_marketplace_fresh()
     check_descriptions_and_models()
 

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -139,6 +139,19 @@ class TestLintPlaybook(FixtureCase):
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertIn("RESULT: PASS", r.stdout)
 
+    def test_hex_agent_color_fails(self):
+        """`color:` accepts eight names only; hex is silently ignored by Claude
+        Code, which is how all 19 agents rendered in the default color."""
+        body = read(self.agent_path())
+        body = body.replace("\nname: ", "\ncolor: \"#1a56db\"\nname: ", 1)
+        self.assertIn('color: "#1a56db"', body)
+        write(self.agent_path(), body)
+        self.regen_catalog()
+        r = self.lint()
+        self.assertEqual(r.returncode, 1, r.stdout)
+        self.assertIn("agent-colors", r.stdout)
+        self.assertIn("#1a56db", r.stdout)
+
     def test_ghost_skill_reference_fails(self):
         write(self.agent_path(), AGENT_TMPL.format(extra="Also pull `saas-ghost`."))
         r = self.lint()

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -1497,11 +1497,14 @@ class TestCcdsDoctor(unittest.TestCase):
             plugins = [{"id": "ccds-guard@ccds", "enabled": True},
                        {"id": "ccds-loops@ccds", "enabled": True}]
         path = os.path.join(self.root, "claude-stub")
+        # indent=2: the real CLI pretty-prints one field per line. A flat
+        # single-line stub hid #70 (the disabled-plugin branch could never
+        # match on real output), so the stub must keep the real shape.
         write(path, "#!/usr/bin/env bash\ncase \"$1\" in\n"
                     "  --version) printf '%%s\\n' %s ;;\n"
                     "  plugin)    printf '%%s\\n' %s ;;\n"
                     "esac\n" % (shlex.quote(version),
-                                shlex.quote(json.dumps(plugins))))
+                                shlex.quote(json.dumps(plugins, indent=2))))
         os.chmod(path, 0o755)
         return path
 
@@ -1581,6 +1584,51 @@ class TestCcdsDoctor(unittest.TestCase):
         self.assertIn("WARN  claude-cli", r.stdout)
         self.assertIn("WARN  plugins-installed", r.stdout)
         self.assertIn("RESULT: PASS", r.stdout)
+
+    CONTENT_PLUGINS = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True},
+                       {"id": "ccds-core@ccds", "enabled": True},
+                       {"id": "ccds-saas@ccds", "enabled": True}]
+
+    def test_plugin_and_file_copies_overlap_fails(self):
+        """ADR-0020: the roster reaches Claude Code by plugins OR file copies.
+        Both at once = every agent loaded twice; doctor must name the copies
+        and hand over the removal command rather than say PASS (which is what
+        it did on the maintainer's own machine for weeks)."""
+        r = self.doctor(claude=self.stub_claude(plugins=self.CONTENT_PLUGINS))
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  plugin-file-overlap: loaded twice: plugin(s) ccds-core ccds-saas",
+                      r.stdout)
+        self.assertIn("1 agent file(s) + %d cross-cutting skill(s)"
+                      % len(self._global_skills()), r.stdout)
+        self.assertIn("rm -f " + os.path.join(self.home, ".claude", "agents",
+                                              "plan-architect.md"), r.stdout)
+        self.assertIn("rm -rf " + os.path.join(self.home, ".claude", "skills",
+                                               self._global_skills()[0]), r.stdout)
+        # the enforcement pair must never be reported as a content plugin
+        self.assertNotIn("ccds-guard ccds", r.stdout.split("plugin-file-overlap")[1])
+
+    def test_plugin_only_install_passes(self):
+        """No file copies + content plugins enabled is the recommended shape:
+        agents/skills checks report the plugin as the source and pass."""
+        shutil.rmtree(os.path.join(self.home, ".claude", "agents"))
+        shutil.rmtree(os.path.join(self.home, ".claude", "skills"))
+        r = self.doctor(claude=self.stub_claude(plugins=self.CONTENT_PLUGINS))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("OK  agents-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  skills-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  plugin-file-overlap: plugins (ccds-core ccds-saas) supply", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
+
+    def test_file_only_install_is_not_an_overlap(self):
+        r = self.doctor()
+        self.assertIn("OK  plugin-file-overlap: no ccds content plugin enabled", r.stdout)
+
+    def test_missing_core_agent_without_core_plugin_names_both_remedies(self):
+        os.remove(os.path.join(self.home, ".claude", "agents", "plan-architect.md"))
+        r = self.doctor()
+        self.assertIn("FAIL  agents-installed", r.stdout)
+        self.assertIn("claude plugin install ccds-core@ccds", r.stdout)
 
     def test_missing_core_agent_fails(self):
         os.remove(os.path.join(self.home, ".claude", "agents", "plan-architect.md"))
@@ -1738,6 +1786,7 @@ class TestDebPostinst(unittest.TestCase):
         r = self._run({"SUDO_USER": getpass.getuser()})
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertEqual(self.claude_calls(), [
+            "plugin list --json",   # ADR-0020 route probe, read-only
             "plugin marketplace add test-owner/test-repo",
             "plugin install ccds-guard@ccds --scope user",
             "plugin install ccds-loops@ccds --scope user",
@@ -1877,6 +1926,7 @@ class TestInstallPlaybook(unittest.TestCase):
         self.assertIn("# existing content", self.bashrc(),
                       "must not clobber the user's rc file")
         self.assertEqual(self.claude_calls(), [
+            "plugin list --json",   # ADR-0020 route probe, read-only
             "plugin marketplace add test-owner/test-repo",
             "plugin install ccds-guard@ccds --scope user",
             "plugin install ccds-loops@ccds --scope user",
@@ -2096,6 +2146,26 @@ class TestInstallPlaybookPs1(unittest.TestCase):
                         "completion block did not go to CCDS_PS_PROFILE")
         self.assertIn("# >>> ccds-completion >>>", read(self.profile))
         self.assertNotIn("ggrace519", " ".join(self.claude_calls()))
+
+    def test_enabled_content_plugin_skips_the_file_copies(self):
+        """ADR-0020: with ccds-core enabled the plugin already supplies the
+        roster, so the installer must not write a second copy into ~/.claude.
+        The stub prints pretty-printed JSON, the real CLI's shape."""
+        plugins_json = os.path.join(self.root, "plugins.json")
+        write(plugins_json, json.dumps(
+            [{"id": "ccds-guard@ccds", "enabled": True},
+             {"id": "ccds-core@ccds", "enabled": True}], indent=2))
+        write(self.claude,
+              "@echo off\r\necho %%* >> \"%s\"\r\n"
+              "if \"%%1\"==\"plugin\" if \"%%2\"==\"list\" type \"%s\"\r\n"
+              "exit /b 0\r\n" % (self.log, plugins_json))
+        r = self.install()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("Supplied by enabled plugin(s): ccds-core", r.stdout)
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "agents")))
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "skills")))
+        self.assertTrue(os.path.isfile(os.path.join(self.home, ".claude", "CLAUDE.md")))
+        self.assertIn("install ccds-guard@ccds", " ".join(self.claude_calls()))
 
     def test_skip_plugins_makes_no_claude_calls(self):
         r = self.install("-SkipPlugins")
@@ -2489,6 +2559,98 @@ class TestReleaseStagingSh(unittest.TestCase):
         self.assertIn("package not found after fpm run", r.stdout + r.stderr)
 
 
+@unittest.skipUnless(PWSH, "bin/ccds.ps1 doctor is the Windows twin; "
+                           "runs under Windows PowerShell only")
+class TestCcdsDoctorPs1(unittest.TestCase):
+    """`ccds.ps1 doctor` — the first behavioral coverage of the PowerShell
+    doctor. Mirrors TestCcdsDoctor: an installed-layout root, a synthetic
+    healthy USERPROFILE, and a recording `claude.cmd` whose `plugin list
+    --json` pretty-prints like the real CLI (the shape that hid #70)."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="ccds-doctor-ps-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.inst = os.path.join(self.root, "playbook")
+        os.makedirs(os.path.join(self.inst, "bin"))
+        os.makedirs(os.path.join(self.inst, "scripts"))
+        shutil.copy(os.path.join(REPO_ROOT, "bin", "ccds.ps1"),
+                    os.path.join(self.inst, "bin", "ccds.ps1"))
+        shutil.copy(os.path.join(REPO_ROOT, "Sync-AgentPacks.ps1"),
+                    os.path.join(self.inst, "scripts", "Sync-AgentPacks.ps1"))
+        shutil.copy(os.path.join(REPO_ROOT, "Verify-Agents.ps1"),
+                    os.path.join(self.inst, "scripts", "Verify-Agents.ps1"))
+        shutil.copy(os.path.join(SCRIPTS, "ccds-user-setup.sh"),
+                    os.path.join(self.inst, "scripts", "ccds-user-setup.sh"))
+        shutil.copy(os.path.join(REPO_ROOT, "catalog.json"),
+                    os.path.join(self.inst, "catalog.json"))
+        write(os.path.join(self.inst, "version.txt"), "0.0.1\n")
+        self.home = os.path.join(self.root, "home")
+        write(os.path.join(self.home, ".claude", "agents", "plan-architect.md"),
+              "---\nname: plan-architect\ndescription: test\n---\nbody\n")
+        for name in GLOBAL_SKILLS:
+            write(os.path.join(self.home, ".claude", "skills", name, "SKILL.md"),
+                  "---\nname: %s\ndescription: test\n---\nbody\n" % name)
+        write(os.path.join(self.home, ".claude", "CLAUDE.md"),
+              "# my own notes\n\n# >>> ccds >>>\nblock body\n# <<< ccds <<<\n")
+
+    def stub_claude(self, plugins=None):
+        if plugins is None:
+            plugins = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True}]
+        plugins_json = os.path.join(self.root, "plugins.json")
+        write(plugins_json, json.dumps(plugins, indent=2))
+        path = os.path.join(self.root, "claude.cmd")
+        write(path, "@echo off\r\n"
+                    "if \"%%1\"==\"--version\" echo 2.1.224 (Claude Code)\r\n"
+                    "if \"%%1\"==\"plugin\" type \"%s\"\r\n"
+                    "exit /b 0\r\n" % plugins_json)
+        return path
+
+    def doctor(self, plugins=None):
+        return subprocess.run(
+            [PWSH, "-NoProfile", "-ExecutionPolicy", "Bypass",
+             "-File", os.path.join(self.inst, "bin", "ccds.ps1"), "doctor"],
+            capture_output=True, text=True,
+            env={**os.environ, "USERPROFILE": self.home,
+                 "CCDS_DOCTOR_RELEASE_URL": "http://127.0.0.1:9/releases/latest",
+                 "CCDS_CLAUDE_CMD": self.stub_claude(plugins)})
+
+    CONTENT_PLUGINS = [{"id": "ccds-guard@ccds", "enabled": True},
+                       {"id": "ccds-loops@ccds", "enabled": True},
+                       {"id": "ccds-core@ccds", "enabled": True},
+                       {"id": "ccds-saas@ccds", "enabled": True}]
+
+    def test_healthy_file_install_passes(self):
+        r = self.doctor()
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("FAIL  : 0", r.stdout)
+        self.assertIn("OK  plugin-file-overlap: no ccds content plugin enabled", r.stdout)
+
+    def test_disabled_plugin_in_pretty_printed_json_fails(self):
+        """#70 twin: the disabled branch must match on the real multi-line shape."""
+        r = self.doctor(plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                                 {"id": "ccds-loops@ccds", "enabled": True}])
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  plugins-installed: installed but DISABLED: ccds-guard", r.stdout)
+
+    def test_plugin_and_file_copies_overlap_fails(self):
+        r = self.doctor(plugins=self.CONTENT_PLUGINS)
+        self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
+        self.assertIn("FAIL  plugin-file-overlap: loaded twice: plugin(s) ccds-core ccds-saas", r.stdout)
+        self.assertIn("Remove-Item -Force '%s'" % os.path.join(
+            self.home, ".claude", "agents", "plan-architect.md"), r.stdout)
+        self.assertIn("Remove-Item -Recurse -Force", r.stdout)
+
+    def test_plugin_only_install_passes(self):
+        shutil.rmtree(os.path.join(self.home, ".claude", "agents"))
+        shutil.rmtree(os.path.join(self.home, ".claude", "skills"))
+        r = self.doctor(plugins=self.CONTENT_PLUGINS)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("OK  agents-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  skills-installed: supplied by the enabled ccds-core plugin", r.stdout)
+        self.assertIn("OK  plugin-file-overlap: plugins (ccds-core ccds-saas) supply", r.stdout)
+
+
 @unittest.skipUnless(PWSH, "build-release.ps1 is a PowerShell script "
                            "(Windows-targeted, like the ZIP it builds)")
 class TestReleaseZipPs1(unittest.TestCase):
@@ -2669,11 +2831,55 @@ class TestUserSetupPlugins(unittest.TestCase):
         r = self.setup()
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertEqual(self.calls(), [
+            "plugin list --json",   # ADR-0020 route detection, read-only
             "plugin marketplace add test-owner/test-repo",
             "plugin install ccds-guard@ccds --scope user",
             "plugin install ccds-loops@ccds --scope user",
         ])
         self.assertIn("Plugins     : installed", r.stdout)
+        # the stub prints no plugins -> file route -> copies happen
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.home, ".claude", "agents", "plan-architect.md")))
+        self.assertIn("Agents      : %s/.claude/agents/" % self.home, r.stdout)
+
+    def _plugin_stub(self, ids):
+        """A claude whose `plugin list --json` pretty-prints these enabled ids
+        (the real CLI's shape) and accepts every other command."""
+        body = json.dumps([{"id": i, "enabled": True} for i in ids], indent=2)
+        return self.stub_claude(
+            'case "$*" in "plugin list --json") cat <<\'JSON\'\n%s\nJSON\n;; esac\nexit 0'
+            % body)
+
+    def test_enabled_content_plugin_skips_the_file_copies(self):
+        """ADR-0020: with ccds-core enabled the plugin already supplies the
+        roster, so setup must not write a second copy into ~/.claude."""
+        r = self.setup(claude=self._plugin_stub(
+            ["ccds-guard@ccds", "ccds-loops@ccds", "ccds-core@ccds"]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("Supplied by enabled plugin(s): ccds-core", r.stdout)
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "agents")))
+        self.assertFalse(os.path.exists(os.path.join(self.home, ".claude", "skills")))
+        self.assertIn("Agents      : from plugins (ccds-core)", r.stdout)
+        # the enforcement plugins are still installed on this route
+        self.assertIn("plugin install ccds-guard@ccds --scope user", self.calls())
+        # the ccds block still lands
+        self.assertTrue(os.path.isfile(os.path.join(self.home, ".claude", "CLAUDE.md")))
+
+    def test_enforcement_plugins_alone_do_not_skip_the_copies(self):
+        r = self.setup(claude=self._plugin_stub(["ccds-guard@ccds", "ccds-loops@ccds"]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.home, ".claude", "agents", "plan-architect.md")))
+        self.assertNotIn("Supplied by enabled plugin", r.stdout)
+
+    def test_stale_file_copies_next_to_plugins_are_named_not_deleted(self):
+        stale = os.path.join(self.home, ".claude", "agents", "plan-architect.md")
+        write(stale, "old copy\n")
+        r = self.setup(claude=self._plugin_stub(["ccds-core@ccds"]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("loaded in ADDITION to the plugins", r.stderr)
+        self.assertIn("rm -f " + stale, r.stderr)
+        self.assertTrue(os.path.isfile(stale), "setup must never delete user files")
 
     def test_skip_plugins_suppresses_every_call(self):
         r = self.setup("--skip-plugins")

--- a/tests/test_playbook_scripts.py
+++ b/tests/test_playbook_scripts.py
@@ -1581,6 +1581,46 @@ class TestCcdsDoctor(unittest.TestCase):
         self.assertIn("DISABLED", r.stdout)
         self.assertIn("claude plugin enable ccds-guard", r.stdout)
 
+    def test_deliberately_disabled_guard_warns_instead_of_failing(self):
+        """ADR-0021: a recorded opt-out (~/.claude/ccds-guard.disabled) is a
+        choice, not a broken install. Only the guard can be opted out."""
+        write(os.path.join(self.home, ".claude", "ccds-guard.disabled"),
+              "too strict on src/credentials paths; revisit\n")
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("WARN  plugins-installed: ccds-guard disabled on purpose", r.stdout)
+        self.assertIn("too strict on src/credentials paths", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
+        # the marker never excuses a disabled ccds-loops
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": False}]))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("FAIL  plugins-installed: installed but DISABLED", r.stdout)
+
+    def test_unreadable_marker_does_not_abort_doctor(self):
+        marker = os.path.join(self.home, ".claude", "ccds-guard.disabled")
+        write(marker, "secret reason\n")
+        os.chmod(marker, 0)
+        self.addCleanup(os.chmod, marker, 0o600)
+        if os.access(marker, os.R_OK):
+            self.skipTest("running with privileges that ignore file modes")
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("no reason recorded", r.stdout)
+        self.assertIn("RESULT: PASS", r.stdout)
+
+    def test_disabled_guard_without_marker_names_the_marker(self):
+        r = self.doctor(claude=self.stub_claude(plugins=[
+            {"id": "ccds-guard@ccds", "enabled": False},
+            {"id": "ccds-loops@ccds", "enabled": True}]))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("ccds-guard.disabled", r.stdout)
+
     def test_plugins_from_any_marketplace_count(self):
         # A local or renamed marketplace is still a real install.
         r = self.doctor(claude=self.stub_claude(
@@ -2646,6 +2686,21 @@ class TestCcdsDoctorPs1(unittest.TestCase):
         self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
         self.assertIn("FAIL  plugins-installed: installed but DISABLED: ccds-guard", r.stdout)
 
+    def test_deliberately_disabled_guard_warns_instead_of_failing(self):
+        write(os.path.join(self.home, ".claude", "ccds-guard.disabled"), "revisit\n")
+        r = self.doctor(plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                                 {"id": "ccds-loops@ccds", "enabled": True}])
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("WARN  plugins-installed: ccds-guard disabled on purpose", r.stdout)
+        self.assertIn("revisit", r.stdout)
+
+    def test_marker_must_be_a_file_not_a_directory(self):
+        os.makedirs(os.path.join(self.home, ".claude", "ccds-guard.disabled"))
+        r = self.doctor(plugins=[{"id": "ccds-guard@ccds", "enabled": False},
+                                 {"id": "ccds-loops@ccds", "enabled": True}])
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("FAIL  plugins-installed: installed but DISABLED", r.stdout)
+
     def test_plugin_and_file_copies_overlap_fails(self):
         r = self.doctor(plugins=self.CONTENT_PLUGINS)
         self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
@@ -3377,7 +3432,10 @@ class TestGuardHooks(unittest.TestCase):
             capture_output=True, text=True,
             env={**os.environ, "CCDS_GUARD_DISABLE": "",
                  "CCDS_GUARD_UNATTENDED": "",
-                 "CCDS_GUARD_ADJUDICATOR_CMD": "", **(env or {})})
+                 "CCDS_GUARD_ADJUDICATOR_CMD": "",
+                 # never the developer's real ~/.claude/ccds-guard-rules.txt
+                 "CCDS_GUARD_USER_RULES": "/nonexistent/ccds-guard-rules.txt",
+                 **(env or {})})
 
     def bash(self, command, env=None):
         return self.guard({"tool_name": "Bash",
@@ -3433,6 +3491,167 @@ class TestGuardHooks(unittest.TestCase):
                      "/proj/docs/how-to-manage-credentials.md"):
             self.assert_allow(self.file("Read", path))
             self.assert_allow(self.file("Write", path))
+
+    # --- #74: source code is never a secret, wherever it lives ---
+
+    N8N = "packages/cli/src/credentials/credentials.service.ts"
+
+    def test_source_files_inside_a_credentials_dir_allowed(self):
+        """49 of 52 real adjudications were reads of an open-source repo's
+        src/credentials/ module. A .ts/.py/... file is code, not a key."""
+        for path in ("/proj/" + self.N8N,
+                     "/proj/packages/cli/src/credentials/__tests__/validation.test.ts",
+                     "/proj/app/secrets/rotate.py",
+                     "/proj/lib/credentials/loader.go"):
+            self.assert_allow(self.file("Read", path))
+            self.assert_allow(self.file("Write", path))
+        self.assert_allow(self.bash("sed -n '325,355p' " + self.N8N))
+        self.assert_allow(self.bash(
+            "cd packages/cli && pnpm vitest run src/credentials/__tests__/"
+            "validation.test.ts 2>&1 | tail -8"))
+
+    def test_source_exemption_never_applies_to_secret_shapes(self):
+        """Review-panel probes: a code suffix must not launder a key. Inside a
+        dot-directory, a dotfile, or a key/env stem the exemption is off and
+        the deny rules decide as before."""
+        for path in ("/proj/.env.ts", "/home/u/.ssh/id_rsa.md",
+                     "/home/u/.ssh/config.ts", "/proj/id_rsa.md",
+                     "/home/u/.claude/credentials/svc.ts"):
+            self.assert_deny(self.file("Read", path), "secrets file")
+        self.assert_deny(self.guard({"tool_name": "Grep", "tool_input": {
+            "path": "/home/u/.ssh", "glob": "*.ts", "pattern": "."}}), "secrets file")
+
+    def test_switching_the_guard_off_asks(self):
+        """The model must not silently remove its own gates: the doctor
+        opt-out marker and `claude plugin disable ccds-guard` both ask."""
+        self.assert_ask(self.bash("echo 'too strict' > ~/.claude/ccds-guard.disabled"),
+                        "session-safety")
+        self.assert_ask(self.file("Write", "/home/u/.claude/ccds-guard.disabled"),
+                        "opt-out marker")
+        for cmd in ("claude plugin disable ccds-guard",
+                    "claude plugin uninstall ccds-loops@ccds"):
+            self.assert_ask(self.bash(cmd), "enforcement plugin")
+        self.assert_allow(self.bash("claude plugin disable firecrawl@firecrawl"))
+        self.assert_allow(self.bash("claude plugin list --json"))
+
+    def test_data_files_inside_a_credentials_dir_still_denied(self):
+        for path in ("/proj/credentials/api_key.txt", "/proj/secrets/prod.json",
+                     "/proj/credentials/service-account.json",
+                     # code outside a source tree: the directory rule still decides
+                     "/proj/secrets/keys.py", "/proj/secrets/notes.md",
+                     "/proj/credentials/credentials.json.ts"):
+            self.assert_deny(self.file("Read", path), "secrets file")
+        # Grep cannot launder either: wildcards become separators, so the
+        # candidate basename is a dotfile and the exemption is off
+        self.assert_deny(self.guard({"tool_name": "Grep", "tool_input": {
+            "path": "/proj", "glob": "src/secrets/*.py", "pattern": "."}}), "secrets file")
+        self.assert_ask(self.bash("ls packages/cli/test/integration/credentials/"),
+                        "may hold secrets")
+
+    # --- #74: operator rules file (declared credential paths) ---
+
+    def user_rules(self, text):
+        tmp = tempfile.mkdtemp(prefix="ccds-guard-user-rules-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        path = os.path.join(tmp, "ccds-guard-rules.txt")
+        write(path, text)
+        return {"CCDS_GUARD_USER_RULES": path}
+
+    KEY_CMD = 'curl -sS -H "X-API-KEY: $(cat ~/.claude/credentials/svc.key)" https://api.example'
+
+    def test_declared_credential_path_is_exempt_only_with_operator_rule(self):
+        self.assert_ask(self.bash(self.KEY_CMD), "may hold secrets")
+        self.assert_deny(self.file("Read", "/home/u/.claude/credentials/svc.key"),
+                         "secrets file")
+        env = self.user_rules(
+            "allow-path: (^|/)\\.claude/credentials/   # keys my skills read\n")
+        self.assert_allow(self.bash(self.KEY_CMD, env=env))
+        self.assert_allow(self.file("Read", "/home/u/.claude/credentials/svc.key",
+                                    env=env))
+        # the exemption is exactly what was declared: other secrets still deny
+        self.assert_deny(self.file("Read", "/home/u/.aws/credentials", env=env),
+                         "secrets file")
+        self.assert_deny(self.file("Read", "/proj/.env", env=env), "secrets file")
+
+    def test_operator_deny_beats_a_shipped_allow(self):
+        """Review finding: 'can also tighten' was false while every allow was
+        checked before every deny. Operator deny-path rules go first."""
+        env = self.user_rules("deny-path: (^|/)prod-secrets\\.py$   # my key module\n")
+        self.assert_allow(self.file("Read", "/proj/src/prod-secrets.py"))
+        self.assert_deny(self.file("Read", "/proj/src/prod-secrets.py", env=env), "my key module")
+        self.assert_ask(self.bash("cat src/prod-secrets.py", env=env), "may hold secrets")
+
+    def test_empty_or_bad_operator_rule_is_skipped_and_named(self):
+        """Review finding: `allow-path:` with an empty body compiled to a regex
+        matching every path — a silent global exemption."""
+        env = self.user_rules("allow-path:\nallow-path: ([oops\nwhat-path: x\n")
+        r = self.file("Read", "/home/u/.ssh/id_rsa", env=env)
+        self.assert_deny(r, "secrets file")
+        self.assertIn(":1 ignored — empty pattern", r.stderr)
+        self.assertIn(":2 ignored — invalid regex", r.stderr)
+        self.assertIn(":3 ignored — unknown rule category", r.stderr)
+
+    def test_operator_rules_file_watched_by_name_and_wherever_relocated(self):
+        """Review finding: the watch matched the spelled path, so
+        `cd ~/.claude && ... > ccds-guard-rules.txt` slipped past it."""
+        self.assert_ask(self.bash("cd ~/.claude && printf 'allow-path: .*' > ccds-guard-rules.txt"),
+                        "session-safety")
+        self.assert_ask(self.file("Write", "ccds-guard-rules.txt"), "operator's own guard rules")
+        self.assert_ask(self.file("Write", "C:\\Users\\u\\.claude\\ccds-guard-rules.txt."),
+                        "operator's own guard rules")
+        env = self.user_rules("# empty\n")
+        relocated = env["CCDS_GUARD_USER_RULES"]
+        self.assert_ask(self.file("Write", relocated, env=env), "operator's own guard rules")
+        self.assert_ask(self.bash("echo x >> " + relocated, env=env), "session-safety")
+
+    def test_operator_rules_can_also_tighten(self):
+        env = self.user_rules("deny-path: (^|/)vault\\.db$   # my local vault\n")
+        self.assert_deny(self.file("Read", "/home/u/vault.db", env=env), "my local vault")
+
+    def test_operator_rules_file_is_tamper_watched(self):
+        for path in ("/home/u/.claude/ccds-guard-rules.txt",
+                     "C:\\Users\\u\\.claude\\ccds-guard-rules.txt"):
+            self.assert_ask(self.file("Write", path), "operator's own guard rules")
+        self.assert_allow(self.file("Read", "/home/u/.claude/ccds-guard-rules.txt"))
+
+    def test_symlinked_operator_rules_file_is_ignored(self):
+        """Review finding: the tamper watch is on the path, so a symlink would
+        move the content to an unwatched target. Creating the link asks (below);
+        if one exists anyway, the loader must not follow it."""
+        self.assert_ask(self.bash("ln -sf /tmp/mine.txt ~/.claude/ccds-guard-rules.txt"),
+                        "session-safety")
+        tmp = tempfile.mkdtemp(prefix="ccds-guard-symlink-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        target = os.path.join(tmp, "evil.txt")
+        write(target, "allow-path: .*\n")
+        link = os.path.join(tmp, "ccds-guard-rules.txt")
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks unavailable here")
+        env = {"CCDS_GUARD_USER_RULES": link}
+        r = self.file("Read", "/home/u/.ssh/id_rsa", env=env)
+        self.assert_deny(r, "secrets file")
+        self.assertIn("is a symlink and was ignored", r.stderr)
+
+    def test_operator_rules_file_absent_or_broken_is_harmless(self):
+        env = self.user_rules("allow-path: ([unclosed\n# nothing else\n")
+        self.assert_deny(self.file("Read", "/proj/.env", env=env), "secrets file")
+        self.assertNotIn("inert", self.file("Read", "/proj/README.md", env=env).stderr)
+
+    def test_operator_rules_do_not_mask_a_missing_shipped_table(self):
+        tmp = tempfile.mkdtemp(prefix="ccds-guard-test-")
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        orphan = os.path.join(tmp, "pretooluse-guard.py")
+        shutil.copyfile(GUARD, orphan)
+        env = self.user_rules("deny-path: (^|/)\\.env$\n")
+        r = subprocess.run([sys.executable, orphan],
+                           input=json.dumps({"tool_name": "Read",
+                                             "tool_input": {"file_path": "/proj/README.md"}}),
+                           capture_output=True, text=True,
+                           env={**os.environ, "CCDS_GUARD_DISABLE": "", **env})
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("inert", r.stderr, "an empty shipped table must still warn")
 
     def test_windows_backslash_paths_normalized(self):
         self.assert_deny(self.file("Read", "C:\\proj\\.env"), "secrets file")


### PR DESCRIPTION
## Promotion: develop → main (v0.19.0)

First promotion under the two-branch model (ADR-0019). **Merge as a merge commit or fast-forward — never squash** (squashing diverges the branches and every later promotion conflicts). Then tag `v0.19.0` on `main`; the release workflow builds the ZIP/.deb/.rpm from the tag.

## What ships (6 commits on develop since v0.18.0)

- #69 — ADR-0019: `develop` integrates, `main` releases and stays the GitHub default (the plugin marketplace installs from the default branch). CI on both branches; `promotion-only` guard on `main`.
- #71 — ADR-0020: `ccds doctor` detects the double-loaded roster (plugins + file copies), setup no longer creates it, and the doctor now sees a DISABLED plugin on real CLI output (#70).
- #72 — Agent `color:` values are the eight names Claude Code accepts (were hex, silently ignored); `plan-architect`/`saas-architect` state assumptions instead of asking from inside a subagent; CLAUDE.md platform claim corrected.
- #75 — ADR-0021: the guard exempts source code in a source tree from the secret scan (49/52 adjudications were false positives on `src/credentials/` paths), operators get `~/.claude/ccds-guard-rules.txt`, a deliberate opt-out marker is reported as a choice, and the model switching off its own gates now asks. Reviewed by a three-model panel; all findings folded in (#74).
- #76 — Changelog retitled `v0.19.0 — 2026-09-06`.

## Verification on develop at this tip

- `python3 -m unittest discover -s tests`: 306 run, 21 skipped (Windows-only), 0 failures. `scripts/lint-playbook.py`: PASS.
- Every constituent PR was green on CI including the `windows-latest` job (PowerShell doctor, installer gate, and the Windows-only doctor tests).
- The `promotion-only` check on this PR must pass (head is `develop`).

## After merging

1. `git tag v0.19.0 <merge-commit> && git push origin v0.19.0` — the release workflow publishes the assets.
2. Sync both branches locally (`git pull --ff-only` on `main` and `develop`); never delete `develop`.
3. Plugin users get everything on their next `marketplace update`; file-install users via `ccds update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRcT9LqHK3ftpoVNtjKjz7